### PR TITLE
Use `psa` for compilation in Nix derivations

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -75,16 +75,20 @@ let
     { sources ? [ "src" ]
     , withDevDeps ? false
     , name ? projectName
+    , censorCodes ? [ "UserDefinedWarning" ]
     , ...
     }:
     let
       nodeModules = mkNodeModules { inherit withDevDeps; };
-      srcs = builtins.concatStringsSep "," sources;
+      sepWithComma = builtins.concatStringsSep ",";
       # for e.g. `cp -r {a,b,c}` vs `cp -r a`
       srcsStr =
+        let
+          withCommas = sepWithComma sources;
+        in
         if builtins.length sources > 1
-        then ("{" + srcs + "}")
-        else srcs;
+        then ("{" + withCommas + "}")
+        else withCommas;
       # This is what spago2nix does
       spagoGlob = pkg:
         ''".spago/${pkg.name}/${pkg.version}/src/**/*.purs"'';
@@ -112,7 +116,7 @@ let
         '';
       buildPhase = ''
         psa --strict --censor-lib --is-lib=.spago ${spagoGlobs} \
-          --censor-codes=UserDefinedWarning "./**/*.purs"
+          --censor-codes=${sepWithComma censorCodes} "./**/*.purs"
       '';
       installPhase = ''
         mkdir $out

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -65,7 +65,7 @@ import Affjax as Affjax
 import Affjax.RequestBody as Affjax.RequestBody
 import Affjax.RequestHeader as Affjax.RequestHeader
 import Affjax.ResponseFormat as Affjax.ResponseFormat
-import Affjax.StatusCode (StatusCode(StatusCode)) as Affjax
+import Affjax.StatusCode as Affjax.StatusCode
 import Cardano.Types.Transaction (Transaction(Transaction))
 import Cardano.Types.Transaction as Transaction
 import Cardano.Types.TransactionUnspentOutput (TransactionUnspentOutput)
@@ -74,7 +74,7 @@ import Control.Monad.Error.Class (throwError)
 import Control.Monad.Logger.Trans (LoggerT, runLoggerT)
 import Control.Monad.Reader.Trans (ReaderT, runReaderT, withReaderT, ask, asks)
 import Data.Array (length)
-import Data.Bifunctor (bimap, lmap)
+import Data.Bifunctor (lmap)
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
 import Data.Either (Either(Left, Right), either, isRight, note, hush)
@@ -540,7 +540,8 @@ handleAffjaxResponse
   -> Either ClientError result
 handleAffjaxResponse (Left affjaxError) =
   Left (ClientHttpError affjaxError)
-handleAffjaxResponse (Right { status: Affjax.StatusCode statusCode, body })
+handleAffjaxResponse
+  (Right { status: Affjax.StatusCode.StatusCode statusCode, body })
   | statusCode < 200 || statusCode > 299 =
       Left (ClientHttpResponseError body)
   | otherwise =

--- a/src/QueryM/Utxos.purs
+++ b/src/QueryM/Utxos.purs
@@ -41,13 +41,10 @@ utxosAt :: Address -> QueryM (Maybe UtxoM)
 utxosAt addr = asks _.wallet >>= maybe (allUtxosAt addr) (utxosAtByWallet addr)
   where
   -- Add more wallet types here:
-  utxosAtByWallet
-    :: Address -> Wallet -> QueryM (Maybe UtxoM)
-  utxosAtByWallet address (Nami _) = cip30UtxosAt address
-  utxosAtByWallet address (Gero _) = cip30UtxosAt address
-  -- Unreachable but helps build when we add wallets, most of them shouldn't
-  -- require any specific behaviour.
-  utxosAtByWallet address _ = allUtxosAt address
+  utxosAtByWallet :: Address -> Wallet -> QueryM (Maybe UtxoM)
+  utxosAtByWallet address = case _ of
+    Nami _ -> cip30UtxosAt address
+    Gero _ -> cip30UtxosAt address
 
   -- Gets all utxos at an (internal) Address in terms of (internal)
   -- Cardano.Transaction.Types.


### PR DESCRIPTION
Closes #518. Now we can compile with `psa --strict --censor-lib` which will silence the superfluous warnings from libraries and cause building to fail if any compiler warnings are reported (very helpful to catch things like redundant imports, etc...)

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [-] All Purescript imports are explicit, including constructors (n/a)
- [-] **All** existing examples have been run locally against a fully-synced testnet node (n/a)
- [-] The integration and unit tests have been run (`npm run test`) locally (n/a, except I ran the `checks.ctl-unit-test` via Nix to make sure it passes (Hydra is having issues)