### PR TITLE
Add a comment about networkId in enterpriseAddress*Hash

### DIFF
--- a/src/Contract/Address.purs
+++ b/src/Contract/Address.purs
@@ -156,6 +156,7 @@ getNetworkId = wrapContract Address.getNetworkId
 -- | Get the `ValidatorHash` with an Plutus `Address`
 enterpriseAddressValidatorHash :: Address -> Maybe ValidatorHash
 enterpriseAddressValidatorHash =
+  -- Network id does not matter here (#484)
   Address.enterpriseAddressValidatorHash <=< fromPlutusType <<< Tuple MainnetId
 
 -- | Get the `StakeValidatorHash` with an Plutus `Address`
@@ -167,6 +168,7 @@ enterpriseAddressStakeValidatorHash =
 -- | Get the `ScriptHash` with an Plutus `Address`
 enterpriseAddressScriptHash :: Address -> Maybe ScriptHash
 enterpriseAddressScriptHash =
+  -- Network id does not matter here (#484)
   Address.enterpriseAddressScriptHash <=< fromPlutusType <<< Tuple MainnetId
 
 -- | Converts a Plutus `TypedValidator` to a Plutus (`BaseAddress`) `Address`


### PR DESCRIPTION
Closes #484 

I check it with this test:

```
addressValidatorHash :: TestPlanM Unit
addressValidatorHash = do
  test "enterpriseAddressValidatorHash" do
    let
      mbVal = enterpriseAddressValidatorHash addr1
      mbVal' =
        Address.enterpriseAddressValidatorHash <=< fromPlutusType <<< Tuple
          TestnetId
          $ _.address
          $ unwrap (unsafePartial $ fromJust $ toPlutusType addr1)
      mbVal'' =
        Address.enterpriseAddressValidatorHash <=< fromPlutusType <<< Tuple
          MainnetId
          $ _.address
          $ unwrap (unsafePartial $ fromJust $ toPlutusType addr1)
    mbVal `shouldEqual` mbVal'
    mbVal' `shouldEqual` mbVal''

addressScriptHash :: TestPlanM Unit
addressScriptHash = do
  test "enterpriseAddressScriptHash" do
    let
      mbVal = enterpriseAddressScriptHash addr1
      mbVal' =
        Address.enterpriseAddressScriptHash <=< fromPlutusType <<< Tuple
          TestnetId
          $ _.address
          $ unwrap (unsafePartial $ fromJust $ toPlutusType addr1)
      mbVal'' =
        Address.enterpriseAddressScriptHash <=< fromPlutusType <<< Tuple
          MainnetId
          $ _.address
          $ unwrap (unsafePartial $ fromJust $ toPlutusType addr1)
    mbVal `shouldEqual` mbVal'
    mbVal' `shouldEqual` mbVal''

```


Not going to include it into the test suite, because it is not testing some property we need to maintain.