### PR TITLE
Viet/aeson for posix time range construction

### DIFF
--- a/src/Helpers.purs
+++ b/src/Helpers.purs
@@ -18,6 +18,7 @@ module Helpers
   , logString
   , logWithLevel
   , maybeArrayMerge
+  , mkErrorRecord
   , notImplemented
   , uIntToBigInt
   ) where
@@ -194,3 +195,15 @@ logString cfgLevel level message = do
   timestamp <- now
   logWithLevel cfgLevel $ { timestamp, message, level, tags: Map.empty }
 
+-- | Used for `EncodeAeson` for datatype errors
+mkErrorRecord
+  :: forall (a :: Type)
+   . String -- Error type
+  -> String -- Error
+  -> a
+  -> { "errorType" :: String
+     , "error" :: String
+     , "args" :: a
+     }
+mkErrorRecord errorType error a =
+  { "errorType": errorType, "error": error, "args": a }

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -47,6 +47,7 @@ import Aeson
   , caseAesonArray
   , caseAesonObject
   , decodeAeson
+  , encodeAeson'
   , getField
   , getFieldOptional
   , isNull
@@ -199,6 +200,7 @@ newtype SystemStart = SystemStart String
 derive instance Generic SystemStart _
 derive instance Newtype SystemStart _
 derive newtype instance DecodeAeson SystemStart
+derive newtype instance EncodeAeson SystemStart
 derive newtype instance Eq SystemStart
 
 instance Show SystemStart where
@@ -210,6 +212,7 @@ newtype CurrentEpoch = CurrentEpoch BigInt
 derive instance Generic CurrentEpoch _
 derive instance Newtype CurrentEpoch _
 derive newtype instance DecodeAeson CurrentEpoch
+derive newtype instance EncodeAeson CurrentEpoch
 derive newtype instance Eq CurrentEpoch
 derive newtype instance Ord CurrentEpoch
 
@@ -222,6 +225,7 @@ newtype EraSummaries = EraSummaries (Array EraSummary)
 
 derive instance Generic EraSummaries _
 derive instance Newtype EraSummaries _
+derive newtype instance EncodeAeson EraSummaries
 
 instance Show EraSummaries where
   show = genericShow
@@ -261,6 +265,17 @@ instance DecodeAeson EraSummary where
     parameters <- getField o "parameters"
     pure $ wrap { start, end, parameters }
 
+instance EncodeAeson EraSummary where
+  encodeAeson' (EraSummary { start, end, parameters }) = do
+    s <- encodeAeson' start
+    e <- encodeAeson' end
+    p <- encodeAeson' parameters
+    encodeAeson'
+      { "start": s
+      , "end": e
+      , "parameters": p
+      }
+
 newtype EraSummaryTime = EraSummaryTime
   { time :: RelativeTime -- 0-18446744073709552000, The time is relative to the
   -- start time of the network.
@@ -283,6 +298,17 @@ instance DecodeAeson EraSummaryTime where
     epoch <- getField o "epoch"
     pure $ wrap { time, slot, epoch }
 
+instance EncodeAeson EraSummaryTime where
+  encodeAeson' (EraSummaryTime { time, slot, epoch }) = do
+    t <- encodeAeson' time
+    s <- encodeAeson' slot
+    e <- encodeAeson' epoch
+    encodeAeson'
+      { "time": t
+      , "slot": s
+      , "epoch": e
+      }
+
 -- | A time in seconds relative to another one (typically, system start or era
 -- | start). [ 0 .. 18446744073709552000 ]
 newtype RelativeTime = RelativeTime BigInt
@@ -292,6 +318,7 @@ derive instance Newtype RelativeTime _
 derive newtype instance Eq RelativeTime
 derive newtype instance Ord RelativeTime
 derive newtype instance DecodeAeson RelativeTime
+derive newtype instance EncodeAeson RelativeTime
 
 instance Show RelativeTime where
   show = genericShow
@@ -304,6 +331,7 @@ derive instance Newtype AbsSlot _
 derive newtype instance Eq AbsSlot
 derive newtype instance Ord AbsSlot
 derive newtype instance DecodeAeson AbsSlot
+derive newtype instance EncodeAeson AbsSlot
 
 instance Show AbsSlot where
   show = genericShow
@@ -317,6 +345,7 @@ derive instance Newtype Epoch _
 derive newtype instance Eq Epoch
 derive newtype instance Ord Epoch
 derive newtype instance DecodeAeson Epoch
+derive newtype instance EncodeAeson Epoch
 
 instance Show Epoch where
   show = genericShow
@@ -343,12 +372,24 @@ instance DecodeAeson EraSummaryParameters where
     safeZone <- getField o "safeZone"
     pure $ wrap { epochLength, slotLength, safeZone }
 
+instance EncodeAeson EraSummaryParameters where
+  encodeAeson' (EraSummaryParameters { epochLength, slotLength, safeZone }) = do
+    el <- encodeAeson' epochLength
+    sl <- encodeAeson' slotLength
+    sz <- encodeAeson' safeZone
+    encodeAeson'
+      { "epochLength": el
+      , "slotLength": sl
+      , "safeZone": sz
+      }
+
 -- | An epoch number or length. [ 0 .. 18446744073709552000 ]
 newtype EpochLength = EpochLength BigInt
 
 derive instance Generic EpochLength _
 derive instance Newtype EpochLength _
 derive newtype instance DecodeAeson EpochLength
+derive newtype instance EncodeAeson EpochLength
 
 instance Show EpochLength where
   show = genericShow
@@ -359,6 +400,7 @@ newtype SlotLength = SlotLength BigInt
 derive instance Generic SlotLength _
 derive instance Newtype SlotLength _
 derive newtype instance DecodeAeson SlotLength
+derive newtype instance EncodeAeson SlotLength
 
 instance Show SlotLength where
   show = genericShow
@@ -371,6 +413,7 @@ newtype SafeZone = SafeZone BigInt
 derive instance Generic SafeZone _
 derive instance Newtype SafeZone _
 derive newtype instance DecodeAeson SafeZone
+derive newtype instance EncodeAeson SafeZone
 
 instance Show SafeZone where
   show = genericShow

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -227,6 +227,7 @@ newtype EraSummaries = EraSummaries (Array EraSummary)
 
 derive instance Generic EraSummaries _
 derive instance Newtype EraSummaries _
+derive newtype instance Eq EraSummaries
 derive newtype instance EncodeAeson EraSummaries
 
 instance Show EraSummaries where
@@ -251,6 +252,7 @@ newtype EraSummary = EraSummary
 
 derive instance Generic EraSummary _
 derive instance Newtype EraSummary _
+derive newtype instance Eq EraSummary
 
 instance Show EraSummary where
   show = genericShow
@@ -286,6 +288,7 @@ newtype EraSummaryTime = EraSummaryTime
 
 derive instance Generic EraSummaryTime _
 derive instance Newtype EraSummaryTime _
+derive newtype instance Eq EraSummaryTime
 
 instance Show EraSummaryTime where
   show = genericShow
@@ -357,6 +360,7 @@ newtype EraSummaryParameters = EraSummaryParameters
 
 derive instance Generic EraSummaryParameters _
 derive instance Newtype EraSummaryParameters _
+derive newtype instance Eq EraSummaryParameters
 
 instance Show EraSummaryParameters where
   show = genericShow
@@ -381,6 +385,7 @@ newtype EpochLength = EpochLength BigInt
 
 derive instance Generic EpochLength _
 derive instance Newtype EpochLength _
+derive newtype instance Eq EpochLength
 derive newtype instance DecodeAeson EpochLength
 derive newtype instance EncodeAeson EpochLength
 
@@ -392,6 +397,7 @@ newtype SlotLength = SlotLength BigInt
 
 derive instance Generic SlotLength _
 derive instance Newtype SlotLength _
+derive newtype instance Eq SlotLength
 derive newtype instance DecodeAeson SlotLength
 derive newtype instance EncodeAeson SlotLength
 
@@ -405,6 +411,7 @@ newtype SafeZone = SafeZone BigInt
 
 derive instance Generic SafeZone _
 derive instance Newtype SafeZone _
+derive newtype instance Eq SafeZone
 derive newtype instance DecodeAeson SafeZone
 derive newtype instance EncodeAeson SafeZone
 

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -25,6 +25,8 @@ module QueryM.Ogmios
   , TxHash
   , UtxoQR(..)
   , UtxoQueryResult(..)
+  , aesonArray
+  , aesonObject
   , evaluateTxCall
   , queryChainTipCall
   , queryCurrentEpochCall
@@ -266,14 +268,11 @@ instance DecodeAeson EraSummary where
     pure $ wrap { start, end, parameters }
 
 instance EncodeAeson EraSummary where
-  encodeAeson' (EraSummary { start, end, parameters }) = do
-    s <- encodeAeson' start
-    e <- encodeAeson' end
-    p <- encodeAeson' parameters
+  encodeAeson' (EraSummary { start, end, parameters }) =
     encodeAeson'
-      { "start": s
-      , "end": e
-      , "parameters": p
+      { "start": start
+      , "end": end
+      , "parameters": parameters
       }
 
 newtype EraSummaryTime = EraSummaryTime
@@ -299,14 +298,11 @@ instance DecodeAeson EraSummaryTime where
     pure $ wrap { time, slot, epoch }
 
 instance EncodeAeson EraSummaryTime where
-  encodeAeson' (EraSummaryTime { time, slot, epoch }) = do
-    t <- encodeAeson' time
-    s <- encodeAeson' slot
-    e <- encodeAeson' epoch
+  encodeAeson' (EraSummaryTime { time, slot, epoch }) =
     encodeAeson'
-      { "time": t
-      , "slot": s
-      , "epoch": e
+      { "time": time
+      , "slot": slot
+      , "epoch": epoch
       }
 
 -- | A time in seconds relative to another one (typically, system start or era
@@ -373,14 +369,11 @@ instance DecodeAeson EraSummaryParameters where
     pure $ wrap { epochLength, slotLength, safeZone }
 
 instance EncodeAeson EraSummaryParameters where
-  encodeAeson' (EraSummaryParameters { epochLength, slotLength, safeZone }) = do
-    el <- encodeAeson' epochLength
-    sl <- encodeAeson' slotLength
-    sz <- encodeAeson' safeZone
+  encodeAeson' (EraSummaryParameters { epochLength, slotLength, safeZone }) =
     encodeAeson'
-      { "epochLength": el
-      , "slotLength": sl
-      , "safeZone": sz
+      { "epochLength": epochLength
+      , "slotLength": slotLength
+      , "safeZone": safeZone
       }
 
 -- | An epoch number or length. [ 0 .. 18446744073709552000 ]

--- a/src/Types/Interval.purs
+++ b/src/Types/Interval.purs
@@ -51,6 +51,21 @@ module Types.Interval
 
 import Prelude
 
+import Aeson
+  ( class DecodeAeson
+  , class EncodeAeson
+  , Aeson
+  , JsonDecodeError
+      ( TypeMismatch
+      )
+  , caseAesonArray
+  , caseAesonObject
+  , decodeAeson
+  , encodeAeson'
+  , getField
+  , getFieldOptional
+  , isNull
+  )
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except.Trans (ExceptT(ExceptT), runExceptT)
 import Data.Array (find)
@@ -391,6 +406,8 @@ derive newtype instance Ord POSIXTime
 derive newtype instance Semiring POSIXTime
 derive newtype instance FromData POSIXTime
 derive newtype instance ToData POSIXTime
+derive newtype instance DecodeAeson POSIXTime
+derive newtype instance EncodeAeson POSIXTime
 
 instance Show POSIXTime where
   show = genericShow
@@ -459,6 +476,9 @@ derive instance Eq SlotToPosixTimeError
 
 instance Show SlotToPosixTimeError where
   show = genericShow
+
+instance EncodeAeson SlotToPosixTimeError where
+  encodeAeson' (ParseToDataTime sysStart) = "Parse to Data" 
 
 -- Based on:
 -- https://github.com/input-output-hk/cardano-ledger/blob/2acff66e84d63a81de904e1c0de70208ff1819ea/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L186

--- a/src/Types/Interval.purs
+++ b/src/Types/Interval.purs
@@ -58,17 +58,16 @@ import Aeson
   , JsonDecodeError
       ( TypeMismatch
       )
-  , caseAesonArray
-  , caseAesonObject
+  , aesonNull
   , decodeAeson
+  , encodeAeson
   , encodeAeson'
   , getField
-  , getFieldOptional
   , isNull
   )
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except.Trans (ExceptT(ExceptT), runExceptT)
-import Data.Array (find)
+import Data.Array (find, head, index, length)
 import Data.Bifunctor (bimap, lmap)
 import Data.BigInt (BigInt)
 import Data.BigInt (fromInt, fromNumber, fromString) as BigInt
@@ -89,7 +88,8 @@ import Data.Tuple.Nested (type (/\), (/\))
 import Data.UInt as UInt
 import Effect (Effect)
 import Effect.Class (liftEffect)
-import Helpers (bigIntToUInt, liftEither, liftM, uIntToBigInt)
+import Foreign.Object (Object)
+import Helpers (bigIntToUInt, mkErrorRecord, liftEither, liftM, uIntToBigInt)
 import Plutus.Types.DataSchema
   ( class HasPlutusSchema
   , type (:+)
@@ -103,6 +103,7 @@ import QueryM.Ogmios
   , EraSummaries(EraSummaries)
   , EraSummary(EraSummary)
   , SystemStart
+  , aesonObject
   )
 import TypeLevel.Nat (S, Z)
 import ToData (class ToData, genericToData)
@@ -476,8 +477,63 @@ derive instance Eq SlotToPosixTimeError
 instance Show SlotToPosixTimeError where
   show = genericShow
 
+slotToPosixTimeErrorStr :: String
+slotToPosixTimeErrorStr = "slotToPosixTimeError"
+
 instance EncodeAeson SlotToPosixTimeError where
-  encodeAeson' (ParseToDataTime sysStart) = "Parse to Data" 
+  encodeAeson' (CannotFindSlotInEraSummaries absSlot) =
+    encodeAeson' $ mkErrorRecord
+      slotToPosixTimeErrorStr
+      "cannotFindSlotInEraSummaries"
+      [ absSlot ]
+  encodeAeson' (StartingSlotGreaterThanSlot absSlot) = do
+    encodeAeson' $ mkErrorRecord
+      slotToPosixTimeErrorStr
+      "startingSlotGreaterThanSlot"
+      [ absSlot ]
+  encodeAeson' (EndTimeLessThanTime absTime) = do
+    encodeAeson' $ mkErrorRecord
+      slotToPosixTimeErrorStr
+      "endTimeLessThanTime"
+      [ absTime ]
+  encodeAeson' CannotGetBigIntFromNumber = do
+    encodeAeson' $ mkErrorRecord
+      slotToPosixTimeErrorStr
+      "cannotGetBigIntFromNumber"
+      aesonNull
+
+instance DecodeAeson SlotToPosixTimeError where
+  decodeAeson = aesonObject $ \o -> do
+    errorType <- getField o "errorType"
+    unless (errorType == slotToPosixTimeErrorStr)
+      $ throwError
+      $ TypeMismatch "Expected SlotToPosixTimeError"
+    getField o "error" >>= case _ of
+      "cannotFindSlotInEraSummaries" -> do
+        arg <- extractArg o
+        pure $ CannotFindSlotInEraSummaries arg
+      "startingSlotGreaterThanSlot" -> do
+        arg <- extractArg o
+        pure $ StartingSlotGreaterThanSlot arg
+      "endTimeLessThanTime" -> do
+        arg <- extractArg o
+        pure $ EndTimeLessThanTime arg
+      "cannotGetBigIntFromNumber" -> do
+        args <- getField o "args"
+        unless (isNull args) (throwError $ TypeMismatch "Non-empty args")
+        pure CannotGetBigIntFromNumber
+      _ -> throwError $ TypeMismatch "Unknown error message"
+
+-- Extracts a singleton array from an object for "args"
+extractArg
+  :: forall (a :: Type)
+   . DecodeAeson a
+  => Object Aeson
+  -> Either JsonDecodeError a
+extractArg o = do
+  args <- getField o "args"
+  when (length args /= one) (throwError $ TypeMismatch "Incorrect args")
+  note (TypeMismatch "Could not extract head") (head args)
 
 -- Based on:
 -- https://github.com/input-output-hk/cardano-ledger/blob/2acff66e84d63a81de904e1c0de70208ff1819ea/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L186
@@ -552,6 +608,8 @@ derive instance Generic RelSlot _
 derive instance Newtype RelSlot _
 derive newtype instance Eq RelSlot
 derive newtype instance Ord RelSlot
+derive newtype instance DecodeAeson RelSlot
+derive newtype instance EncodeAeson RelSlot
 
 instance Show RelSlot where
   show = genericShow
@@ -565,6 +623,8 @@ derive instance Generic RelTime _
 derive instance Newtype RelTime _
 derive newtype instance Eq RelTime
 derive newtype instance Ord RelTime
+derive newtype instance DecodeAeson RelTime
+derive newtype instance EncodeAeson RelTime
 
 instance Show RelTime where
   show = genericShow
@@ -577,6 +637,8 @@ derive instance Generic ModTime _
 derive instance Newtype ModTime _
 derive newtype instance Eq ModTime
 derive newtype instance Ord ModTime
+derive newtype instance DecodeAeson ModTime
+derive newtype instance EncodeAeson ModTime
 
 instance Show ModTime where
   show = genericShow
@@ -589,6 +651,8 @@ derive instance Generic AbsTime _
 derive instance Newtype AbsTime _
 derive newtype instance Eq AbsTime
 derive newtype instance Ord AbsTime
+derive newtype instance DecodeAeson AbsTime
+derive newtype instance EncodeAeson AbsTime
 
 instance Show AbsTime where
   show = genericShow
@@ -648,6 +712,77 @@ derive instance Eq PosixTimeToSlotError
 
 instance Show PosixTimeToSlotError where
   show = genericShow
+
+posixTimeToSlotErrorStr :: String
+posixTimeToSlotErrorStr = "posixTimeToSlotError"
+
+instance EncodeAeson PosixTimeToSlotError where
+  encodeAeson' (CannotFindTimeInEraSummaries absTime) =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "cannotFindTimeInEraSummaries"
+      [ absTime ]
+  encodeAeson' (PosixTimeBeforeSystemStart posixTime) =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "posixTimeBeforeSystemStart"
+      [ posixTime ]
+  encodeAeson' (StartTimeGreaterThanTime absTime) =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "startTimeGreaterThanTime"
+      [ absTime ]
+  encodeAeson' (EndSlotLessThanSlotOrModNonZero absSlot modTime) =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "endSlotLessThanSlotOrModNonZero"
+      [ encodeAeson absSlot, encodeAeson modTime ]
+  encodeAeson' (CannotConvertAbsSlotToSlot absSlot) =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "cannotConvertAbsSlotToSlot"
+      [ absSlot ]
+  encodeAeson' CannotGetBigIntFromNumber' =
+    encodeAeson' $ mkErrorRecord
+      posixTimeToSlotErrorStr
+      "cannotGetBigIntFromNumber"
+      aesonNull
+
+instance DecodeAeson PosixTimeToSlotError where
+  decodeAeson = aesonObject $ \o -> do
+    errorType <- getField o "errorType"
+    unless (errorType == posixTimeToSlotErrorStr)
+      $ throwError
+      $ TypeMismatch "Expected PosixTimeToSlotError"
+    getField o "error" >>= case _ of
+      "cannotFindTimeInEraSummaries" -> do
+        arg <- extractArg o
+        pure $ CannotFindTimeInEraSummaries arg
+      "posixTimeBeforeSystemStart" -> do
+        arg <- extractArg o
+        pure $ PosixTimeBeforeSystemStart arg
+      "startTimeGreaterThanTime" -> do
+        arg <- extractArg o
+        pure $ StartTimeGreaterThanTime arg
+      "endSlotLessThanSlotOrModNonZero" -> do
+        args <- getField o "args"
+        when (length args /= 2)
+          (throwError $ TypeMismatch "Incorrect args")
+        as <- decodeAeson =<< note
+          (TypeMismatch "Could not extract first element")
+          (index args 0)
+        mt <- decodeAeson =<< note
+          (TypeMismatch "Could not extract second element")
+          (index args 1)
+        pure $ EndSlotLessThanSlotOrModNonZero as mt
+      "cannotConvertAbsSlotToSlot" -> do
+        arg <- extractArg o
+        pure $ CannotConvertAbsSlotToSlot arg
+      "cannotGetBigIntFromNumber'" -> do
+        args <- getField o "args"
+        unless (isNull args) (throwError $ TypeMismatch "Non-empty args")
+        pure CannotGetBigIntFromNumber'
+      _ -> throwError $ TypeMismatch "Unknown error message"
 
 -- | Converts a `POSIXTime` to `Slot` given an `EraSummaries` and
 -- | `SystemStart` queried from Ogmios.

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -24,7 +24,12 @@ import QueryM
   )
 import QueryM.CurrentEpoch (getCurrentEpoch)
 import QueryM.EraSummaries (getEraSummaries)
-import QueryM.Ogmios (EraSummaries, OgmiosAddress, SystemStart)
+import QueryM.Ogmios
+  ( AbsSlot(AbsSlot)
+  , EraSummaries
+  , OgmiosAddress
+  , SystemStart
+  )
 import QueryM.SystemStart (getSystemStart)
 import QueryM.Utxos (utxosAt)
 import Serialization.Address (Slot(Slot))
@@ -32,7 +37,15 @@ import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Types.ByteArray (hexToByteArrayUnsafe)
 import Types.Chain (BlockHeaderHash(BlockHeaderHash))
-import Types.Interval (POSIXTime(POSIXTime), posixTimeToSlot, slotToPosixTime)
+import Types.Interval
+  ( PosixTimeToSlotError
+      ( CannotConvertAbsSlotToSlot
+      , PosixTimeBeforeSystemStart
+      )
+  , POSIXTime(POSIXTime)
+  , posixTimeToSlot
+  , slotToPosixTime
+  )
 import Types.Transaction (DataHash(DataHash))
 import Partial.Unsafe (unsafePartial)
 
@@ -61,6 +74,7 @@ suite = do
     test "Get SystemStart" testGetSystemStart
     test "Inverse posixTimeToSlot >>> slotToPosixTime " testPosixTimeToSlot
     test "Inverse slotToPosixTime >>> posixTimeToSlot " testSlotToPosixTime
+    test "PosixTimeToSlot errors" testPosixTimeToSlotError
   -- Test inverse in one direction.
   group "Address loop" do
     test "Ogmios Address to Address & back Testnet"
@@ -181,8 +195,8 @@ testPosixTimeToSlot = do
         ePosixTime <- slotToPosixTime es ss slot
         either (throw <<< show) (shouldEqual $ transf posixTime) ePosixTime
 
-  mkPosixTime :: String -> POSIXTime
-  mkPosixTime = POSIXTime <<< unsafePartial fromJust <<< BigInt.fromString
+mkPosixTime :: String -> POSIXTime
+mkPosixTime = POSIXTime <<< unsafePartial fromJust <<< BigInt.fromString
 
 testSlotToPosixTime :: Aff Unit
 testSlotToPosixTime = do
@@ -211,5 +225,37 @@ testSlotToPosixTime = do
         eSlot <- posixTimeToSlot es ss posixTime
         either (throw <<< show) (shouldEqual slot) eSlot
 
-  mkSlot :: Int -> Slot
-  mkSlot = Slot <<< UInt.fromInt
+mkSlot :: Int -> Slot
+mkSlot = Slot <<< UInt.fromInt
+
+testPosixTimeToSlotError :: Aff Unit
+testPosixTimeToSlotError = do
+  traceQueryConfig >>= flip runQueryM do
+    eraSummaries <- getEraSummaries
+    sysStart <- getSystemStart
+    let
+      posixTime = mkPosixTime "1000"
+      badPosixTime = mkPosixTime "99999999999999999999999999999999999999"
+      badAbsSlot = AbsSlot
+        $ unsafePartial fromJust
+        $ BigInt.fromString "99999999999999999999999998405630783"
+    -- Some difficulty reproducing all the errors
+    errTest eraSummaries sysStart
+      posixTime
+      (PosixTimeBeforeSystemStart posixTime)
+    errTest eraSummaries sysStart
+      badPosixTime
+      (CannotConvertAbsSlotToSlot badAbsSlot)
+  where
+  errTest
+    :: forall (err :: Type)
+     . EraSummaries
+    -> SystemStart
+    -> POSIXTime
+    -> PosixTimeToSlotError
+    -> QueryM Unit
+  errTest es ss posixTime expectedErr = liftEffect do
+    posixTimeToSlot es ss posixTime >>= case _ of
+      Left err -> err `shouldEqual` expectedErr
+      Right _ ->
+        throw $ "Test should have failed giving: " <> show expectedErr

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -225,8 +225,8 @@ testSlotToPosixTime = do
         eSlot <- posixTimeToSlot es ss posixTime
         either (throw <<< show) (shouldEqual slot) eSlot
 
-mkSlot :: Int -> Slot
-mkSlot = Slot <<< UInt.fromInt
+  mkSlot :: Int -> Slot
+  mkSlot = Slot <<< UInt.fromInt
 
 testPosixTimeToSlotError :: Aff Unit
 testPosixTimeToSlotError = do

--- a/test/Plutus/Time.purs
+++ b/test/Plutus/Time.purs
@@ -1,0 +1,232 @@
+module Test.Plutus.Time
+  ( suite
+  ) where
+
+import Data.BigInt as BigInt
+import Data.Maybe (Maybe(Just, Nothing))
+import Prelude
+import Mote (group)
+import QueryM.Ogmios
+  ( AbsSlot(AbsSlot)
+  , CurrentEpoch(CurrentEpoch)
+  , Epoch(Epoch)
+  , EpochLength(EpochLength)
+  , EraSummaries(EraSummaries)
+  , EraSummary(EraSummary)
+  , EraSummaryParameters(EraSummaryParameters)
+  , EraSummaryTime(EraSummaryTime)
+  , SafeZone(SafeZone)
+  , SlotLength(SlotLength)
+  , SystemStart(SystemStart)
+  , RelativeTime(RelativeTime)
+  )
+import Test.Utils (toFromAesonTest)
+import TestM (TestPlanM)
+import Types.Interval
+  ( AbsTime(AbsTime)
+  , ModTime(ModTime)
+  , POSIXTime(POSIXTime)
+  , PosixTimeToSlotError
+      ( CannotConvertAbsSlotToSlot
+      , CannotFindTimeInEraSummaries
+      , CannotGetBigIntFromNumber'
+      , EndSlotLessThanSlotOrModNonZero
+      , PosixTimeBeforeSystemStart
+      , StartTimeGreaterThanTime
+      )
+  , RelSlot(RelSlot)
+  , RelTime(RelTime)
+  , SlotToPosixTimeError
+      ( CannotFindSlotInEraSummaries
+      , CannotGetBigIntFromNumber
+      , EndTimeLessThanTime
+      , StartingSlotGreaterThanSlot
+      )
+  , ToOnChainPosixTimeRangeError
+      ( PosixTimeToSlotError'
+      , SlotToPosixTimeError'
+      )
+  )
+
+absSlotFixture :: AbsSlot
+absSlotFixture = AbsSlot $ BigInt.fromInt 34892625
+
+absTimeFixture :: AbsTime
+absTimeFixture = AbsTime $ BigInt.fromInt 321541237
+
+posixTimeFixture :: POSIXTime
+posixTimeFixture = POSIXTime $ BigInt.fromInt 12345678
+
+modTimeFixture :: ModTime
+modTimeFixture = ModTime $ BigInt.fromInt 7836
+
+slotToPosixTimeErrFixture :: SlotToPosixTimeError
+slotToPosixTimeErrFixture = CannotFindSlotInEraSummaries absSlotFixture
+
+posixTimeToSlotErrFixture :: PosixTimeToSlotError
+posixTimeToSlotErrFixture = CannotFindTimeInEraSummaries absTimeFixture
+
+relTimeFixture :: RelTime
+relTimeFixture = RelTime $ BigInt.fromInt 85723
+
+relSlotFixture :: RelSlot
+relSlotFixture = RelSlot $ BigInt.fromInt 12855
+
+currentEpochFixture :: CurrentEpoch
+currentEpochFixture = CurrentEpoch $ BigInt.fromInt 58326646
+
+systemStartFixture :: SystemStart
+systemStartFixture = SystemStart "2019-07-24T20:20:16Z"
+
+eraSummariesFixture :: EraSummaries
+eraSummariesFixture = EraSummaries
+  [ EraSummary
+      { "start": EraSummaryTime
+          { "time": RelativeTime zero
+          , "slot": AbsSlot zero
+          , "epoch": Epoch zero
+          }
+      , "end": Just $ EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 31968000
+          , "slot": AbsSlot $ BigInt.fromInt 1598400
+          , "epoch": Epoch $ BigInt.fromInt 74
+          }
+      , "parameters": EraSummaryParameters
+          { "epochLength": EpochLength $ BigInt.fromInt 21600
+          , "slotLength": SlotLength $ BigInt.fromInt 20
+          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          }
+      }
+  , EraSummary
+      { "start": EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 31968000
+          , "slot": AbsSlot $ BigInt.fromInt 1598400
+          , "epoch": Epoch $ BigInt.fromInt 74
+          }
+      , "end": Just $ EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 44064000
+          , "slot": AbsSlot $ BigInt.fromInt 13694400
+          , "epoch": Epoch $ BigInt.fromInt 102
+          }
+      , "parameters": EraSummaryParameters
+          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          , "slotLength": SlotLength one
+          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          }
+      }
+  , EraSummary
+      { "start": EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 44064000
+          , "slot": AbsSlot $ BigInt.fromInt 13694400
+          , "epoch": Epoch $ BigInt.fromInt 102
+          }
+      , "end": Just $ EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 48384000
+          , "slot": AbsSlot $ BigInt.fromInt 18014400
+          , "epoch": Epoch $ BigInt.fromInt 112
+          }
+      , "parameters": EraSummaryParameters
+          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          , "slotLength": SlotLength one
+          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          }
+      }
+  , EraSummary
+      { "start": EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 48384000
+          , "slot": AbsSlot $ BigInt.fromInt 18014400
+          , "epoch": Epoch $ BigInt.fromInt 112
+          }
+      , "end": Just $ EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 66528000
+          , "slot": AbsSlot $ BigInt.fromInt 36158400
+          , "epoch": Epoch $ BigInt.fromInt 154
+          }
+      , "parameters": EraSummaryParameters
+          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          , "slotLength": SlotLength one
+          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          }
+      }
+  , EraSummary
+      { "start": EraSummaryTime
+          { "time": RelativeTime $ BigInt.fromInt 66528000
+          , "slot": AbsSlot $ BigInt.fromInt 36158400
+          , "epoch": Epoch $ BigInt.fromInt 154
+          }
+      , "end": Nothing
+      , "parameters": EraSummaryParameters
+          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          , "slotLength": SlotLength one
+          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          }
+      }
+  ]
+
+suite :: TestPlanM Unit
+suite = do
+  group "Time-related Aeson representation tests" do
+    group "POSIXTime" do
+      let input = posixTimeFixture
+      toFromAesonTest input
+    group "SlotToPosixTimeError" do
+      group "CannotFindSlotInEraSummaries" do
+        let err = slotToPosixTimeErrFixture
+        toFromAesonTest err
+      group "StartingSlotGreaterThanSlot" do
+        let err = StartingSlotGreaterThanSlot absSlotFixture
+        toFromAesonTest err
+      group "EndTimeLessThanTime" do
+        let err = EndTimeLessThanTime absTimeFixture
+        toFromAesonTest err
+      group "CannotGetBigIntFromNumber" do
+        let err = CannotGetBigIntFromNumber
+        toFromAesonTest err
+    group "PosixTimeToSlotError" do
+      group "CannotConvertAbsSlotToSlot" do
+        let err = posixTimeToSlotErrFixture
+        toFromAesonTest err
+      group "PosixTimeBeforeSystemStart" do
+        let err = PosixTimeBeforeSystemStart posixTimeFixture
+        toFromAesonTest err
+      group "StartTimeGreaterThanTime" do
+        let err = StartTimeGreaterThanTime absTimeFixture
+        toFromAesonTest err
+      group "EndSlotLessThanSlotOrModNonZero" do
+        let err = EndSlotLessThanSlotOrModNonZero absSlotFixture modTimeFixture
+        toFromAesonTest err
+      group "CannotConvertAbsSlotToSlot" do
+        let err = CannotConvertAbsSlotToSlot absSlotFixture
+        toFromAesonTest err
+      group "CannotGetBigIntFromNumber'" do
+        let err = CannotGetBigIntFromNumber'
+        toFromAesonTest err
+    group "ToOnChainPosixTimeRangeError" do
+      group "PosixTimeToSlotError'" do
+        let err = PosixTimeToSlotError' posixTimeToSlotErrFixture
+        toFromAesonTest err
+      group "SlotToPosixTimeError'" do
+        let err = SlotToPosixTimeError' slotToPosixTimeErrFixture
+        toFromAesonTest err
+    group "Misc. Types" do
+      group "AbsSlot" do
+        let input = absSlotFixture
+        toFromAesonTest input
+      group "AbsTime" do
+        let input = absTimeFixture
+        toFromAesonTest input
+      group "RelSlot" do
+        let input = relSlotFixture
+        toFromAesonTest input
+      group "RelTime" do
+        let input = relTimeFixture
+        toFromAesonTest input
+      group "EraSummaries" do
+        let input = eraSummariesFixture
+        toFromAesonTest input
+      group "SystemStart" do
+        let input = systemStartFixture
+        toFromAesonTest input
+      group "CurrentEpoch" do
+        let input = currentEpochFixture
+        toFromAesonTest input

--- a/test/Plutus/Time.purs
+++ b/test/Plutus/Time.purs
@@ -49,7 +49,7 @@ import Types.Interval
   )
 
 absSlotFixture :: AbsSlot
-absSlotFixture = AbsSlot $ BigInt.fromInt 34892625
+absSlotFixture = mkAbsSlot 34892625
 
 absTimeFixture :: AbsTime
 absTimeFixture = AbsTime $ BigInt.fromInt 321541237
@@ -78,6 +78,24 @@ currentEpochFixture = CurrentEpoch $ BigInt.fromInt 58326646
 systemStartFixture :: SystemStart
 systemStartFixture = SystemStart "2019-07-24T20:20:16Z"
 
+mkRelativeTime :: Int -> RelativeTime
+mkRelativeTime = RelativeTime <<< BigInt.fromInt
+
+mkAbsSlot :: Int -> AbsSlot
+mkAbsSlot = AbsSlot <<< BigInt.fromInt
+
+mkEpoch :: Int -> Epoch
+mkEpoch = Epoch <<< BigInt.fromInt
+
+mkEpochLength :: Int -> EpochLength
+mkEpochLength = EpochLength <<< BigInt.fromInt
+
+mkSlotLength :: Int -> SlotLength
+mkSlotLength = SlotLength <<< BigInt.fromInt
+
+mkSafeZone :: Int -> SafeZone
+mkSafeZone = SafeZone <<< BigInt.fromInt
+
 eraSummariesFixture :: EraSummaries
 eraSummariesFixture = EraSummaries
   [ EraSummary
@@ -87,78 +105,78 @@ eraSummariesFixture = EraSummaries
           , "epoch": Epoch zero
           }
       , "end": Just $ EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 31968000
-          , "slot": AbsSlot $ BigInt.fromInt 1598400
-          , "epoch": Epoch $ BigInt.fromInt 74
+          { "time": mkRelativeTime 31968000
+          , "slot": mkAbsSlot 1598400
+          , "epoch": mkEpoch 74
           }
       , "parameters": EraSummaryParameters
-          { "epochLength": EpochLength $ BigInt.fromInt 21600
-          , "slotLength": SlotLength $ BigInt.fromInt 20
-          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          { "epochLength": mkEpochLength 21600
+          , "slotLength": mkSlotLength 20
+          , "safeZone": mkSafeZone 129600
           }
       }
   , EraSummary
       { "start": EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 31968000
-          , "slot": AbsSlot $ BigInt.fromInt 1598400
-          , "epoch": Epoch $ BigInt.fromInt 74
+          { "time": mkRelativeTime 31968000
+          , "slot": mkAbsSlot 1598400
+          , "epoch": mkEpoch 74
           }
       , "end": Just $ EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 44064000
-          , "slot": AbsSlot $ BigInt.fromInt 13694400
-          , "epoch": Epoch $ BigInt.fromInt 102
+          { "time": mkRelativeTime 44064000
+          , "slot": mkAbsSlot 13694400
+          , "epoch": mkEpoch 102
           }
       , "parameters": EraSummaryParameters
-          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          { "epochLength": mkEpochLength 432000
           , "slotLength": SlotLength one
-          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          , "safeZone": mkSafeZone 129600
           }
       }
   , EraSummary
       { "start": EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 44064000
-          , "slot": AbsSlot $ BigInt.fromInt 13694400
-          , "epoch": Epoch $ BigInt.fromInt 102
+          { "time": mkRelativeTime 44064000
+          , "slot": mkAbsSlot 13694400
+          , "epoch": mkEpoch 102
           }
       , "end": Just $ EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 48384000
-          , "slot": AbsSlot $ BigInt.fromInt 18014400
-          , "epoch": Epoch $ BigInt.fromInt 112
+          { "time": mkRelativeTime 48384000
+          , "slot": mkAbsSlot 18014400
+          , "epoch": mkEpoch 112
           }
       , "parameters": EraSummaryParameters
-          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          { "epochLength": mkEpochLength 432000
           , "slotLength": SlotLength one
-          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          , "safeZone": mkSafeZone 129600
           }
       }
   , EraSummary
       { "start": EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 48384000
-          , "slot": AbsSlot $ BigInt.fromInt 18014400
-          , "epoch": Epoch $ BigInt.fromInt 112
+          { "time": mkRelativeTime 48384000
+          , "slot": mkAbsSlot 18014400
+          , "epoch": mkEpoch 112
           }
       , "end": Just $ EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 66528000
-          , "slot": AbsSlot $ BigInt.fromInt 36158400
-          , "epoch": Epoch $ BigInt.fromInt 154
+          { "time": mkRelativeTime 66528000
+          , "slot": mkAbsSlot 36158400
+          , "epoch": mkEpoch 154
           }
       , "parameters": EraSummaryParameters
-          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          { "epochLength": mkEpochLength 432000
           , "slotLength": SlotLength one
-          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          , "safeZone": mkSafeZone 129600
           }
       }
   , EraSummary
       { "start": EraSummaryTime
-          { "time": RelativeTime $ BigInt.fromInt 66528000
-          , "slot": AbsSlot $ BigInt.fromInt 36158400
-          , "epoch": Epoch $ BigInt.fromInt 154
+          { "time": mkRelativeTime 66528000
+          , "slot": mkAbsSlot 36158400
+          , "epoch": mkEpoch 154
           }
       , "end": Nothing
       , "parameters": EraSummaryParameters
-          { "epochLength": EpochLength $ BigInt.fromInt 432000
+          { "epochLength": mkEpochLength 432000
           , "slotLength": SlotLength one
-          , "safeZone": SafeZone $ BigInt.fromInt 129600
+          , "safeZone": mkSafeZone 129600
           }
       }
   ]

--- a/test/Unit.purs
+++ b/test/Unit.purs
@@ -12,6 +12,7 @@ import Test.Metadata.Seabug as Seabug
 import Test.Metadata.Cip25 as Cip25
 import Test.Parser as Parser
 import Test.Plutus.Address as Plutus.Address
+import Test.Plutus.Time as Plutus.Time
 import Test.Plutus.Value as Plutus.Value
 import Test.Serialization as Serialization
 import Test.Serialization.Address as Serialization.Address
@@ -35,6 +36,7 @@ testPlan = do
   Hashing.suite
   Parser.suite
   Plutus.Address.suite
+  Plutus.Time.suite
   Plutus.Value.suite
   Seabug.suite
   Serialization.suite

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -1,22 +1,33 @@
 module Test.Utils
-  ( interpret
-  , unsafeCall
+  ( aesonRoundTrip
   , assertTrue
   , assertTrue_
   , errMaybe
+  , interpret
+  , toFromAesonTest
+  , unsafeCall
   ) where
 
 import Prelude
 
+import Aeson
+  ( class DecodeAeson
+  , class EncodeAeson
+  , JsonDecodeError
+  , decodeAeson
+  , encodeAeson
+  )
 import Data.Const (Const)
+import Data.Either (Either(Right))
 import Data.Foldable (sequence_)
 import Data.Maybe (Maybe(Just, Nothing))
 import Effect.Aff (Aff, error)
 import Effect.Aff.Class (liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Exception (throwException, throw)
-import Mote (Plan, foldPlan, planT)
+import Mote (Plan, foldPlan, planT, test)
 import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
 import TestM (TestPlanM)
@@ -67,3 +78,27 @@ errMaybe
 errMaybe msg = case _ of
   Nothing -> liftEffect $ throw msg
   Just res -> pure res
+
+toFromAesonTest
+  :: forall (a :: Type)
+   . Eq a
+  => Show a
+  => DecodeAeson a
+  => EncodeAeson a
+  => a
+  -> TestPlanM Unit
+toFromAesonTest x = test (show x) $ do
+  let
+    (xOrErr :: Either JsonDecodeError a) =
+      aesonRoundTrip x
+  xOrErr `shouldEqual` Right x
+
+aesonRoundTrip
+  :: forall (a :: Type)
+   . Eq a
+  => Show a
+  => DecodeAeson a
+  => EncodeAeson a
+  => a
+  -> Either JsonDecodeError a
+aesonRoundTrip = decodeAeson <<< encodeAeson


### PR DESCRIPTION
- Aeson types for https://github.com/Plutonomicon/cardano-transaction-lib/pull/447
- Roundtrip testing for Aeson.
- Added extra testing for POSIXTimeRange construction, some of the errors were difficult to reproduce so I only did a subset.