### PR TITLE
Use ogmios-datum-cache reflection

### DIFF
--- a/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
+++ b/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
@@ -41,18 +41,7 @@ $schema methodType
 
 $schema mirrorType
     $type
-        $object
-    $properties
-        $property-name "step"
-        $property-schema stepType
-        $property-name "id"
-        $property-schema $string
-
-$schema stepType
-    $type
         $string
-    $string-values
-        "INIT"
 
 $schema result
     $type

--- a/fixtures/test/parsing/JsonWsp/UtxoQueryResponse.json
+++ b/fixtures/test/parsing/JsonWsp/UtxoQueryResponse.json
@@ -27,9 +27,6 @@
         }
       ]
     ],
-    "reflection": {
-      "step": "INIT",
-      "id": "Hello123"
-    }
+    "reflection": "Hello123"
   }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -1529,11 +1529,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1652145155,
-        "narHash": "sha256-WSXfGUzgcn+ELZrPfROQULRyBdtxPnvY4AdI/iHgCgk=",
+        "lastModified": 1652451460,
+        "narHash": "sha256-LB/8p7GdQ7i5j4npBmPe7wnNeXb46ejxQ0cVIxyC3Hs=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "24884ede2dc0d553d968010fbcbb2a4390134e60",
+        "rev": "001770e88d1f62092c27401645028c9a33146dc5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1529,11 +1529,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1652451460,
-        "narHash": "sha256-LB/8p7GdQ7i5j4npBmPe7wnNeXb46ejxQ0cVIxyC3Hs=",
+        "lastModified": 1652673546,
+        "narHash": "sha256-fd3UST7vjed7KLOrLsFD8/nP7YXhCAQ3ODFs5SjZ6SQ=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "001770e88d1f62092c27401645028c9a33146dc5",
+        "rev": "dbff887d14122249352c1a853be05023f64a2664",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -610,6 +610,22 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -1451,6 +1467,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1634172192,
+        "narHash": "sha256-FBF4U/T+bMg4sEyT/zkgasvVquGzgdAf4y8uCosKMmo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2cf9db0e3d45b9d00f16f2836cb1297bcadc475e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2cf9db0e3d45b9d00f16f2836cb1297bcadc475e",
+        "type": "github"
+      }
+    },
     "ogmios": {
       "inputs": {
         "Win32-network": "Win32-network_2",
@@ -1492,13 +1524,16 @@
       }
     },
     "ogmios-datum-cache": {
-      "flake": false,
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1649871652,
-        "narHash": "sha256-X2oDliRDUb7Y8a5SfBxSzWgzYY0Spun2YwZFN+3gCTE=",
+        "lastModified": 1652145155,
+        "narHash": "sha256-WSXfGUzgcn+ELZrPfROQULRyBdtxPnvY4AdI/iHgCgk=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "9e8bcbe00f88715afdb202cd9654ec2adc72c09e",
+        "rev": "24884ede2dc0d553d968010fbcbb2a4390134e60",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
     ogmios.url = "github:mlabs-haskell/ogmios/c4f896bf32ad066be8edd8681ee11e4ab059be7f";
     ogmios-datum-cache = {
       url = "github:mlabs-haskell/ogmios-datum-cache";
-      flake = true;
     };
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,7 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios/c4f896bf32ad066be8edd8681ee11e4ab059be7f";
-    ogmios-datum-cache = {
-      url = "github:mlabs-haskell/ogmios-datum-cache";
-    };
+    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables
@@ -194,7 +192,7 @@
               };
               autoStart = true;
               startFromLast = false;
-              filter = "{ \"const\": true }";
+              filter = builtins.toJSON { const = true; };
             };
           }
         }:
@@ -303,7 +301,7 @@
                   useHostStore = true;
                   ports = [ (bindPort datumCache.port) ];
                   restart = "on-failure";
-                  depends_on = [ "postgres" ];
+                  depends_on = [ "postgres" "ogmios" ];
                   command = [
                     "${pkgs.bash}/bin/sh"
                     "-c"

--- a/flake.nix
+++ b/flake.nix
@@ -189,8 +189,8 @@
               ];
             blockFetcher = {
               firstBlock = {
-                slot = 44366242;
-                id = "d2a4249fe3d0607535daa26caf12a38da2233586bc51e79ed0b3a36170471bf5";
+                slot = 54066900;
+                id = "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d";
               };
               autoStart = true;
               startFromLast = false;

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     ogmios.url = "github:mlabs-haskell/ogmios/c4f896bf32ad066be8edd8681ee11e4ab059be7f";
     ogmios-datum-cache = {
       url = "github:mlabs-haskell/ogmios-datum-cache";
-      flake = false;
+      flake = true;
     };
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
@@ -148,9 +148,7 @@
         easy-ps =
           import inputs.easy-purescript-nix { pkgs = prev; };
         ogmios-datum-cache =
-          nixpkgs.legacyPackages.${system}.haskellPackages.callPackage
-            ogmios-datum-cache
-            { };
+          inputs.ogmios-datum-cache.defaultPackage.${system};
         ogmios = ogmios.packages.${system}."ogmios:exe:ogmios";
         cardano-cli = cardano-node-exe.packages.${system}.cardano-cli;
         purescriptProject = import ./nix { inherit system; pkgs = prev; };

--- a/flake.nix
+++ b/flake.nix
@@ -187,10 +187,14 @@
                 "dbname=${postgres.db}"
                 "password=${postgres.password}"
               ];
-            saveAllDatums = true;
-            firstFetchBlock = {
-              slot = 44366242;
-              id = "d2a4249fe3d0607535daa26caf12a38da2233586bc51e79ed0b3a36170471bf5";
+            blockFetcher = {
+              firstBlock = {
+                slot = 44366242;
+                id = "d2a4249fe3d0607535daa26caf12a38da2233586bc51e79ed0b3a36170471bf5";
+              };
+              autoStart = true;
+              startFromLast = false;
+              filter = "{ \"const\": true }";
             };
           }
         }:
@@ -285,12 +289,13 @@
               let
                 configFile = ''
                   dbConnectionString = "${datumCache.dbConnectionString}"
-                  saveAllDatums = ${pkgs.lib.boolToString datumCache.saveAllDatums}
                   server.port = ${toString datumCache.port}
                   ogmios.address = "ogmios"
                   ogmios.port = ${toString ogmios.port}
-                  firstFetchBlock.slot = ${toString datumCache.firstFetchBlock.slot}
-                  firstFetchBlock.id = "${datumCache.firstFetchBlock.id}"
+                  blockFetcher.autoStart = ${nixpkgs.lib.boolToString datumCache.blockFetcher.autoStart}
+                  blockFetcher.firstBlock.slot = ${toString datumCache.blockFetcher.firstBlock.slot}
+                  blockFetcher.firstBlock.id = "${datumCache.blockFetcher.firstBlock.id}"
+                  blockFetcher.filter = "${nixpkgs.lib.strings.replaceStrings ["\"" "\\"] ["\\\"" "\\\\"] datumCache.blockFetcher.filter}"
                 '';
               in
               {

--- a/src/Contract/PlutusData.purs
+++ b/src/Contract/PlutusData.purs
@@ -3,15 +3,11 @@
 -- | `Datum` and `Redeemer`. It also contains typeclasses like `FromData` and
 -- | `ToData`.
 module Contract.PlutusData
-  ( cancelFetchBlocksRequest
-  , datumFilterAddHashesRequest
-  , datumFilterGetHashesRequest
-  , datumFilterRemoveHashesRequest
-  , datumFilterSetHashesRequest
+  ( cancelFetchBlocks
   , datumHash
   , getDatumByHash
   , getDatumsByHashes
-  , startFetchBlocksRequest
+  , startFetchBlocks
   , module Datum
   , module ExportQueryM
   , module PlutusData
@@ -27,41 +23,14 @@ import Contract.Monad (Contract, wrapContract)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import FromData (class FromData, fromData) as FromData
-import QueryM
-  ( cancelFetchBlocksRequest
-  , datumFilterAddHashesRequest
-  , datumFilterGetHashesRequest
-  , datumFilterRemoveHashesRequest
-  , datumFilterSetHashesRequest
-  , datumHash
-  , getDatumByHash
-  , getDatumsByHashes
-  , startFetchBlocksRequest
-  ) as QueryM
-import QueryM
-  ( DatumCacheListeners
-  , DatumCacheWebSocket
-  , defaultDatumCacheWsConfig
-  , mkDatumCacheWebSocketAff
-  ) as ExportQueryM
-import Serialization.Address (Slot, BlockId)
+import QueryM (DatumCacheListeners, DatumCacheWebSocket, defaultDatumCacheWsConfig, mkDatumCacheWebSocketAff) as ExportQueryM
+import QueryM (cancelFetchBlocks, datumHash, getDatumByHash, getDatumsByHashes, startFetchBlocks) as QueryM
+import Serialization.Address (Slot)
 import ToData (class ToData, toData) as ToData
-import Types.PlutusData
-  ( PlutusData(Constr, Map, List, Integer, Bytes)
-  ) as PlutusData
-import Types.Datum
-  ( Datum(Datum)
-  , DatumHash
-  , unitDatum
-  ) as Datum
-import Types.Redeemer
-  ( Redeemer(Redeemer)
-  , RedeemerHash(RedeemerHash)
-  , redeemerHash
-  , unitRedeemer
-  ) as Redeemer
--- Not importing `RedeemerTag` for now.
-import Types.Transaction (DatumHash)
+import Types.Datum (Datum(Datum), DatumHash, unitDatum) as Datum
+import Types.PlutusData (PlutusData(Constr, Map, List, Integer, Bytes)) as PlutusData
+import Types.Redeemer (Redeemer(Redeemer), RedeemerHash(RedeemerHash), redeemerHash, unitRedeemer) as Redeemer
+import Types.Transaction (BlockId, DatumHash)
 import Types.Transaction (DataHash(DataHash)) as Transaction
 
 -- | Get a `PlutusData` given a `DatumHash`.
@@ -78,34 +47,15 @@ getDatumsByHashes
   -> Contract r (Map DatumHash Datum.Datum)
 getDatumsByHashes = wrapContract <<< QueryM.getDatumsByHashes
 
-startFetchBlocksRequest
+startFetchBlocks
   :: forall (r :: Row Type)
    . { slot :: Slot, id :: BlockId }
   -> Contract r Unit
-startFetchBlocksRequest = wrapContract <<< QueryM.startFetchBlocksRequest
+startFetchBlocks = wrapContract <<< QueryM.startFetchBlocks
 
 -- | Cancels a running block fetcher job. Throws on no fetchers running
-cancelFetchBlocksRequest :: forall (r :: Row Type). Contract r Unit
-cancelFetchBlocksRequest = wrapContract QueryM.cancelFetchBlocksRequest
-
-datumFilterAddHashesRequest
-  :: forall (r :: Row Type). Array DatumHash -> Contract r Unit
-datumFilterAddHashesRequest =
-  wrapContract <<< QueryM.datumFilterAddHashesRequest
-
-datumFilterRemoveHashesRequest
-  :: forall (r :: Row Type). Array DatumHash -> Contract r Unit
-datumFilterRemoveHashesRequest =
-  wrapContract <<< QueryM.datumFilterRemoveHashesRequest
-
-datumFilterSetHashesRequest
-  :: forall (r :: Row Type). Array DatumHash -> Contract r Unit
-datumFilterSetHashesRequest =
-  wrapContract <<< QueryM.datumFilterSetHashesRequest
-
-datumFilterGetHashesRequest
-  :: forall (r :: Row Type). Contract r (Array DatumHash)
-datumFilterGetHashesRequest = wrapContract QueryM.datumFilterGetHashesRequest
+cancelFetchBlocks :: forall (r :: Row Type). Contract r Unit
+cancelFetchBlocks = wrapContract QueryM.cancelFetchBlocks
 
 -- | Hashes a Plutus-style Datum
 datumHash :: forall (r :: Row Type). Datum.Datum -> Contract r (Maybe DatumHash)

--- a/src/Contract/PlutusData.purs
+++ b/src/Contract/PlutusData.purs
@@ -38,6 +38,7 @@ import QueryM
   ) as QueryM
 import Serialization.Address (Slot)
 import ToData (class ToData, toData) as ToData
+import Types.Chain (BlockHeaderHash)
 import Types.Datum (Datum(Datum), DatumHash, unitDatum) as Datum
 import Types.PlutusData (PlutusData(Constr, Map, List, Integer, Bytes)) as PlutusData
 import Types.Redeemer
@@ -46,7 +47,7 @@ import Types.Redeemer
   , redeemerHash
   , unitRedeemer
   ) as Redeemer
-import Types.Transaction (BlockId, DatumHash)
+import Types.Transaction (DatumHash)
 import Types.Transaction (DataHash(DataHash)) as Transaction
 
 -- | Get a `PlutusData` given a `DatumHash`.
@@ -65,7 +66,7 @@ getDatumsByHashes = wrapContract <<< QueryM.getDatumsByHashes
 
 startFetchBlocks
   :: forall (r :: Row Type)
-   . { slot :: Slot, id :: BlockId }
+   . { slot :: Slot, id :: BlockHeaderHash }
   -> Contract r Unit
 startFetchBlocks = wrapContract <<< QueryM.startFetchBlocks
 

--- a/src/Contract/PlutusData.purs
+++ b/src/Contract/PlutusData.purs
@@ -23,13 +23,29 @@ import Contract.Monad (Contract, wrapContract)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import FromData (class FromData, fromData) as FromData
-import QueryM (DatumCacheListeners, DatumCacheWebSocket, defaultDatumCacheWsConfig, mkDatumCacheWebSocketAff) as ExportQueryM
-import QueryM (cancelFetchBlocks, datumHash, getDatumByHash, getDatumsByHashes, startFetchBlocks) as QueryM
+import QueryM
+  ( DatumCacheListeners
+  , DatumCacheWebSocket
+  , defaultDatumCacheWsConfig
+  , mkDatumCacheWebSocketAff
+  ) as ExportQueryM
+import QueryM
+  ( cancelFetchBlocks
+  , datumHash
+  , getDatumByHash
+  , getDatumsByHashes
+  , startFetchBlocks
+  ) as QueryM
 import Serialization.Address (Slot)
 import ToData (class ToData, toData) as ToData
 import Types.Datum (Datum(Datum), DatumHash, unitDatum) as Datum
 import Types.PlutusData (PlutusData(Constr, Map, List, Integer, Bytes)) as PlutusData
-import Types.Redeemer (Redeemer(Redeemer), RedeemerHash(RedeemerHash), redeemerHash, unitRedeemer) as Redeemer
+import Types.Redeemer
+  ( Redeemer(Redeemer)
+  , RedeemerHash(RedeemerHash)
+  , redeemerHash
+  , unitRedeemer
+  ) as Redeemer
 import Types.Transaction (BlockId, DatumHash)
 import Types.Transaction (DataHash(DataHash)) as Transaction
 

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -4,7 +4,7 @@ module QueryM
   , DatumCacheListeners
   , DatumCacheWebSocket
   , DispatchIdMap
-  , DispatchError(..)
+  , DispatchError(JsError, JsonError)
   , FeeEstimate(..)
   , FinalizedTransaction(..)
   , HashedData(..)

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -153,7 +153,7 @@ import Types.MultiMap as MultiMap
 import Types.PlutusData (PlutusData)
 import Types.PubKeyHash (PubKeyHash)
 import Types.Scripts (PlutusScript)
-import Types.Transaction (BlockId, Transaction(Transaction))
+import Types.Transaction (Transaction(Transaction))
 import Types.Transaction as Transaction
 import Types.TransactionUnspentOutput (TransactionUnspentOutput)
 import Types.UnbalancedTransaction (StakePubKeyHash, PaymentPubKeyHash)
@@ -264,7 +264,7 @@ getDatumsByHashes :: Array DatumHash -> QueryM (Map DatumHash Datum)
 getDatumsByHashes hashes = unwrap <$> do
   mkDatumCacheRequest DcWsp.getDatumsByHashesCall _.getDatumsByHashes hashes
 
-startFetchBlocks :: { slot :: Slot, id :: BlockId } -> QueryM Unit
+startFetchBlocks :: { slot :: Slot, id :: Chain.BlockHeaderHash } -> QueryM Unit
 startFetchBlocks start = void $ mkDatumCacheRequest DcWsp.startFetchBlocksCall
   _.startFetchBlocks
   start
@@ -726,7 +726,8 @@ type DatumCacheListeners =
   { getDatumByHash :: ListenerSet DatumHash GetDatumByHashR
   , getDatumsByHashes :: ListenerSet (Array DatumHash) GetDatumsByHashesR
   , startFetchBlocks ::
-      ListenerSet { slot :: Slot, id :: BlockId } StartFetchBlocksR
+      ListenerSet { slot :: Slot, id :: Chain.BlockHeaderHash }
+        StartFetchBlocksR
   , cancelFetchBlocks :: ListenerSet Unit CancelFetchBlocksR
   }
 

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -23,10 +23,6 @@ module QueryM
   , applyArgs
   , calculateMinFee
   , cancelFetchBlocksRequest
-  , datumFilterAddHashesRequest
-  , datumFilterGetHashesRequest
-  , datumFilterRemoveHashesRequest
-  , datumFilterSetHashesRequest
   , datumHash
   , traceQueryConfig
   , finalizeTx
@@ -109,24 +105,16 @@ import QueryM.DatumCacheWsp
   ( DatumCacheMethod
       ( StartFetchBlocks
       , CancelFetchBlocks
-      , DatumFilterAddHashes
-      , DatumFilterRemoveHashes
-      , DatumFilterSetHashes
       )
   , DatumCacheRequest
       ( GetDatumByHashRequest
       , GetDatumsByHashesRequest
       , StartFetchBlocksRequest
       , CancelFetchBlocksRequest
-      , DatumFilterAddHashesRequest
-      , DatumFilterRemoveHashesRequest
-      , DatumFilterSetHashesRequest
-      , DatumFilterGetHashesRequest
       )
   , DatumCacheResponse
       ( GetDatumByHashResponse
       , GetDatumsByHashesResponse
-      , DatumFilterGetHashesResponse
       )
   )
 import QueryM.DatumCacheWsp as DcWsp
@@ -301,25 +289,6 @@ cancelFetchBlocksRequest :: QueryM Unit
 cancelFetchBlocksRequest = matchCacheQuery (const CancelFetchBlocksRequest)
   CancelFetchBlocks
   unit
-
-datumFilterAddHashesRequest :: Array DatumHash -> QueryM Unit
-datumFilterAddHashesRequest = matchCacheQuery DatumFilterAddHashesRequest
-  DatumFilterAddHashes
-
-datumFilterRemoveHashesRequest :: Array DatumHash -> QueryM Unit
-datumFilterRemoveHashesRequest = matchCacheQuery DatumFilterRemoveHashesRequest
-  DatumFilterRemoveHashes
-
-datumFilterSetHashesRequest :: Array DatumHash -> QueryM Unit
-datumFilterSetHashesRequest = matchCacheQuery DatumFilterSetHashesRequest
-  DatumFilterSetHashes
-
-datumFilterGetHashesRequest :: QueryM (Array DatumHash)
-datumFilterGetHashesRequest = do
-  queryDatumCache DatumFilterGetHashesRequest >>= case _ of
-    DatumFilterGetHashesResponse hashes -> pure $ hashes
-    _ -> liftEffect $ throw
-      "Request-response type mismatch. Should not have happened"
 
 matchCacheQuery
   :: forall (args :: Type)

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -53,7 +53,7 @@ import Serialization.Address (Slot)
 import Type.Proxy (Proxy(Proxy))
 import Types.ByteArray (byteArrayToHex)
 import Types.Datum (Datum, DatumHash)
-import Types.Transaction (BlockId)
+import Types.Chain (BlockHeaderHash)
 
 newtype WspFault = WspFault Json
 
@@ -167,12 +167,12 @@ getDatumsByHashesCall = mkDatumCacheCallType
   ({ hashes: _ } <<< map (byteArrayToHex <<< unwrap))
 
 startFetchBlocksCall
-  :: JsonWspCall { slot :: Slot, id :: BlockId } StartFetchBlocksR
+  :: JsonWspCall { slot :: Slot, id :: BlockHeaderHash } StartFetchBlocksR
 startFetchBlocksCall = mkDatumCacheCallType
   StartFetchBlocks
   ( \({ slot, id }) ->
       { slot
-      , id: encodeJson (byteArrayToHex $ unwrap id)
+      , id: encodeJson (unwrap id)
       , datumFilter: { "const": true }
       }
   )

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -182,7 +182,8 @@ mkJsonWspRequest req = do
   toArgs = case _ of
     GetDatumByHashRequest dh -> encodeJson { hash: byteArrayToHex $ unwrap dh }
     GetDatumsByHashesRequest dhs -> encodeHashes dhs
-    StartFetchBlocksRequest slotnblock -> encodeJson slotnblock
+    StartFetchBlocksRequest { slot, id } ->
+      encodeJson { slot, id, datumFilter: { "const": true } }
     CancelFetchBlocksRequest -> jsonNull
     DatumFilterAddHashesRequest dhs -> encodeHashes dhs
     DatumFilterRemoveHashesRequest dhs -> encodeHashes dhs

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -1,9 +1,14 @@
 module QueryM.DatumCacheWsp
-  ( DatumCacheMethod(..)
-  , GetDatumByHashR(..)
-  , GetDatumsByHashesR(..)
-  , StartFetchBlocksR(..)
-  , CancelFetchBlocksR(..)
+  ( DatumCacheMethod
+      ( GetDatumByHash
+      , GetDatumsByHashes
+      , StartFetchBlocks
+      , CancelFetchBlocks
+      )
+  , GetDatumByHashR(GetDatumByHashR)
+  , GetDatumsByHashesR(GetDatumsByHashesR)
+  , StartFetchBlocksR(StartFetchBlocksR)
+  , CancelFetchBlocksR(CancelFetchBlocksR)
   , JsonWspRequest
   , JsonWspResponse
   , WspFault(WspFault)
@@ -23,38 +28,32 @@ import Aeson
   , caseAesonObject
   , decodeAeson
   , getNestedAeson
-  , jsonToAeson
-  , toStringifiedNumbersJson
   , (.:)
   )
 import Control.Alt ((<|>))
 import Data.Argonaut
   ( Json
-  , JsonDecodeError(..)
-  , decodeJson
+  , JsonDecodeError
+      ( TypeMismatch
+      )
   , encodeJson
-  , jsonNull
   , stringify
   )
 import Data.Argonaut.Encode (class EncodeJson)
-import Data.Bifunctor (lmap)
-import Data.Either (Either(..), either, note)
+import Data.Either (Either(Left))
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (Maybe(Just, Nothing), maybe)
+import Data.Maybe (Maybe(Nothing, Just))
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Traversable (traverse)
-import Data.TraversableWithIndex (forWithIndex)
 import Data.Tuple.Nested (type (/\), (/\))
-import Effect (Effect)
 import QueryM.JsonWsp (JsonWspCall, mkCallType)
-import QueryM.Ogmios as Ogmios
-import QueryM.UniqueId (ListenerId, uniqueId)
+import QueryM.UniqueId (ListenerId)
 import Serialization.Address (Slot)
-import Type.Proxy (Proxy(..))
-import Types.ByteArray (byteArrayToHex, hexToByteArray)
+import Type.Proxy (Proxy(Proxy))
+import Types.ByteArray (byteArrayToHex)
 import Types.Datum (Datum, DatumHash)
-import Types.Transaction (DataHash(DataHash), BlockId)
+import Types.Transaction (BlockId)
 
 newtype WspFault = WspFault Json
 
@@ -76,7 +75,7 @@ type JsonWspResponse =
   , servicename :: String
   , methodname :: String
   , result :: Maybe Aeson
-  , fault :: Maybe Aeson
+  , fault :: Maybe WspFault
   , reflection :: ListenerId
   }
 

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -21,7 +21,7 @@ import Control.Alt ((<|>))
 import Data.Argonaut (Json, JsonDecodeError(..), decodeJson, encodeJson, jsonNull, stringify)
 import Data.Argonaut.Encode (class EncodeJson)
 import Data.Bifunctor (lmap)
-import Data.Either (Either(Left), note)
+import Data.Either (Either(..), either, note)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), maybe)

--- a/src/QueryM/JsonWsp.js
+++ b/src/QueryM/JsonWsp.js
@@ -1,4 +1,0 @@
-const uniqid = require ("uniqid");
-
-// _uniqueId :: String -> Effect String
-exports._uniqueId = str => () => uniqid(str)

--- a/src/QueryM/JsonWsp.purs
+++ b/src/QueryM/JsonWsp.purs
@@ -15,8 +15,23 @@ module QueryM.JsonWsp
 
 import Prelude
 
-import Aeson (class DecodeAeson, Aeson, caseAesonBigInt, caseAesonObject, caseAesonString, caseAesonUInt, decodeAeson, getField, getFieldOptional)
-import Data.Argonaut (class EncodeJson, Json, JsonDecodeError(TypeMismatch), encodeJson)
+import Aeson
+  ( class DecodeAeson
+  , Aeson
+  , caseAesonBigInt
+  , caseAesonObject
+  , caseAesonString
+  , caseAesonUInt
+  , decodeAeson
+  , getField
+  , getFieldOptional
+  )
+import Data.Argonaut
+  ( class EncodeJson
+  , Json
+  , JsonDecodeError(TypeMismatch)
+  , encodeJson
+  )
 import Data.BigInt as BigInt
 import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe)

--- a/src/QueryM/JsonWsp.purs
+++ b/src/QueryM/JsonWsp.purs
@@ -36,11 +36,9 @@ import Data.Either (Either(Left, Right))
 import Data.UInt as UInt
 import Effect (Effect)
 import Foreign.Object (Object)
+import QueryM.UniqueId (uniqueId)
 import Record as Record
 import Type.Proxy (Proxy)
-
--- creates a unique id prefixed by its argument
-foreign import _uniqueId :: String -> Effect String
 
 -- | Structure of all json wsp websocket requests
 -- described in: https://ogmios.dev/getting-started/basics/
@@ -65,7 +63,7 @@ mkJsonWspRequest
      }
   -> Effect (JsonWspRequest a)
 mkJsonWspRequest service method = do
-  id <- _uniqueId $ method.methodname <> "-"
+  id <- uniqueId $ method.methodname <> "-"
   pure
     $ Record.merge { mirror: { step: "INIT", id } }
     $

--- a/src/QueryM/JsonWsp.purs
+++ b/src/QueryM/JsonWsp.purs
@@ -24,7 +24,6 @@ import Aeson
   , caseAesonUInt
   , decodeAeson
   , getField
-  , getFieldOptional
   )
 import Data.Argonaut
   ( class EncodeJson
@@ -34,8 +33,6 @@ import Data.Argonaut
   )
 import Data.BigInt as BigInt
 import Data.Either (Either(Left, Right))
-import Data.Maybe (Maybe)
-import Data.Traversable (traverse)
 import Data.UInt as UInt
 import Effect (Effect)
 import Foreign.Object (Object)

--- a/src/QueryM/JsonWsp.purs
+++ b/src/QueryM/JsonWsp.purs
@@ -7,6 +7,7 @@ module QueryM.JsonWsp
   , mkCallType
   , buildRequest
   , parseJsonWspResponse
+  , parseJsonWspResponseId
   , parseFieldToString
   , parseFieldToUInt
   , parseFieldToBigInt
@@ -14,10 +15,12 @@ module QueryM.JsonWsp
 
 import Prelude
 
-import Aeson (class DecodeAeson, Aeson, caseAesonBigInt, caseAesonObject, caseAesonString, caseAesonUInt, decodeAeson, getField)
+import Aeson (class DecodeAeson, Aeson, caseAesonBigInt, caseAesonObject, caseAesonString, caseAesonUInt, decodeAeson, getField, getFieldOptional)
 import Data.Argonaut (class EncodeJson, Json, JsonDecodeError(TypeMismatch), encodeJson)
 import Data.BigInt as BigInt
 import Data.Either (Either(Left, Right))
+import Data.Maybe (Maybe)
+import Data.Traversable (traverse)
 import Data.UInt as UInt
 import Effect (Effect)
 import Foreign.Object (Object)
@@ -115,6 +118,13 @@ parseJsonWspResponse = aesonObject $ \o -> do
     , result
     , reflection
     }
+
+-- | Parse just ID from the response
+parseJsonWspResponseId
+  :: Aeson
+  -> Either JsonDecodeError ListenerId
+parseJsonWspResponseId = aesonObject $ \o -> do
+  parseMirror =<< getField o "reflection"
 
 -- | Helper for assuming we get an object
 aesonObject

--- a/src/QueryM/UniqueId.js
+++ b/src/QueryM/UniqueId.js
@@ -1,0 +1,6 @@
+/* global require exports */
+
+const uniqid = require("uniqid");
+
+// _uniqueId :: String -> Effect String
+exports.uniqueId = str => () => uniqid(str);

--- a/src/QueryM/UniqueId.purs
+++ b/src/QueryM/UniqueId.purs
@@ -1,0 +1,9 @@
+module QueryM.UniqueId (ListenerId, uniqueId) where
+
+import Effect (Effect)
+
+-- | Creates a unique id prefixed by its argument
+foreign import uniqueId :: String -> Effect String
+
+-- | A unique request ID used for dispatching
+type ListenerId = String

--- a/src/Types/Transaction.purs
+++ b/src/Types/Transaction.purs
@@ -1,7 +1,6 @@
 module Types.Transaction
   ( AuxiliaryData(..)
   , AuxiliaryDataHash(..)
-  , BlockId(..)
   , BootstrapWitness
   , Certificate(..)
   , CostModel(..)
@@ -875,13 +874,6 @@ instance Show DataHash where
 
 -- To help with people copying & pasting code from Haskell to Purescript
 type DatumHash = DataHash
-
-newtype BlockId = BlockId ByteArray
-
-derive instance Generic BlockId _
-derive instance Newtype BlockId _
-derive newtype instance Eq BlockId
-derive newtype instance Ord BlockId
 
 -- Option<Certificates>,
 -- these are the constructors, but this will generally be an Empty Option in our initial efforts

--- a/src/Types/Transaction.purs
+++ b/src/Types/Transaction.purs
@@ -1,6 +1,7 @@
 module Types.Transaction
   ( AuxiliaryData(..)
   , AuxiliaryDataHash(..)
+  , BlockId(..)
   , BootstrapWitness
   , Certificate(..)
   , CostModel(..)
@@ -874,6 +875,13 @@ instance Show DataHash where
 
 -- To help with people copying & pasting code from Haskell to Purescript
 type DatumHash = DataHash
+
+newtype BlockId = BlockId ByteArray
+
+derive instance Generic BlockId _
+derive instance Newtype BlockId _
+derive newtype instance Eq BlockId
+derive newtype instance Ord BlockId
 
 -- Option<Certificates>,
 -- these are the constructors, but this will generally be an Empty Option in our initial efforts

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -11,7 +11,15 @@ import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Effect.Exception (throw)
 import Mote (group, test)
-import QueryM (cancelFetchBlocks, getChainTip, getDatumByHash, getDatumsByHashes, runQueryM, startFetchBlocks, traceQueryConfig)
+import QueryM
+  ( cancelFetchBlocks
+  , getChainTip
+  , getDatumByHash
+  , getDatumsByHashes
+  , runQueryM
+  , startFetchBlocks
+  , traceQueryConfig
+  )
 import QueryM.Ogmios (OgmiosAddress)
 import QueryM.Utxos (utxosAt)
 import Test.Spec.Assertions (shouldEqual)
@@ -79,7 +87,11 @@ testOgmiosDatumCacheFetcher :: Aff Unit
 testOgmiosDatumCacheFetcher =
   traceQueryConfig >>= flip runQueryM do
     void $ try cancelFetchBlocks -- ignore error if the fetcher was not running
-    startFetchBlocks { slot: Slot (UInt.fromInt 54066900), id: BlockId $ hexToByteArrayUnsafe "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d" }
+    startFetchBlocks
+      { slot: Slot (UInt.fromInt 54066900)
+      , id: BlockId $ hexToByteArrayUnsafe
+          "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d"
+      }
     cancelFetchBlocks
 
 testUtxosAt :: OgmiosAddress -> Aff Unit

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -3,18 +3,21 @@ module Test.AffInterface (suite) where
 import Prelude
 
 import Address (addressToOgmiosAddress, ogmiosAddressToAddress)
+import Contract.Address (Slot(..))
 import Data.Maybe (Maybe(Just, Nothing))
+import Data.UInt as UInt
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
+import Effect.Console (log)
 import Effect.Exception (throw)
 import Mote (group, test)
-import QueryM (getChainTip, runQueryM, traceQueryConfig, getDatumByHash)
-import Types.Transaction (DataHash(..))
+import QueryM (cancelFetchBlocks, getChainTip, getDatumByHash, getDatumsByHashes, runQueryM, startFetchBlocks, traceQueryConfig)
 import QueryM.Ogmios (OgmiosAddress)
 import QueryM.Utxos (utxosAt)
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.ByteArray (hexToByteArrayUnsafe)
+import Types.Transaction (BlockId(..), DataHash(..))
 
 testnet_addr1 :: OgmiosAddress
 testnet_addr1 =
@@ -45,6 +48,10 @@ suite = do
   group "Ogmios datum cache" do
     test "Can process GetDatumByHash" do
       testOgmiosDatumCacheGetDatumByHash
+    test "Can process GetDatumsByHashes" do
+      testOgmiosDatumCacheGetDatumsByHashes
+    test "Fetcher works" do
+      testOgmiosDatumCacheFetcher
 
 testOgmiosDatumCacheGetDatumByHash :: Aff Unit
 testOgmiosDatumCacheGetDatumByHash =
@@ -56,6 +63,23 @@ testOgmiosDatumCacheGetDatumByHash =
     _datum <- getDatumByHash $ DataHash $ hexToByteArrayUnsafe
       "f7c47c65216f7057569111d962a74de807de57e79f7efa86b4e454d42c875e4e"
     pure unit
+
+testOgmiosDatumCacheGetDatumsByHashes :: Aff Unit
+testOgmiosDatumCacheGetDatumsByHashes =
+  traceQueryConfig >>= flip runQueryM do
+    -- Use this to trigger block fetching in order to actually get the datum:
+    -- ```
+    -- curl localhost:9999/control/fetch_blocks -X POST -d '{"slot": 54066900, "id": "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d", "datumFilter": {"address": "addr_xyz"}}' -H 'Content-Type: application/json'
+    -- ```
+    datums <- getDatumsByHashes $ pure $ DataHash $ hexToByteArrayUnsafe
+      "f7c47c65216f7057569111d962a74de807de57e79f7efa86b4e454d42c875e4e"
+    pure unit
+
+testOgmiosDatumCacheFetcher :: Aff Unit
+testOgmiosDatumCacheFetcher =
+  traceQueryConfig >>= flip runQueryM do
+    startFetchBlocks { slot: Slot (UInt.fromInt 54066900), id: BlockId $ hexToByteArrayUnsafe "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d" }
+    cancelFetchBlocks
 
 testUtxosAt :: OgmiosAddress -> Aff Unit
 testUtxosAt testAddr = case ogmiosAddressToAddress testAddr of

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -24,7 +24,8 @@ import QueryM.Utxos (utxosAt)
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.ByteArray (hexToByteArrayUnsafe)
-import Types.Transaction (BlockId(BlockId), DataHash(DataHash))
+import Types.Chain (BlockHeaderHash(BlockHeaderHash))
+import Types.Transaction (DataHash(DataHash))
 
 testnet_addr1 :: OgmiosAddress
 testnet_addr1 =
@@ -88,7 +89,7 @@ testOgmiosDatumCacheFetcher =
     void $ try cancelFetchBlocks -- ignore error if the fetcher was not running
     startFetchBlocks
       { slot: Slot (UInt.fromInt 54066900)
-      , id: BlockId $ hexToByteArrayUnsafe
+      , id: BlockHeaderHash
           "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d"
       }
     cancelFetchBlocks

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -6,7 +6,7 @@ import Address (addressToOgmiosAddress, ogmiosAddressToAddress)
 import Contract.Address (Slot(..))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.UInt as UInt
-import Effect.Aff (Aff)
+import Effect.Aff (Aff, try)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Effect.Exception (throw)
@@ -78,6 +78,7 @@ testOgmiosDatumCacheGetDatumsByHashes =
 testOgmiosDatumCacheFetcher :: Aff Unit
 testOgmiosDatumCacheFetcher =
   traceQueryConfig >>= flip runQueryM do
+    void $ try cancelFetchBlocks -- ignore error if the fetcher was not running
     startFetchBlocks { slot: Slot (UInt.fromInt 54066900), id: BlockId $ hexToByteArrayUnsafe "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d" }
     cancelFetchBlocks
 

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -3,12 +3,11 @@ module Test.AffInterface (suite) where
 import Prelude
 
 import Address (addressToOgmiosAddress, ogmiosAddressToAddress)
-import Contract.Address (Slot(..))
+import Contract.Address (Slot(Slot))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.UInt as UInt
 import Effect.Aff (Aff, try)
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import Effect.Exception (throw)
 import Mote (group, test)
 import QueryM
@@ -25,7 +24,7 @@ import QueryM.Utxos (utxosAt)
 import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.ByteArray (hexToByteArrayUnsafe)
-import Types.Transaction (BlockId(..), DataHash(..))
+import Types.Transaction (BlockId(BlockId), DataHash(DataHash))
 
 testnet_addr1 :: OgmiosAddress
 testnet_addr1 =
@@ -79,7 +78,7 @@ testOgmiosDatumCacheGetDatumsByHashes =
     -- ```
     -- curl localhost:9999/control/fetch_blocks -X POST -d '{"slot": 54066900, "id": "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d", "datumFilter": {"address": "addr_xyz"}}' -H 'Content-Type: application/json'
     -- ```
-    datums <- getDatumsByHashes $ pure $ DataHash $ hexToByteArrayUnsafe
+    _datums <- getDatumsByHashes $ pure $ DataHash $ hexToByteArrayUnsafe
       "f7c47c65216f7057569111d962a74de807de57e79f7efa86b4e454d42c875e4e"
     pure unit
 


### PR DESCRIPTION
Closes #363 

- Update Ogmios to the recent revision
- Fix incorrect handling of Json parse errors for ODC (cancel Aff instead of letting it freeze).
- Remove deleted endpoints (`datumFilter*`)
- (Partially) unify ODC and Ogmios WS code
- Do not rely on response type to match responses with requests for ODC, use reflection instead