### PR TITLE
Parse `fault` ogmios responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `mkKeyWalletFromFile` helper to use `cardano-cli`-style `skey`s.
 - Removed `Contract.Wallet.mkGeroWallet` and `Contract.Wallet.mkNamiWallet` - `Aff` versions should be used instead.
 - Added `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
+- Improved error response handling for Ogmios
 
 ### Added
 

--- a/src/QueryM/JsonWsp.purs
+++ b/src/QueryM/JsonWsp.purs
@@ -8,8 +8,6 @@ module QueryM.JsonWsp
   , buildRequest
   , parseJsonWspResponse
   , parseJsonWspResponseId
-  , parseFieldToUInt
-  , parseFieldToBigInt
   ) where
 
 import Prelude
@@ -19,20 +17,16 @@ import Aeson
   , class EncodeAeson
   , Aeson
   , JsonDecodeError(TypeMismatch)
-  , caseAesonBigInt
   , caseAesonObject
   , caseAesonString
-  , caseAesonUInt
   , decodeAeson
   , encodeAeson
   , getField
   , getFieldOptional
   )
-import Data.BigInt as BigInt
-import Data.Either (Either(Left, Right))
+import Data.Either (Either(Left))
 import Data.Maybe (Maybe)
 import Data.Traversable (traverse)
-import Data.UInt as UInt
 import Effect (Effect)
 import Foreign.Object (Object)
 import QueryM.UniqueId (ListenerId, uniqueId)
@@ -150,33 +144,6 @@ aesonObject
 aesonObject = caseAesonObject (Left (TypeMismatch "expected object"))
 
 -- parsing json
-
--- | Parses a string at the given field to a UInt
-parseFieldToUInt :: Object Aeson -> String -> Either JsonDecodeError UInt.UInt
-parseFieldToUInt o str = do
-  -- We use string parsing for Ogmios (AffInterface tests) but also change Medea
-  -- schema and UtxoQueryResponse.json to be a string to pass (local) parsing
-  -- tests. Notice "index" is a string in our local example.
-  caseAesonUInt (Left err) Right =<< getField o str
-  where
-  err :: JsonDecodeError
-  err = TypeMismatch $ "expected field: '" <> str <> "' as a UInt"
-
--- -- The below doesn't seem to work with Ogmios query test (AffInterface)
--- -- eventhough it seems more reasonable.
--- num <- decodeNumber =<< getField o str
--- note err $ UInt.fromNumber' num
--- | Parses a string at the given field to a BigInt
-parseFieldToBigInt
-  :: Object Aeson -> String -> Either JsonDecodeError BigInt.BigInt
-parseFieldToBigInt o str = do
-  -- We use string parsing for Ogmios (AffInterface tests) but also change Medea
-  -- schema and UtxoQueryResponse.json to be a string to pass (local) parsing
-  -- tests. Notice "coins" is a string in our local example.
-  caseAesonBigInt (Left err) Right =<< getField o str
-  where
-  err :: JsonDecodeError
-  err = TypeMismatch $ "expected field: '" <> str <> "' as a BigInt"
 
 -- | A parser for the `Mirror` type.
 parseMirror :: Aeson -> Either JsonDecodeError ListenerId

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -99,8 +99,6 @@ import QueryM.JsonWsp
   ( JsonWspCall
   , JsonWspRequest
   , mkCallType
-  , parseFieldToBigInt
-  , parseFieldToUInt
   )
 import Serialization.BigNum as BigNum
 import Type.Proxy (Proxy(Proxy))
@@ -1064,7 +1062,7 @@ aesonArray = caseAesonArray (Left (TypeMismatch "Expected Array"))
 parseTxOutRef :: Aeson -> Either JsonDecodeError OgmiosTxOutRef
 parseTxOutRef = aesonObject $ \o -> do
   txId <- getField o "txId"
-  index <- parseFieldToUInt o "index"
+  index <- getField o "index"
   pure { txId, index }
 
 type OgmiosTxOut =
@@ -1087,7 +1085,7 @@ parseTxOut = aesonObject $ \o -> do
 parseValue :: Object Aeson -> Either JsonDecodeError Value
 parseValue outer = do
   o <- getField outer "value"
-  coins <- parseFieldToBigInt o "coins"
+  coins <- getField o "coins"
     <|> Left (TypeMismatch "Expected 'coins' to be an Int or a BigInt")
   Assets assetsMap <- fromMaybe (Assets Map.empty)
     <$> getFieldOptional o "assets"

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -100,7 +100,6 @@ import QueryM.JsonWsp
   , JsonWspRequest
   , mkCallType
   , parseFieldToBigInt
-  , parseFieldToString
   , parseFieldToUInt
   )
 import Serialization.BigNum as BigNum
@@ -1064,7 +1063,7 @@ aesonArray = caseAesonArray (Left (TypeMismatch "Expected Array"))
 -- parser for txOutRef
 parseTxOutRef :: Aeson -> Either JsonDecodeError OgmiosTxOutRef
 parseTxOutRef = aesonObject $ \o -> do
-  txId <- parseFieldToString o "txId"
+  txId <- getField o "txId"
   index <- parseFieldToUInt o "index"
   pure { txId, index }
 
@@ -1079,9 +1078,9 @@ type OgmiosTxOut =
 -- extracted.
 parseTxOut :: Aeson -> Either JsonDecodeError OgmiosTxOut
 parseTxOut = aesonObject $ \o -> do
-  address <- parseFieldToString o "address"
+  address <- getField o "address"
   value <- parseValue o
-  let datum = hush $ parseFieldToString o "datum"
+  let datum = hush $ getField o "datum"
   pure $ { address, value, datum }
 
 -- parses the `Value` type


### PR DESCRIPTION
Part of #479 related to Ogmios

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
