### PR TITLE
Combine examples into a single module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := bash
 
 ps-sources := $(shell fd -epurs)
 nix-sources := $(shell fd -enix --exclude='spago*')
-ps-entrypoint := Examples.AlwaysSucceeds
+ps-entrypoint := Examples.Combined
 ps-bundle = spago bundle-module -m ${ps-entrypoint} --to output.js
 
 node-ipc = $(shell docker volume inspect cardano-transaction-lib_node-ipc | jq -r '.[0].Mountpoint')

--- a/examples/AlwaysMints.purs
+++ b/examples/AlwaysMints.purs
@@ -1,7 +1,7 @@
 -- | This module demonstrates how the `Contract` interface can be used to build,
 -- | balance, and submit a smart-contract transaction. It creates a transaction
 -- | that mints a value using the `AlwaysMints` policy
-module Examples.AlwaysMints (main) where
+module Examples.AlwaysMints (main, contract) where
 
 import Contract.Prelude
 
@@ -30,7 +30,10 @@ import Contract.Wallet (mkNamiWalletAff)
 import Data.BigInt as BigInt
 
 main :: Effect Unit
-main = launchAff_ $ do
+main = launchAff_ contract
+
+contract :: Aff Unit
+contract = do
   wallet <- Just <$> mkNamiWalletAff
   cfg <- over ContractConfig _ { wallet = wallet } <$> traceContractConfig
   runContract_ cfg $ do

--- a/examples/AlwaysSucceeds.purs
+++ b/examples/AlwaysSucceeds.purs
@@ -1,7 +1,7 @@
 -- | This module demonstrates how the `Contract` interface can be used to build,
 -- | balance, and submit a smart-contract transaction. It creates a transaction
 -- | that pays two Ada to the `AlwaysSucceeds` script address
-module Examples.AlwaysSucceeds (main) where
+module Examples.AlwaysSucceeds (main, contract) where
 
 import Contract.Prelude
 
@@ -39,7 +39,10 @@ import Types.Transaction (TransactionInput(TransactionInput), TransactionHash)
 import Types.TxConstraints (TxConstraints)
 
 main :: Effect Unit
-main = launchAff_ $ do
+main = launchAff_ contract
+
+contract :: Aff Unit
+contract = do
   wallet <- Just <$> mkNamiWalletAff
   cfg <- over ContractConfig _ { wallet = wallet } <$> traceContractConfig
   runContract_ cfg $ do

--- a/examples/Combined.purs
+++ b/examples/Combined.purs
@@ -1,0 +1,34 @@
+-- | This module allows you to run all of the current examples, with a delay
+-- | in between each. This is helpful to ensure that changes you introduce
+-- | don't break existing functionality. If an example fails, you can run it
+-- | individually afterwards to diagnose the problem
+module Examples.Combined (main) where
+
+import Contract.Prelude
+
+import Data.Array (intersperse)
+import Effect.Aff (launchAff_, delay)
+import Examples.AlwaysMints as AlwaysMints
+import Examples.AlwaysSucceeds as AlwaysSucceeds
+import Examples.Datums as Datums
+import Examples.Nami as Nami
+import Examples.Pkh2Pkh as Pkh2Pkh
+
+main :: Effect Unit
+main = launchAff_ $ sequence_ $ intersperse sleep
+  [ AlwaysMints.contract
+  , Datums.contract
+  , Nami.contract
+  , Pkh2Pkh.contract
+  , AlwaysSucceeds.contract
+  ]
+  where
+  sleepWithMsg :: Aff Unit
+  sleepWithMsg = log ("Sleeping for " <> show delayMillis) *> sleep
+
+  -- Wait to run the next contract
+  sleep :: Aff Unit
+  sleep = delay $ wrap delayMillis
+
+  delayMillis :: Number
+  delayMillis = 5_000.0

--- a/examples/Combined.purs
+++ b/examples/Combined.purs
@@ -2,6 +2,15 @@
 -- | in between each. This is helpful to ensure that changes you introduce
 -- | don't break existing functionality. If an example fails, you can run it
 -- | individually afterwards to diagnose the problem
+-- |
+-- | To run an individual example, either edit the `ps-entrypoint` variable
+-- | in the Makefile and run `make run-dev`, or issue the following commands:
+-- |
+-- | ```
+-- | > spago bundle-module -m <ENTRYPOINT> --to output.js
+-- | > BROWSER_RUNTIME=1 webpack-dev-server --progress
+-- | ```
+-- |
 module Examples.Combined (main) where
 
 import Contract.Prelude

--- a/examples/Datums.purs
+++ b/examples/Datums.purs
@@ -15,7 +15,7 @@
 -- |     ```
 -- |   * change the `ps-entrypoint` variable in the Makefile to `Examples.Datums`
 -- |   * `make run-dev` and visit `localhost:4008` in your browser
-module Examples.Datums (main) where
+module Examples.Datums (main, contract) where
 
 import Contract.Prelude
 
@@ -25,7 +25,10 @@ import Contract.Prim.ByteArray (hexToByteArrayUnsafe)
 import Data.Newtype (wrap)
 
 main :: Effect Unit
-main = launchAff_ $ do
+main = launchAff_ contract
+
+contract :: Aff Unit
+contract = do
   cfg <- traceContractConfig
   runContract_ cfg $ do
     logInfo' "Running Examples.Datums"

--- a/examples/Nami.purs
+++ b/examples/Nami.purs
@@ -6,7 +6,7 @@
 --
 -- NOTE: due to Nami's limitations, only chromium-based browsers are supported
 
-module Examples.Nami (main) where
+module Examples.Nami (main, contract) where
 
 import Contract.Prelude
 import Contract.Address (getWalletAddress, getWalletCollateral)
@@ -18,7 +18,10 @@ import Contract.Monad
   )
 
 main :: Effect Unit
-main = launchAff_ $ do
+main = launchAff_ contract
+
+contract :: Aff Unit
+contract = do
   cfg <- defaultContractConfig
   runContract_ cfg $ do
     logAction getWalletAddress

--- a/examples/Pkh2Pkh.purs
+++ b/examples/Pkh2Pkh.purs
@@ -1,7 +1,7 @@
 -- | This module demonstrates how the `Contract` interface can be used to build,
 -- | balance, and submit a transaction. It creates a simple transaction that gets
 -- | UTxOs from the user's wallet and sends two Ada back to the same wallet address
-module Examples.Pkh2Pkh (main) where
+module Examples.Pkh2Pkh (main, contract) where
 
 import Contract.Prelude
 
@@ -31,7 +31,10 @@ import Contract.Wallet (mkNamiWalletAff)
 import Data.BigInt as BigInt
 
 main :: Effect Unit
-main = launchAff_ $ do
+main = launchAff_ contract
+
+contract :: Aff Unit
+contract = do
   wallet <- Just <$> mkNamiWalletAff
   cfg <- mkContractConfig $ ConfigParams
     { ogmiosConfig: defaultOgmiosWsConfig


### PR DESCRIPTION
We should be running all examples locally when opening PRs (at the very least until #465 is addressed). As it is, it's inconvenient to edit the Makefile or issue all of the commands manually. This adds an `Examples.Combined` module for convenience