### PR TITLE
add null redeemers logic to languages in finalizeTx

### DIFF
--- a/server/src/Api/Handlers.hs
+++ b/server/src/Api/Handlers.hs
@@ -102,7 +102,11 @@ finalizeTx (FinalizeRequest {tx, datums, redeemers}) = do
   decodedDatums <-
     throwDecodeErrorWithMessage "Failed to decode datums" $
       traverse decodeCborDatum datums
-  let languages = Set.fromList [PlutusV1]
+  -- See https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L123
+  let languages =
+        if TxWitness.nullRedeemers decodedRedeemers
+          then mempty
+          else Set.fromList [PlutusV1]
       txDatums =
         TxWitness.TxDats . Map.fromList $
           decodedDatums <&> \datum -> (Data.hashData datum, datum)


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/380
In particular:
- We can now send value to a script address without requiring a dummy minting policy to mint something - it turns out that a redeemer was required with our current logic. The Alonzo cddl has specific requirements for empty redeemers found here https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L123
Some `PlutusV2` info can be found here also https://github.com/input-output-hk/cardano-ledger/blob/81a309fa6410d4216724a3eb32e4141da40733e9/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L117