### PR TITLE
fix `Rational` exports

### DIFF
--- a/src/Contract/Numeric/Rational.purs
+++ b/src/Contract/Numeric/Rational.purs
@@ -1,8 +1,15 @@
 -- | Arbitrary precision rational numbers (backed by `BigInt`).
 module Contract.Numeric.Rational
   ( module Rational
-  , module Ratio
   ) where
 
-import Data.Ratio ((%), denominator, numerator, reduce) as Ratio
-import Types.Rational (Rational) as Rational
+import Types.Rational
+  ( Rational
+  , class RationalComponent
+  , reduce
+  , (%)
+  , recip
+  , numerator
+  , denominator
+  , denominatorAsNat
+  ) as Rational


### PR DESCRIPTION
`Contract.Numeric.Rational` was re-exporting from `Data.Ratio` instead of our own `Rational` type. This fixes that.