### PR TITLE
Fix inaccuracies in fee calculation

### DIFF
--- a/server/ctl-server.cabal
+++ b/server/ctl-server.cabal
@@ -60,6 +60,7 @@ library
     , containers
     , exceptions
     , extra
+    , integer-logarithms
     , lens
     , mtl
     , plutus-ledger-api
@@ -69,6 +70,7 @@ library
     , servant-client
     , servant-docs
     , servant-server
+    , strict-containers
     , text
     , wai-cors
     , warp

--- a/server/src/Api/Handlers.hs
+++ b/server/src/Api/Handlers.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Alonzo.Data qualified as Data
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
 import Cardano.Ledger.Alonzo.Tx qualified as Tx
 import Cardano.Ledger.Alonzo.TxWitness qualified as TxWitness
+import Cardano.Ledger.Core qualified as Ledger (TxBody)
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Mary.Value qualified as Value
 import Cardano.Ledger.SafeHash qualified as SafeHash
@@ -32,11 +33,15 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as BL
 import Data.Kind (Type)
+import Data.List qualified as List (find)
 import Data.Map qualified as Map
+import Data.Maybe (fromJust)
+import Data.Maybe.Strict (StrictMaybe)
 import Data.Proxy (Proxy (Proxy))
 import Data.Set qualified as Set
 import Data.Text.Encoding qualified as Text.Encoding
 import Data.Traversable (for)
+import Math.NumberTheory.Logarithms qualified as Math (integerLog2)
 import Plutus.V1.Ledger.Scripts qualified as Ledger.Scripts
 import PlutusTx.Builtins qualified as PlutusTx
 import Types (
@@ -75,13 +80,59 @@ import Types (
   hashLedgerScript,
  )
 
+--------------------------------------------------------------------------------
+-- Handlers
+--------------------------------------------------------------------------------
+
 estimateTxFees :: WitnessCount -> Cbor -> AppM Fee
 estimateTxFees (WitnessCount numWits) cbor = do
-  decoded <-
-    either (throwM . CborDecode) pure $
-      decodeCborTx cbor
-  pparams <- asks protocolParams
-  pure . Fee $ estimateFee pparams numWits decoded
+  tx <- decodeCborTx cbor & either (throwM . CborDecode) pure
+  case tx of
+    C.Tx txBody' keyWits -> do
+      pparams <- asks protocolParams
+      -- calculate and set script integrity hash before estimating fees
+      let txBody = setScriptIntegrityHash pparams txBody'
+          fee = estimateFee pparams numWits (C.Tx txBody keyWits)
+      Fee <$> finalizeTxFee fee
+  where
+    -- `txfee` value must also be taken into account when calculating fees,
+    -- since it affects the final transaction size.
+    finalizeTxFee :: Integer -> AppM Integer
+    finalizeTxFee fee
+      -- `integerLog2` would fail on zero,
+      -- since logarithm of zero is mathematically undefined
+      | fee == 0 = pure 0
+      | otherwise =
+        asks protocolParams <&> \pparams ->
+          let feePerByte =
+                fromIntegral (Shelley.protocolParamTxFeePerByte pparams)
+              -- the required number of bytes is calculated twice to
+              -- be able to handle a possible integer overflow
+              feeBytes =
+                bytesNeeded (fee + bytesNeeded fee * feePerByte)
+           in fee + feeBytes * feePerByte
+      where
+        -- Calculates the number of bytes that a given integer will take
+        -- when CBOR encoded.
+        bytesNeeded :: Integer -> Integer
+        bytesNeeded n =
+          let predicate = (>= (succ $ Math.integerLog2 n `div` 8))
+           in fromIntegral . fromJust $ -- using `fromJust` here is safe
+                List.find predicate [2 ^ x | x <- [(0 :: Int) ..]]
+
+applyArgs :: ApplyArgsRequest -> AppM AppliedScript
+applyArgs ApplyArgsRequest {script, args} =
+  pure . AppliedScript $
+    Ledger.Scripts.applyArguments script args
+
+hashScript :: HashScriptRequest -> AppM HashedScript
+hashScript (HashScriptRequest script) =
+  pure . HashedScript $ hashLedgerScript script
+
+blake2bHash :: BytesToHash -> AppM Blake2bHash
+blake2bHash (BytesToHash hs) =
+  pure . Blake2bHash . PlutusTx.fromBuiltin . PlutusTx.blake2b_256 $
+    PlutusTx.toBuiltin hs
 
 {- | Computes the execution units needed for each script in the transaction.
  https://input-output-hk.github.io/cardano-node/cardano-api/src/Cardano.Api.Fees.html#evaluateTransactionExecutionUnits
@@ -128,32 +179,6 @@ evalTxExecutionUnits cbor =
               , exUnitsSteps = C.executionSteps exUnits
               }
 
-applyArgs :: ApplyArgsRequest -> AppM AppliedScript
-applyArgs ApplyArgsRequest {script, args} =
-  pure . AppliedScript $
-    Ledger.Scripts.applyArguments script args
-
-hashScript :: HashScriptRequest -> AppM HashedScript
-hashScript (HashScriptRequest script) =
-  pure . HashedScript $ hashLedgerScript script
-
-hashData :: HashDataRequest -> AppM HashedData
-hashData (HashDataRequest datum) = do
-  decodedDatum <-
-    throwDecodeErrorWithMessage "Failed to decode Datum" $
-      decodeCborDatum datum
-  pure . HashedData . SafeHash.originalBytes $
-    Data.hashData decodedDatum
-
-throwDecodeErrorWithMessage :: forall (a :: Type). String -> Maybe a -> AppM a
-throwDecodeErrorWithMessage msg =
-  maybe (throwM . CborDecode $ OtherDecodeError msg) pure
-
-blake2bHash :: BytesToHash -> AppM Blake2bHash
-blake2bHash (BytesToHash hs) =
-  pure . Blake2bHash . PlutusTx.fromBuiltin . PlutusTx.blake2b_256 $
-    PlutusTx.toBuiltin hs
-
 finalizeTx :: FinalizeRequest -> AppM FinalizedTransaction
 finalizeTx FinalizeRequest {tx, datums, redeemers} = do
   pparams <- asks protocolParams
@@ -167,20 +192,13 @@ finalizeTx FinalizeRequest {tx, datums, redeemers} = do
     throwDecodeErrorWithMessage "Failed to decode datums" $
       traverse decodeCborDatum datums
   let scripts = Tx.txscripts' $ Tx.wits decodedTx
-      Value.Value ada assets = Tx.mint $ Tx.body decodedTx
-      languages
-        | Map.null scripts && Map.null assets && ada == 0 = mempty
-        | TxWitness.nullRedeemers decodedRedeemers = mempty
-        | otherwise = Set.fromList [PlutusV1]
       txDatums =
         TxWitness.TxDats . Map.fromList $
           decodedDatums <&> \datum -> (Data.hashData datum, datum)
+      txBody = Tx.body decodedTx
+      noScripts = Map.null scripts
       mbIntegrityHash =
-        Tx.hashScriptIntegrity
-          (C.toLedgerPParams C.ShelleyBasedEraAlonzo pparams)
-          languages
-          decodedRedeemers
-          txDatums
+        hashScriptIntegrity pparams txBody decodedRedeemers txDatums noScripts
   let addIntegrityHash t =
         t
           { Tx.body =
@@ -203,7 +221,17 @@ finalizeTx FinalizeRequest {tx, datums, redeemers} = do
           Tx.toCBORForMempoolSubmission finalizedTx
   pure response
 
--- Helpers
+hashData :: HashDataRequest -> AppM HashedData
+hashData (HashDataRequest datum) = do
+  decodedDatum <-
+    throwDecodeErrorWithMessage "Failed to decode Datum" $
+      decodeCborDatum datum
+  pure . HashedData . SafeHash.originalBytes $
+    Data.hashData decodedDatum
+
+--------------------------------------------------------------------------------
+-- Estimate fee
+--------------------------------------------------------------------------------
 
 {- | Calculates the transaction fee for the proposed Alonzo era transaction,
  including the script fees.
@@ -223,6 +251,10 @@ estimateFee pparams numWits (C.Tx txBody _) =
           0
    in estimate
 
+--------------------------------------------------------------------------------
+-- Query node
+--------------------------------------------------------------------------------
+
 queryNode :: forall (r :: Type). C.QueryInMode C.CardanoMode r -> AppM r
 queryNode query = do
   nodeConnectInfo <- getNodeConnectInfo
@@ -239,13 +271,60 @@ queryUtxos txInputs =
             $ C.QueryUTxO (C.QueryUTxOByTxIn txInputs)
         )
 
+--------------------------------------------------------------------------------
+-- Set script integrity hash
+--------------------------------------------------------------------------------
+
+setScriptIntegrityHash ::
+  Shelley.ProtocolParameters ->
+  Shelley.TxBody C.AlonzoEra ->
+  Shelley.TxBody C.AlonzoEra
+setScriptIntegrityHash pparams txBodyAlonzo =
+  case txBodyAlonzo of
+    Shelley.ShelleyTxBody _e txBody scripts scriptData _a _v ->
+      case scriptData of
+        Shelley.TxBodyScriptData _ datums redeemers ->
+          let noScripts = null scripts
+              mbIntegrityHash =
+                hashScriptIntegrity pparams txBody redeemers datums noScripts
+              newTxBody =
+                txBody {Tx.scriptIntegrityHash = mbIntegrityHash}
+           in Shelley.ShelleyTxBody _e newTxBody scripts scriptData _a _v
+        _ -> txBodyAlonzo
+
+hashScriptIntegrity ::
+  Shelley.ProtocolParameters ->
+  Ledger.TxBody (Alonzo.AlonzoEra StandardCrypto) ->
+  TxWitness.Redeemers (Alonzo.AlonzoEra StandardCrypto) ->
+  TxWitness.TxDats (Alonzo.AlonzoEra StandardCrypto) ->
+  Bool ->
+  StrictMaybe (Tx.ScriptIntegrityHash StandardCrypto)
+hashScriptIntegrity pparams' txBody redeemers datums noScripts =
+  let pparams =
+        C.toLedgerPParams C.ShelleyBasedEraAlonzo pparams'
+      Value.Value ada assets =
+        Tx.mint txBody
+      languages
+        | noScripts && Map.null assets && ada == 0 = mempty
+        | TxWitness.nullRedeemers redeemers = mempty
+        | otherwise = Set.fromList [PlutusV1]
+   in Tx.hashScriptIntegrity pparams languages redeemers datums
+
+--------------------------------------------------------------------------------
+-- Encoding / Decoding
+--------------------------------------------------------------------------------
+
+throwDecodeErrorWithMessage :: forall (a :: Type). String -> Maybe a -> AppM a
+throwDecodeErrorWithMessage msg =
+  maybe (throwM . CborDecode $ OtherDecodeError msg) pure
+
+encodeCborText :: BL.ByteString -> Cbor
+encodeCborText = Cbor . Text.Encoding.decodeUtf8 . Base16.encode . BL.toStrict
+
 decodeCborText :: Cbor -> Either CborDecodeError ByteString
 decodeCborText (Cbor cborText) =
   first InvalidHex . Base16.decode $
     Text.Encoding.encodeUtf8 cborText
-
-encodeCborText :: BL.ByteString -> Cbor
-encodeCborText = Cbor . Text.Encoding.decodeUtf8 . Base16.encode . BL.toStrict
 
 decodeCborTx :: Cbor -> Either CborDecodeError (C.Tx C.AlonzoEra)
 decodeCborTx cbor =

--- a/server/test/Main.hs
+++ b/server/test/Main.hs
@@ -94,9 +94,7 @@ feeEstimateSpec = around withTestApp $ do
       result <-
         runClientM' (clientEnv port) $
           estimateTxFees (WitnessCount 1) cborTxFixture
-      -- This is probably incorrect. See:
-      -- https://github.com/Plutonomicon/cardano-transaction-lib/issues/123
-      result `shouldBe` Right (Fee 168449)
+      result `shouldBe` Right (Fee 168625)
 
     it "catches invalid hex strings" $ \port -> do
       result <-

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -399,18 +399,11 @@ calculateMinFee tx@(Transaction { body: Transaction.TxBody body }) = do
   liftAff (Affjax.get Affjax.ResponseFormat.json url)
     <#> either
       (Left <<< ClientHttpError)
-      ( bimap ClientDecodeJsonError coinFromEstimate
+      ( bimap ClientDecodeJsonError (wrap <<< unwrap :: FeeEstimate -> Coin)
           <<< Json.decodeJson
           <<< _.body
       )
   where
-  -- FIXME
-  -- Add some "padding" to the fees so the transaction will submit
-  -- The server is calculating fees that are too low
-  -- See https://github.com/Plutonomicon/cardano-transaction-lib/issues/123
-  coinFromEstimate :: FeeEstimate -> Coin
-  coinFromEstimate = Coin <<< ((+) (BigInt.fromInt 10000)) <<< unwrap
-
   -- Fee estimation occurs before balancing the transaction, so we need to know
   -- the expected number of witnesses to use the cardano-api fee estimation
   -- functions

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -58,7 +58,7 @@ import Aeson as Aeson
 import Affjax as Affjax
 import Affjax.RequestBody as Affjax.RequestBody
 import Affjax.ResponseFormat as Affjax.ResponseFormat
-import Cardano.Types.Value (Coin(Coin))
+import Cardano.Types.Value (Coin)
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Logger.Trans (LoggerT, runLoggerT)
 import Control.Monad.Reader.Trans (ReaderT, runReaderT, withReaderT, ask, asks)


### PR DESCRIPTION
Context: https://github.com/Plutonomicon/cardano-transaction-lib/issues/123

The solution was to take into account both script integrity hash and the fee value when estimating fees. 
Now all examples are successfully submitted with accurate fees.