### PR TITLE
change show instance of ByteArray to hex

### DIFF
--- a/src/Types/ByteArray.purs
+++ b/src/Types/ByteArray.purs
@@ -29,7 +29,7 @@ newtype ByteArray = ByteArray Uint8Array
 derive instance Newtype ByteArray _
 
 instance Show ByteArray where
-  show arr = "(byteArrayFromIntArrayUnsafe " <> show (byteArrayToIntArray arr)
+  show arr = "(byteArrayToHex " <> show (byteArrayToHex arr)
     <> ")"
 
 instance Eq ByteArray where


### PR DESCRIPTION
- Change `Show` instance of `ByteArray` to be hex instead of an int array.