### PR TITLE
Add ARM support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,6 +581,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1641205782,
         "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
@@ -1443,7 +1459,7 @@
         "cardano-ledger": "cardano-ledger_2",
         "cardano-node": "cardano-node_2",
         "cardano-prelude": "cardano-prelude_2",
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flat": "flat_2",
         "goblins": "goblins_2",
         "haskell-nix": "haskell-nix_2",
@@ -1659,6 +1675,7 @@
         "cardano-wallet": "cardano-wallet",
         "easy-purescript-nix": "easy-purescript-nix",
         "ekg-forward": "ekg-forward",
+        "flake-compat": "flake-compat",
         "flat": "flat",
         "goblins": "goblins",
         "haskell-nix": "haskell-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,12 @@
     , ...
     }@inputs:
     let
-      defaultSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      defaultSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
       perSystem = nixpkgs.lib.genAttrs defaultSystems;
       overlay = system: with inputs; (prev: final: {
         easy-ps =

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,11 @@
   description = "cardano-transaction-lib";
 
   inputs = {
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios/c4f896bf32ad066be8edd8681ee11e4ab059be7f";
     ogmios-datum-cache = {


### PR DESCRIPTION
Currently we only offer support for x86_64. This adds aarch64 support for both Linux and Darwin

I also added `flake-compat` back to the inputs so the compatibility default.nix and shell.nix continue to work