### PR TITLE
remove `addDatum` from `MustPayToScript`  of `processConstraints`

### DIFF
--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -1003,7 +1003,8 @@ processConstraint mpsMap osMap = do
             , amount
             , dataHash
             }
-        ExceptT $ addDatum dat
+        -- Note we don't `addDatum` as this included as part of `mustPayToScript`
+        -- constraint already.
         _cpsToTxBody <<< _outputs %= Array.(:) txOut
         _valueSpentBalancesOutputs <>= provide amount
     MustHashDatum dh dt -> do


### PR DESCRIPTION
-  `addDatum` was being called inside `MustPayToScript` of `processConstraints` when it is already being called via `MustIncludeDatum` in `processConstraints` also. Note that the constraint `mustPayToScript` creates two singletons over `MustPayToScript` and `MustIncludeDatum` so we are adding the datum twice. It's possible this doesn't matter if datums are a set anyway.