### PR TITLE
Arion setup for launching runtime dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ SHELL := bash
 .PHONY: autogen-deps run-testnet-node run-testnet-ogmios
 .SHELLFLAGS := -eu -o pipefail -c
 
-ps-sources := $$(find ./* -iregex '.*.purs')
+ps-sources := $(shell fd -epurs)
 ps-entrypoint := Examples.Pkh2Pkh
 ps-bundle = spago bundle-module -m ${ps-entrypoint} --to output.js
+
+node-ipc = $(shell docker volume inspect cardano-transaction-lib_node-ipc | jq -r '.[0].Mountpoint')
 
 run-dev:
 	@${ps-bundle} && BROWSER_RUNTIME=1 webpack-dev-server --progress
@@ -14,10 +16,14 @@ run-build:
 	@${ps-bundle} && BROWSER_RUNTIME=1 webpack --mode=production
 
 check-format:
-	purs-tidy check ${ps-sources}
+	@purs-tidy check ${ps-sources}
 
 format:
-	purs-tidy format-in-place ${ps-sources}
+	@purs-tidy format-in-place ${ps-sources}
 
 run-datum-cache-postgres-console:
-	nix shell nixpkgs#postgresql -c psql postgresql://ctxlib:ctxlib@localhost:5432
+	@nix shell nixpkgs#postgresql -c psql postgresql://ctxlib:ctxlib@localhost:5432
+
+query-testnet-tip:
+	CARDANO_NODE_SOCKET_PATH=${node-ipc}/node.socket cardano-cli query tip \
+	  --testnet-magic 1097911063

--- a/Makefile
+++ b/Makefile
@@ -19,31 +19,5 @@ check-format:
 format:
 	purs-tidy format-in-place ${ps-sources}
 
-run-testnet-node:
-	docker run --rm \
-	  -e NETWORK=testnet \
-	  -v "$$PWD"/.node/socket:/ipc \
-	  -v "$$PWD"/.node/data:/data \
-	  inputoutput/cardano-node:1.34.0
-
-run-testnet-ogmios:
-	ogmios \
-		--node-socket "$$CARDANO_NODE_SOCKET_PATH" \
-		--node-config "$$CARDANO_NODE_CONFIG"
-
-run-haskell-server:
-	nix run -L .#ctl-server:exe:ctl-server
-
-run-datum-cache-postgres:
-	docker run -d --rm \
-		-e "POSTGRES_USER=ctxlib" \
-		-e "POSTGRES_PASSWORD=ctxlib" \
-		-e "POSTGRES_DB=ctxlib" \
-		-p 127.0.0.1:5432:5432 \
-		postgres:13
-
 run-datum-cache-postgres-console:
 	nix shell nixpkgs#postgresql -c psql postgresql://ctxlib:ctxlib@localhost:5432
-
-query-testnet-sync:
-	cardano-cli query tip --testnet-magic 1097911063

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Here is an example that uses the overlay to launch runtime services:
 }
 ```
 
-For launch services for developing on CTL itself, see [below](#launching-services-for-development).
+For launching services for developing CTL itself, see [below](#launching-services-for-development).
 
 ### Other requirements
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,107 @@ Services that are currently required:
   - We hope to deprecate this in the future, but we use it at the moment for certain Cardano libraries that have no Purescript analogue
   - To build the server project, run the following from the repository root: `nix build -L .#ctl-server:exe:ctl-server`
 
-**NOTE**: CTL does **not** launch or provide these services for you. You must configure them and provide the appropriate values to the `ContractConfig` that you create to run your contracts. This repository contains [Makefile targets](#launching-services-for-development) to launch all required services on localhost, but this is intended for local development of CTL itself and is not suitable for deployment
+CTL's overlay (contained in its flake `outputs`) provides some mechanisms for conveniently launching all runtime services using [Arion](https://docs.hercules-ci.com/arion)(itself a wrapper around `docker-compose`). To use this, you must have a setup based on Nix flakes (recommended as well for [using CTL as a dependency for Purescript projects](#using-ctl-as-a-dependency)).
+
+Here is an example that uses the overlay to launch runtime services:
+
+``` nix
+{
+
+  inputs = {
+    # You should probably pin this to a specific revision, especially if using
+    # it for Purescript projects
+    cardano-transaction-lib.url = "github:Plutonomicon/cardano-transaction-lib";
+
+    # To use the same version of `nixpkgs` as we do
+    nixpkgs.follows = "cardano-transaction-lib/nixpkgs";
+  };
+
+  outputs = { self, cardano-transaction-lib, nixpkgs, ... }:
+    # some boilerplate
+    let
+      defaultSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      perSystem = nixpkgs.lib.genAttrs defaultSystems;
+
+      # generate `pkgs` with the CTL overlay applied. This gives you access to
+      # various additional packages, using the same versions of CTL, including:
+      nixpkgsFor = system: import nixpkgs {
+        inherit system;
+        overlays = [ cardano-transaction-lib.overlay.${system} ];
+      };
+
+      # The configuration for the CTL runtime, which will be passed to the
+      # expression that builds the JSON file used by Arion. This value can be
+      # shared between `buildCtlRuntime` and `launchCtlRuntime`, as shown below
+      runtimeConfig = {
+        # *All* of these values are optional, and shown with their default
+        # values. If you need even more customization, you can use `overideAttrs`
+        # to change the values after calling `buildCtlRuntime` (e.g. a secrets
+        # volume for the `postgres` service)
+        node = { port = 3001; };
+        ogmios = { port = 1337; };
+        ctlServer = { port = 8081; };
+        postgres = {
+          port = 5432;
+          user = "ctxlib";
+          password = "ctxlib";
+          db = "ctxlib";
+        };
+        # These values will generate the `config.toml` required by ogmios-datum-cache
+        datumCache = {
+          port = 9999;
+          # If you override some part of `postgres` above, you may also need to
+          # modify the `dbConnectionString`
+          dbConnectionString = nixpkgs.lib.concatStringsSep
+            " "
+            [
+              "host=postgres"
+              "port=${toString postgres.port}"
+              "user=${postgres.user}"
+              "dbname=${postgres.db}"
+              "password=${postgres.password}"
+            ];
+          saveAllDatums = true;
+          firstFetchBlock = {
+            slot = 44366242;
+            id = "d2a4249fe3d0607535daa26caf12a38da2233586bc51e79ed0b3a36170471bf5";
+          };
+        };
+      };
+    in
+
+    {
+      # `launchCtlRuntime` will generate a Nix expression from the provided
+      # config, build it into a JSON file, and then run it with Arion
+      #
+      # Use `nix run .#<APP>` to run the services (e.g. `nix run .#ctl-runtime`)
+      apps = perSystem (system: {
+        ctl-runtime = (nixpkgsFor system).launchCtlRuntime runtimeConfig;
+      });
+
+      # `buildCtlRuntime` will generate a Nix expression that, when built with
+      # `pkgs.arion.build`, outputs a JSON file compatible with Arion. This can
+      # be run directly with Arion or passed to another derivation. Or you can
+      # use `buildCtlRuntime` with `runArion` (from the `hercules-ci-effects`)
+      # library
+      #
+      # Use `nix build .#<PACKAGE` to build. To run with Arion (i.e. in your
+      # shell): `arion --prebuilt-file ./result up`
+      packages = perSystem (system:
+        let
+          pkgs = nixpkgsFor system;
+        in
+        {
+          ctl-runtime = pkgs.arion.build {
+            inherit pkgs;
+            modules = [ (pkgs.buildCtlRuntime runtimeConfig) ];
+          };
+        });
+    };
+}
+```
+
+For launch services for developing on CTL itself, see [below](#launching-services-for-development).
 
 ### Other requirements
 
@@ -101,24 +201,14 @@ Running `nix develop` in the root of the repository will place you in a developm
 
 ### Launching services for development
 
-There are a few Makefile targets provided for convenience, all of which require being in the Nix shell environment:
+To develop locally, you can use one the CTL flake to launch all required services (using default configuration values):
 
-- `make run-testnet-node` starts the node in a Docker container
-- `make run-testnet-ogmios` starts our fork of `ogmios` with the correct flags (i.e. config and node socket locations)
-- `make query-testnet-sync` checks the node's sync status. If the node is fully synced, you will see:
+- The easiest way: `nix run -L .#ctl-runtime` will both build and run the services
+- The same, but indirectly in your shell:
   ```
-  {  "epoch": 1005,
-     "hash": "<HASH>",
-     "slot": 7232440,
-     "block": 322985,
-     "era": "Alonzo",
-     "syncProgress": "100.00"
-  }
+  $ nix build -L .#ctl-runtime
+  $ arion --prebuilt-file ./result up
   ```
-- `make run-datum-cache-postgres` runs a PostgreSQL docker container with the same username, password, and DB name as required for `ogmios-datum-cache`
-- `make run-datum-cache-postgres-console` runs `psql` to access the datum cache DB directly; useful for debugging the datum cache
-
-If you prefer to run these services locally without `make`, the environment variables `CARDANO_NODE_SOCKET_PATH` and `CARDANO_NODE_CONFIG` are also exported in the shell pointing to the correct locations as noted in the previous section.
 
 ### Building/testing the PS project and running it in the browser
 

--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,7 @@
                       ${pkgs.coreutils}/bin/cat <<EOF > config.toml
                         ${configFile}
                       EOF
+                      ${pkgs.coreutils}/bin/sleep 1
                       ${pkgs.ogmios-datum-cache}/bin/ogmios-datum-cache
                     ''
                   ];

--- a/flake.nix
+++ b/flake.nix
@@ -171,6 +171,15 @@
           }
         , datumCache ? {
             port = 9999;
+            dbConnectionString = nixpkgs.lib.concatStringsSep
+              " "
+              [
+                "host=postgres"
+                "port=${toString postgres.port}"
+                "user=${postgres.user}"
+                "dbname=${postgres.db}"
+                "password=${postgres.password}"
+              ];
             saveAllDatums = true;
             firstFetchBlock = {
               slot = 44366242;
@@ -268,13 +277,7 @@
             ogmios-datum-cache =
               let
                 configFile = ''
-                  dbConnectionString = """
-                    host=postgres \
-                    port=${toString postgres.port} \
-                    user=${postgres.user} \
-                    dbname=${postgres.db} \
-                    password=${postgres.password}\
-                  """
+                  dbConnectionString = "${datumCache.dbConnectionString}"
                   saveAllDatums = ${pkgs.lib.boolToString datumCache.saveAllDatums}
                   server.port = ${toString datumCache.port}
                   ogmios.address = "ogmios"

--- a/flake.nix
+++ b/flake.nix
@@ -346,34 +346,6 @@
                 pkgs.fd
                 pkgs.arion
               ];
-
-              shellHook =
-                let
-                  nodeModules = project.mkNodeModules { };
-                in
-                ''
-                  __ln-testnet-config () {
-                    local cfgdir=./.node-cfg
-                    if test -e "$cfgdir"; then
-                      rm -r "$cfgdir"
-                    fi
-
-                    mkdir -p "$cfgdir"/testnet/{config,genesis}
-
-                    ln -s ${pkgs.cardano-configurations}/network/testnet/cardano-node/config.json \
-                      "$cfgdir"/testnet/config/config.json
-                    ln -s ${pkgs.cardano-configurations}/network/testnet/genesis/byron.json \
-                      "$cfgdir"/testnet/genesis/byron.json
-                    ln -s ${pkgs.cardano-configurations}/network/testnet/genesis/shelley.json \
-                      "$cfgdir"/testnet/genesis/shelley.json
-                  }
-
-                  __ln-testnet-config
-
-                  export CARDANO_NODE_SOCKET_PATH="$PWD"/.node/socket/node.socket
-                  export CARDANO_NODE_CONFIG="$PWD"/.node-cfg/testnet/config/config.json
-
-                '';
             };
           };
         in

--- a/flake.nix
+++ b/flake.nix
@@ -207,7 +207,7 @@
               nodeIpcVol = "node-ipc";
               nodeSocketPath = "/ipc/node.socket";
               serverName = "ctl-server:exe:ctl-server";
-              server = ((hsProjectFor system).flake { }).packages."${serverName}";
+              server = self.packages.${system}."${serverName}";
             in
             {
               docker-compose.raw = {
@@ -240,25 +240,31 @@
                     ];
                   };
                 };
-                ogmios = {
-                  service = {
-                    useHostStore = true;
-                    ports = [ "1337:1337" ];
-                    volumes = [
-                      "${cardano-configurations}/network/testnet:/config"
-                      "${nodeIpcVol}:/ipc"
-                    ];
-                    command = [
-                      "${pkgs.bash}/bin/sh"
-                      "-c"
-                      ''
-                        ${pkgs.ogmios}/bin/ogmios \
-                          --node-socket /ipc/node.socket \
-                          --node-config /config/cardano-node/config.json
-                      ''
-                    ];
+                ogmios =
+                  let
+                    ogmiosPort = "1337";
+                  in
+                  {
+                    service = {
+                      useHostStore = true;
+                      ports = [ "${ogmiosPort}:${ogmiosPort}" ];
+                      volumes = [
+                        "${cardano-configurations}/network/testnet:/config"
+                        "${nodeIpcVol}:/ipc"
+                      ];
+                      command = [
+                        "${pkgs.bash}/bin/sh"
+                        "-c"
+                        ''
+                          ${pkgs.ogmios}/bin/ogmios \
+                            --host 0.0.0.0 \
+                            --port ${ogmiosPort} \
+                            --node-socket /ipc/node.socket \
+                            --node-config /config/cardano-node/config.json
+                        ''
+                      ];
+                    };
                   };
-                };
                 ctl-server = {
                   service = {
                     useHostStore = true;

--- a/flake.nix
+++ b/flake.nix
@@ -163,7 +163,13 @@
         { nodePort ? 3001
         , ogmiosPort ? 1337
         , serverPort ? 8081
-        }@cfg:
+        , postgres ? {
+            port = 5432;
+            user = "ctxlib";
+            password = "ctxlib";
+            db = "ctxlib";
+          }
+        }:
         { ... }:
         let
           inherit (builtins) toString;
@@ -244,6 +250,20 @@
                     ${server}/bin/ctl-server
                   ''
                 ];
+              };
+            };
+
+            postgres = {
+              service = {
+                image = "postgres:13";
+                ports = [
+                  "${toString postgres.port}:${toString postgres.port}"
+                ];
+                environment = {
+                  POSTGRES_USER = "${postgres.user}";
+                  POSTGRES_PASSWORD = "${postgres.password}";
+                  POSTGRES_DB = "${postgres.db}";
+                };
               };
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,7 @@
                 pkgs.ogmios-datum-cache
                 pkgs.nixpkgs-fmt
                 pkgs.fd
+                pkgs.arion
               ];
 
               shellHook =
@@ -204,6 +205,7 @@
             let
               nodeDbVol = "node-db";
               nodeIpcVol = "node-ipc";
+              nodeSocketPath = "/ipc/node.socket";
             in
             {
               docker-compose.raw = {
@@ -229,9 +231,27 @@
                       "--database-path"
                       "/data/db"
                       "--socket-path"
-                      "/ipc/node.socket"
+                      "${nodeSocketPath}"
                       "--topology"
                       "/config/topology.json"
+                    ];
+                  };
+                };
+                ogmios = {
+                  service = {
+                    useHostStore = true;
+                    volumes = [
+                      "${cardano-configurations}/network/testnet:/config"
+                      "${nodeIpcVol}:/ipc"
+                    ];
+                    command = [
+                      "${pkgs.bash}/bin/sh"
+                      "-c"
+                      ''
+                        ${pkgs.ogmios}/bin/ogmios \
+                          --node-socket /ipc/node.socket \
+                          --node-config /config/cardano-node/config.json
+                      ''
                     ];
                   };
                 };


### PR DESCRIPTION
Closes #333. This adds the ability to configure, generate, and run Arion expressions (a wrapper around docker-compose) to launch all of CTL's required runtime dependencies

For local development and testing, all that is now needed is `nix run .#ctl-runtime` and everything will be launched. I've removed the old `shellHook` and Makefile commands since the `ctl-runtime` app supersedes them and is much easier to maintain

For CTL users, the overlay exposes functions for generating the Arion expressions. I've added a new guide to the readme illustrating how to use this