### PR TITLE
Fix `node_modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,6 @@ Furthermore, CTL exposes an `overlay` from its flake. You can use this in the Ni
             # The same as `pkgs.mkShell.inputsFrom`
             inputsFrom = [ ];
 
-            # If `true`, will symlink the generated `node_modules` from the
-            # nix store to the CWD
-            symlinkNodeModules = true;
-
             # Which formatter to be made available, `purty` is another option
             formatter = "purs-tidy";
 

--- a/flake.nix
+++ b/flake.nix
@@ -201,14 +201,11 @@
           };
         in
         rec {
-          defaultPackage = packages.cardano-transaction-lib;
+          defaultPackage = packages.ctl-example-bundle-web;
 
+          # Building this package and the check below will ensure that the entire
+          # project compiles (i.e. all of `src`, `examples`, and `test`)
           packages = {
-            cardano-transaction-lib = project.buildPursProject {
-              # Make sure the entire project compiles
-              sources = [ "src" "test" "examples" ];
-            };
-
             ctl-example-bundle-web = project.bundlePursProject {
               sources = [ "src" "examples" ];
               main = "Examples.Pkh2Pkh";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -42,16 +42,12 @@ let
     { packages ? [ ]
     , inputsFrom ? [ ]
     , shellHook ? ""
-    , symlinkNodeModules ? true
     , formatter ? "purs-tidy"
     , pursls ? true
-    }: pkgs.mkShell {
-      buildInputs =
-        assert pkgs.lib.assertOneOf
-          "formatter"
-          formatter
-          [ "purs-tidy" "purty" ];
-        [
+    }:
+      assert pkgs.lib.assertOneOf "formatter" formatter [ "purs-tidy" "purty" ];
+      pkgs.mkShell {
+        buildInputs = [
           purs
           nodejs
           pkgs.easy-ps.spago
@@ -62,33 +58,17 @@ let
         ] ++ pkgs.lib.lists.optional
           pursls
           pkgs.easy-ps.purescript-language-server;
-      inherit packages inputsFrom;
-      shellHook =
-        let
-          nodeModules = mkNodeModules { };
-        in
-        pkgs.lib.optionalString symlinkNodeModules ''
-          __ln-node-modules () {
-            local modules=./node_modules
-            if test -L "$modules"; then
-              rm "$modules";
-            elif test -e "$modules"; then
-              echo 'refusing to overwrite existing (non-symlinked) `node_modules`'
-              exit 1
-            fi
-
-            ln -s ${nodeModules}/lib/node_modules "$modules"
-          }
-
-          __ln-node-modules
-        ''
-        +
-        ''
-          export NODE_PATH="$PWD/node_modules:$NODE_PATH"
-          export PATH="${nodeModules}/bin:$PATH"
-        ''
-        + shellHook;
-    };
+        inherit packages inputsFrom;
+        shellHook =
+          let
+            nodeModules = mkNodeModules { };
+          in
+          ''
+            export NODE_PATH="${nodeModules}/node_modules"
+            export PATH="${nodeModules}/bin:$PATH"
+          ''
+          + shellHook;
+      };
 
   buildPursProject =
     { sources ? [ "src" ]


### PR DESCRIPTION
Symlinking the `node_modules` isn't really necessary and causes more issues than it solves, so that has been removed from the `shellHook`. I also removed the `buildPursProject` package from the flake, since the other package and the `checks` ensure that the entire project compiles (that was my rationale for keeping it previously). This speeds up CI a fair amount