### PR TITLE
Add `entrypoint` arg to `bundlePursProject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Furthermore, CTL exposes an `overlay` from its flake. You can use this in the Ni
             entrypoint = "index.js";
             # The HTML template to render the bundle to (must correspond to
             # the template listed in the webpack config)
-            htmlTemplate = "index.js";
+            htmlTemplate = "index.html";
             # If this should be bundled for the browser
             browserRuntime = true;
             # The path to the webpack config to use

--- a/README.md
+++ b/README.md
@@ -277,9 +277,12 @@ Furthermore, CTL exposes an `overlay` from its flake. You can use this in the Ni
             #
             # The main Purscript module entrypoint
             main = "Main";
-            # The JS entrypoint (must correspond to the one listed in the 
+            # The JS entrypoint (must correspond to the one listed in the
             # webpack config), relative to the `src`
             entrypoint = "index.js";
+            # The HTML template to render the bundle to (must correspond to
+            # the template listed in the webpack config)
+            htmlTemplate = "index.js";
             # If this should be bundled for the browser
             browserRuntime = true;
             # The path to the webpack config to use

--- a/README.md
+++ b/README.md
@@ -275,8 +275,11 @@ Furthermore, CTL exposes an `overlay` from its flake. You can use this in the Ni
             sources = ["src" "exe"];
             # All of the following are optional and show with default values:
             #
-            # The main module entrypoint
+            # The main Purscript module entrypoint
             main = "Main";
+            # The JS entrypoint (must correspond to the one listed in the 
+            # webpack config), relative to the `src`
+            entrypoint = "index.js";
             # If this should be bundled for the browser
             browserRuntime = true;
             # The path to the webpack config to use

--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,7 @@
             ctl-example-bundle-web = project.bundlePursProject {
               sources = [ "src" "examples" ];
               main = "Examples.Pkh2Pkh";
+              entrypoint = "examples/index.js";
             };
           };
 
@@ -286,8 +287,7 @@
               purs-tidy check $(fd -epurs)
               fourmolu -m check -o -XTypeApplications -o -XImportQualifiedPost \
                 $(fd -ehs)
-              nixpkgs-fmt --check ./{flake,default,shell}.nix \
-                 $(fd -enix --exclude='spago*')
+              nixpkgs-fmt --check $(fd -enix --exclude='spago*')
               touch $out
             '';
         });

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,7 @@
               sources = [ "src" "examples" ];
               main = "Examples.Pkh2Pkh";
               entrypoint = "examples/index.js";
+              htmlTemplate = "examples/index.html";
             };
           };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -161,6 +161,7 @@ let
     { name ? "${projectName}-bundle-" +
         (if browserRuntime then "web" else "nodejs")
     , entrypoint ? "index.js"
+    , htmlTemplate ? "index.html"
     , main ? "Main"
     , browserRuntime ? true
     , webpackConfig ? "webpack.config.js"
@@ -178,6 +179,7 @@ let
           spago bundle-module --no-install --no-build -m "${main}" \
             --to ${bundledModuleName}
           cp $src/${entrypoint} .
+          cp $src/${htmlTemplate} .
           cp $src/${webpackConfig} .
           mkdir ./dist
           webpack --mode=production -c ${webpackConfig} -o ./dist

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -160,6 +160,7 @@ let
   bundlePursProject =
     { name ? "${projectName}-bundle-" +
         (if browserRuntime then "web" else "nodejs")
+    , entrypoint ? "index.js"
     , main ? "Main"
     , browserRuntime ? true
     , webpackConfig ? "webpack.config.js"
@@ -176,6 +177,7 @@ let
           chmod -R +rwx .
           spago bundle-module --no-install --no-build -m "${main}" \
             --to ${bundledModuleName}
+          cp $src/${entrypoint} .
           cp $src/${webpackConfig} .
           mkdir ./dist
           webpack --mode=production -c ${webpackConfig} -o ./dist


### PR DESCRIPTION
Adds an `entrypoint` argument to `bundlePursProject` (otherwise it might not get copied into the builder)