### PR TITLE
Fix balancer tx input duplicate elements

### DIFF
--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -687,7 +687,7 @@ balanceTxIns' utxos fees (TxBody txBody) = do
   nonMintedValue <- note (BalanceTxInsCannotMinus $ CannotMinus $ wrap mintVal)
     $ Array.foldMap getAmount txOutputs `minus` mintVal
 
-  -- -- Useful spies for debugging:
+  -- Useful spies for debugging:
   -- let x = spy "nonMintedVal" nonMintedValue
   --     y = spy "feees" fees
   --     z = spy "changeMinUtxo" changeMinUtxo
@@ -738,7 +738,7 @@ collectTxIns originalTxIns utxos value =
       originalTxIns
       $ utxosToTransactionInput utxos
 
-  -- -- Useful spies for debugging:
+  -- Useful spies for debugging:
   -- x = spy "collectTxIns:value" value
   -- y = spy "collectTxIns:txInsValueOG" (txInsValue utxos originalTxIns)
   -- z = spy "collectTxIns:txInsValueNEW" (txInsValue utxos updatedInputs)
@@ -807,7 +807,7 @@ balanceNonAdaOuts' changeAddr utxos txBody'@(TxBody txBody) = do
       $ filterNonAda inputValue `minus` nonMintedAdaOutputValue
 
   let
-    -- -- Useful spies for debugging:
+    -- Useful spies for debugging:
     -- a = spy "balanceNonAdaOuts'nonMintedOutputValue" nonMintedOutputValue
     -- b = spy "balanceNonAdaOuts'nonMintedAdaOutputValue" nonMintedAdaOutputValue
     -- c = spy "balanceNonAdaOuts'nonAdaChange" nonAdaChange

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -690,16 +690,16 @@ balanceTxIns' utxos fees (TxBody txBody) = do
     $ Array.foldMap getAmount txOutputs `minus` mintVal
 
   -- Useful spies for debugging:
-  -- let x = spy "nonMintedVal" nonMintedValue
-  --     y = spy "feees" fees
-  --     z = spy "changeMinUtxo" changeMinUtxo
-  --     a = spy "txBody" txBody
+  let x = spy "nonMintedVal" nonMintedValue
+      y = spy "feees" fees
+      z = spy "changeMinUtxo" changeMinUtxo
+      a = spy "txBody" txBody
 
   let
     minSpending :: Value
     minSpending = lovelaceValueOf (fees + changeMinUtxo) <> nonMintedValue
 
-  -- a = spy "minSpending" minSpending
+    a = spy "minSpending" minSpending
 
   txIns :: Array TransactionInput <-
     lmap
@@ -740,9 +740,9 @@ collectTxIns originalTxIns utxos value =
       $ utxosToTransactionInput utxos
 
   -- Useful spies for debugging:
-  -- x = spy "collectTxInsValue" value
-  -- y = spy "txInsValueOG" (txInsValue originalTxIns)
-  -- z = spy "txInsValueNEW" (txInsValue updatedInputs)
+  x = spy "collectTxIns:value" value
+  y = spy "collectTxIns:txInsValueOG" (txInsValue utxos originalTxIns)
+  z = spy "collectTxIns:txInsValueNEW" (txInsValue utxos updatedInputs)
 
   isSufficient :: Array TransactionInput -> Boolean
   isSufficient txIns' =

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -39,6 +39,7 @@ import Data.Show.Generic (genericShow)
 import Data.Traversable (traverse_)
 import Data.Tuple (fst)
 import Data.Tuple.Nested ((/\), type (/\))
+import Debug (spy)
 import Effect.Class (class MonadEffect)
 import ProtocolParametersAlonzo
   ( adaOnlyWords
@@ -804,9 +805,9 @@ balanceNonAdaOuts' changeAddr utxos txBody'@(TxBody txBody) = do
 
   let
     -- Useful spies for debugging:
-    -- a = spy "balanceNonAdaOuts'nonMintedOutputValue" nonMintedOutputValue
-    -- b = spy "balanceNonAdaOuts'nonMintedAdaOutputValue" nonMintedAdaOutputValue
-    -- c = spy "balanceNonAdaOuts'nonAdaChange" nonAdaChange
+    a = spy "balanceNonAdaOuts'nonMintedOutputValue" nonMintedOutputValue
+    b = spy "balanceNonAdaOuts'nonMintedAdaOutputValue" nonMintedAdaOutputValue
+    c = spy "balanceNonAdaOuts'nonAdaChange" nonAdaChange
 
     outputs :: Array TransactionOutput
     outputs =

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -734,7 +734,7 @@ collectTxIns originalTxIns utxos value =
     Foldable.foldl
       ( \newTxIns txIn ->
           if isSufficient newTxIns then newTxIns
-          else txIn `Array.insert` newTxIns -- treat as a set.
+          else [ txIn ] `Array.union` newTxIns -- treat as a set.
       )
       originalTxIns
       $ utxosToTransactionInput utxos

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -289,9 +289,9 @@ balanceTx (UnbalancedTx { transaction: unbalancedTx, utxoIndex }) = do
         lmap ReturnAdaChangeError'
 
     -- Sort inputs at the very end so it behaves as a Set.
-    let completeTx = unsignedTx # _body <<< _inputs %~ Array.sort
+    let sortedUnsignedTx = unsignedTx # _body <<< _inputs %~ Array.sort
     -- Logs final balanced tx and returns it
-    ExceptT $ logTx "Post-balancing Tx " allUtxos completeTx <#> Right
+    ExceptT $ logTx "Post-balancing Tx " allUtxos sortedUnsignedTx <#> Right
   where
   prebalanceCollateral
     :: BigInt

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -808,6 +808,7 @@ balanceNonAdaOuts' changeAddr utxos txBody'@(TxBody txBody) = do
     a = spy "balanceNonAdaOuts'nonMintedOutputValue" nonMintedOutputValue
     b = spy "balanceNonAdaOuts'nonMintedAdaOutputValue" nonMintedAdaOutputValue
     c = spy "balanceNonAdaOuts'nonAdaChange" nonAdaChange
+    d = spy "balanceNonAdaOuts'inputValue" inputValue
 
     outputs :: Array TransactionOutput
     outputs =
@@ -827,8 +828,10 @@ balanceNonAdaOuts' changeAddr utxos txBody'@(TxBody txBody) = do
           { no: txOuts'
           , yes: TransactionOutput txOut@{ amount: v } : txOuts
           } ->
-            TransactionOutput
-              txOut { amount = v <> nonAdaChange } : txOuts <> txOuts'
+            let v' = spy "balanceNonAdaOuts'spy v before: " v
+            in 
+              TransactionOutput
+                txOut { amount = v <> nonAdaChange } : txOuts <> txOuts'
 
   -- Original code uses "isNat" because there is a guard against zero, see
   -- isPos for more detail.

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -31,7 +31,7 @@ import Control.Monad.Reader.Class (asks)
 import Control.Monad.Reader.Trans (ReaderT)
 import Control.Monad.State.Trans (StateT, get, gets, put, runStateT)
 import Control.Monad.Trans.Class (lift)
-import Data.Array (singleton, union) as Array
+import Data.Array ((:), singleton, union) as Array
 import Data.Array (elemIndex, insert, toUnfoldable, zip)
 import Data.Bifunctor (lmap)
 import Data.BigInt (BigInt, fromInt)
@@ -678,7 +678,7 @@ addMissingValueSpent = do
         , amount: missing
         , dataHash: Nothing
         }
-    _cpsToTxBody <<< _outputs <>= Array.singleton txOut
+    _cpsToTxBody <<< _outputs %= Array.(:) txOut
 
 updateUtxoIndex
   :: forall (a :: Type)
@@ -739,7 +739,7 @@ addOwnOutput (OutputConstraint { datum: d, value }) = do
     dHash <- liftM TypedTxOutHasNoDatumHash (typedTxOutDatumHash typedTxOut)
     dat <-
       ExceptT $ lift $ getDatumByHash dHash <#> note (CannotQueryDatum dHash)
-    _cpsToTxBody <<< _outputs <>= Array.singleton txOut
+    _cpsToTxBody <<< _outputs %= Array.(:) txOut
     ExceptT $ addDatum dat
     _valueSpentBalancesOutputs <>= provide value'
 
@@ -988,7 +988,7 @@ processConstraint mpsMap osMap = do
             , amount
             , dataHash
             }
-        _cpsToTxBody <<< _outputs <>= Array.singleton txOut
+        _cpsToTxBody <<< _outputs %= Array.(:) txOut
         _valueSpentBalancesOutputs <>= provide amount
     MustPayToScript vlh dat plutusValue -> do
       let amount = unwrap $ fromPlutusType plutusValue
@@ -1004,7 +1004,7 @@ processConstraint mpsMap osMap = do
             , dataHash
             }
         ExceptT $ addDatum dat
-        _cpsToTxBody <<< _outputs <>= Array.singleton txOut
+        _cpsToTxBody <<< _outputs %= Array.(:) txOut
         _valueSpentBalancesOutputs <>= provide amount
     MustHashDatum dh dt -> do
       mdh <- lift $ datumHash dt


### PR DESCRIPTION
A small PR to fix a few things:
- Since we're using `Data.Array` instead of `Data.Set`, insertions don't account for duplicates which was a bug. As a result, we were sometimes doubling inputs and causing balancing issues.
- The array is sorted at the very end of balancing to replicate a Set.
- This isn't  a bug but I've optimised tx outputs in script lookups to cons instead of append. The ordering is less important for outputs.

There isn't an outstanding issue for this.