### PR TITLE
Fix forgotten Nami mention instead of CIP-30

### DIFF
--- a/src/QueryM/Utxos.purs
+++ b/src/QueryM/Utxos.purs
@@ -84,7 +84,7 @@ utxosAt addr = asks _.wallet >>= maybe (allUtxosAt addr) (utxosAtByWallet addr)
 
   cip30UtxosAt :: Address -> QueryM (Maybe UtxoM)
   cip30UtxosAt address = getWalletCollateral >>= maybe
-    (liftEffect $ throw "Nami wallet missing collateral")
+    (liftEffect $ throw "CIP-30 wallet missing collateral")
     \collateral' -> do
       let collateral = unwrap collateral'
       utxos' <- allUtxosAt address


### PR DESCRIPTION

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
