### PR TITLE
Fix `node_modules` path

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -64,7 +64,7 @@ let
             nodeModules = mkNodeModules { };
           in
           ''
-            export NODE_PATH="${nodeModules}/node_modules"
+            export NODE_PATH="${nodeModules}/lib/node_modules"
             export PATH="${nodeModules}/bin:$PATH"
           ''
           + shellHook;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -99,9 +99,7 @@ let
         in
         ''
           export HOME="$TMP"
-          cp -r ${nodeModules}/lib/node_modules .
-          chmod -R u+rw node_modules
-          export NODE_PATH="$PWD/node_modules:$NODE_PATH"
+          export NODE_PATH="${nodeModules}/lib/node_modules"
           export PATH="${nodeModules}/bin:$PATH"
           cp -r $src/${srcsStr} .
           install-spago-style

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
   },
 
   resolve: {
-    modules: ["node_modules"],
+    modules: [process.env.NODE_PATH],
     extensions: [".js"],
     fallback: {
       buffer: require.resolve("buffer/"),


### PR DESCRIPTION
We need to use the `node_modules` from `process.env.NODE_PATH`, otherwise webpack can't find them