### PR TITLE
Fix ScriptHash bug

### DIFF
--- a/src/Cardano/Types/Value.purs
+++ b/src/Cardano/Types/Value.purs
@@ -84,7 +84,6 @@ import Metadata.ToMetadata (class ToMetadata)
 import Partial.Unsafe (unsafePartial)
 import Serialization.Hash
   ( ScriptHash
-  , scriptHashAsBytes
   , scriptHashFromBytes
   , scriptHashToBytes
   )
@@ -655,7 +654,7 @@ currencyScriptHash (CurrencySymbol byteArray) =
   unsafePartial fromJust $ scriptHashFromBytes (wrap byteArray)
 
 scriptHashAsCurrencySymbol :: ScriptHash -> CurrencySymbol
-scriptHashAsCurrencySymbol = CurrencySymbol <<< unwrap <<< scriptHashAsBytes
+scriptHashAsCurrencySymbol = CurrencySymbol <<< unwrap <<< scriptHashToBytes
 
 -- | The minting policy hash of a currency symbol
 currencyMPSHash :: CurrencySymbol -> MintingPolicyHash

--- a/src/Plutus/Types/CurrencySymbol.purs
+++ b/src/Plutus/Types/CurrencySymbol.purs
@@ -24,7 +24,6 @@ import Data.Maybe (Maybe)
 import FromData (class FromData)
 import Serialization.Hash
   ( ScriptHash
-  , scriptHashAsBytes
   , scriptHashFromBytes
   , scriptHashToBytes
   )
@@ -58,7 +57,7 @@ adaSymbol :: CurrencySymbol
 adaSymbol = CurrencySymbol mempty
 
 scriptHashAsCurrencySymbol :: ScriptHash -> CurrencySymbol
-scriptHashAsCurrencySymbol = CurrencySymbol <<< unwrap <<< scriptHashAsBytes
+scriptHashAsCurrencySymbol = CurrencySymbol <<< unwrap <<< scriptHashToBytes
 
 -- | The minting policy hash of a currency symbol.
 currencyMPSHash :: CurrencySymbol -> Maybe MintingPolicyHash

--- a/src/Serialization/Hash.js
+++ b/src/Serialization/Hash.js
@@ -63,7 +63,6 @@ exports.ed25519KeyHashToBytes = hashToBytes;
 exports.ed25519KeyHashToBech32Unsafe = hashToBech32Unsafe;
 exports._ed25519KeyHashToBech32Impl = hashToBech32Impl;
 
-exports.scriptHashAsBytes = h => h;
 exports.scriptHashToBytes = hashToBytes;
 exports.scriptHashToBech32Unsafe = hashToBech32Unsafe;
 exports._scriptHashToBech32Impl = hashToBech32Impl;

--- a/src/Serialization/Hash.purs
+++ b/src/Serialization/Hash.purs
@@ -11,7 +11,6 @@ module Serialization.Hash
   , scriptHashFromBytes
   , scriptHashFromBech32
   , scriptHashToBech32
-  , scriptHashAsBytes
   ) where
 
 import Prelude
@@ -161,9 +160,6 @@ foreign import _scriptHashFromBech32Impl
   :: MaybeFfiHelper
   -> Bech32String
   -> Maybe ScriptHash
-
--- | Drops the type and returns the hash as a generic bytearray
-foreign import scriptHashAsBytes :: ScriptHash -> RawBytes
 
 -- | Encodes the hash to Cbor bytes
 foreign import scriptHashToBytes :: ScriptHash -> RawBytes


### PR DESCRIPTION
` exports.scriptHashAsBytes = h => h;` was incorrect, CSL type is not literally bytes.