### PR TITLE
Upgrade ODC for more stable datum gets from datum hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Single `Plutus.Conversion` module exposing all `(Type <-> Plutus Type)` conversion functions.
 - Support for using a `PrivateKey` as a `Wallet`.
+- Upgraded `ogmios-datum-cache` to `54ad2964af07ea0370bf95c0fed71f60a778ead5` for more stable datum from datum hash.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Single `Plutus.Conversion` module exposing all `(Type <-> Plutus Type)` conversion functions.
 - Support for using a `PrivateKey` as a `Wallet`.
-- Upgraded `ogmios-datum-cache` to `54ad2964af07ea0370bf95c0fed71f60a778ead5` for more stable datum from datum hash.
+- Upgraded `ogmios-datum-cache` to `54ad2964af07ea0370bf95c0fed71f60a778ead5` for more stable datum from datum hash (see [here](https://github.com/Plutonomicon/cardano-transaction-lib/issues/526) for more details).
 
 ### Removed
 
 - `FromPlutusType` / `ToPlutusType` type classes.
-
 
 ## [1.0.0] - 2022-06-10
 

--- a/flake.lock
+++ b/flake.lock
@@ -1525,19 +1525,21 @@
     "ogmios-datum-cache": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_3",
+        "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
-        "lastModified": 1652673546,
-        "narHash": "sha256-fd3UST7vjed7KLOrLsFD8/nP7YXhCAQ3ODFs5SjZ6SQ=",
+        "lastModified": 1655041544,
+        "narHash": "sha256-ZTftQtrivnugqHjsMrV0wxKLfnrDxSX0MXM1KUkf4R0=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "dbff887d14122249352c1a853be05023f64a2664",
+        "rev": "54ad2964af07ea0370bf95c0fed71f60a778ead5",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
+        "rev": "54ad2964af07ea0370bf95c0fed71f60a778ead5",
         "type": "github"
       }
     },
@@ -1790,6 +1792,21 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "unstable_nixpkgs": {
+      "locked": {
+        "lastModified": 1655120009,
+        "narHash": "sha256-h4JQSaVUNnAhMgfqRl6ie2OO5v3vtmgISVzUTdT827g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "693d5359ee0bfc1de975845f3a9f8f81a7abc535",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,7 @@
               "dbname=${postgres.db}"
               "password=${postgres.password}"
             ];
+          controlApiToken = "";
           blockFetcher = {
             firstBlock = {
               slot = 54066900;
@@ -318,6 +319,7 @@
                   datumCache.blockFetcher.filter;
                 configFile = ''
                   dbConnectionString = "${datumCache.dbConnectionString}"
+                  server.controlApiToken = "${toString datumCache.controlApiToken}"
                   server.port = ${toString datumCache.port}
                   ogmios.address = "ogmios"
                   ogmios.port = ${toString ogmios.port}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios";
-    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache";
+    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/54ad2964af07ea0370bf95c0fed71f60a778ead5";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables


### PR DESCRIPTION
Upgraded ODC to `54ad2964af07ea0370bf95c0fed71f60a778ead5` so that datum from datum hash is more stable.
