### PR TITLE
Use `--entry` with bundle derivation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -226,7 +226,7 @@ let
           cp $src/${htmlTemplate} .
           cp $src/${webpackConfig} .
           mkdir ./dist
-          webpack --mode=production -c ${webpackConfig} -o ./dist
+          webpack --mode=production -c ${webpackConfig} -o ./dist --entry ${entrypoint}
         '';
         installPhase = ''
           mkdir $out

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -226,7 +226,7 @@ let
           cp $src/${htmlTemplate} .
           cp $src/${webpackConfig} .
           mkdir ./dist
-          webpack --mode=production -c ${webpackConfig} -o ./dist --entry ${entrypoint}
+          webpack --mode=production -c ${webpackConfig} -o ./dist --entry ./${entrypoint}
         '';
         installPhase = ''
           mkdir $out


### PR DESCRIPTION
We currently allow users to override the default entrypoint using `bundlePursProject`, but if users want to use multiple entrypoints with the same config we need to use the correct flag with webpack