### PR TITLE
Update ODC, Use CLI options instead of config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,23 +16,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
-- `mkKeyWalletFromFile` helper to use `cardano-cli`-style `skey`s.
-- Removed `Contract.Wallet.mkGeroWallet` and `Contract.Wallet.mkNamiWallet` - `Aff` versions should be used instead.
-- Added `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
-- Updated `ogmios-datum-cache` to the recent revision
-
 ### Added
 
+- `mkKeyWalletFromFile` helper to use `cardano-cli`-style `skey`s.
 - Single `Plutus.Conversion` module exposing all `(Type <-> Plutus Type)` conversion functions.
 - Support for using a `PrivateKey` as a `Wallet`.
+- `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
 
 ### Removed
 
 - `FromPlutusType` / `ToPlutusType` type classes.
+- `Contract.Wallet.mkGeroWallet` and `Contract.Wallet.mkNamiWallet` - `Aff` versions should be used instead.
 
 ### Changed
 
-- Upgraded `ogmios-datum-cache` to `54ad2964af07ea0370bf95c0fed71f60a778ead5` for more stable datum from datum hash (see [here](https://github.com/Plutonomicon/cardano-transaction-lib/issues/526) for more details).
+- Updated `ogmios-datum-cache` - bug fixes (#542, #526).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `mkKeyWalletFromFile` helper to use `cardano-cli`-style `skey`s.
 - Removed `Contract.Wallet.mkGeroWallet` and `Contract.Wallet.mkNamiWallet` - `Aff` versions should be used instead.
 - Added `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
+- Updated `ogmios-datum-cache` to the recent revision
 
 ### Added
 

--- a/flake.lock
+++ b/flake.lock
@@ -1529,17 +1529,17 @@
         "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
-        "lastModified": 1655041544,
-        "narHash": "sha256-ZTftQtrivnugqHjsMrV0wxKLfnrDxSX0MXM1KUkf4R0=",
+        "lastModified": 1655907774,
+        "narHash": "sha256-MTP1y+4xMAW3slZbdeD2P8a7s+df98/pzQJBKFGzcm0=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "54ad2964af07ea0370bf95c0fed71f60a778ead5",
+        "rev": "aaacc6336cc7029f072e2e3945256a113435bfaf",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "54ad2964af07ea0370bf95c0fed71f60a778ead5",
+        "rev": "aaacc6336cc7029f072e2e3945256a113435bfaf",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1529,17 +1529,17 @@
         "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
-        "lastModified": 1655907774,
+        "lastModified": 1655911416,
         "narHash": "sha256-MTP1y+4xMAW3slZbdeD2P8a7s+df98/pzQJBKFGzcm0=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "aaacc6336cc7029f072e2e3945256a113435bfaf",
+        "rev": "1be5e903e14f5a1785983bdb38203195b401bd15",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "aaacc6336cc7029f072e2e3945256a113435bfaf",
+        "rev": "1be5e903e14f5a1785983bdb38203195b401bd15",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios";
-    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/aaacc6336cc7029f072e2e3945256a113435bfaf";
+    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/1be5e903e14f5a1785983bdb38203195b401bd15";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios";
-    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/54ad2964af07ea0370bf95c0fed71f60a778ead5";
+    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/aaacc6336cc7029f072e2e3945256a113435bfaf";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables
@@ -187,15 +187,6 @@
         };
         datumCache = {
           port = 9999;
-          dbConnectionString = nixpkgs.lib.concatStringsSep
-            " "
-            [
-              "host=postgres"
-              "port=5432"
-              "user=${postgres.user}"
-              "dbname=${postgres.db}"
-              "password=${postgres.password}"
-            ];
           controlApiToken = "";
           blockFetcher = {
             firstBlock = {
@@ -317,17 +308,6 @@
                 filter = nixpkgs.lib.strings.replaceStrings
                   [ "\"" "\\" ] [ "\\\"" "\\\\" ]
                   datumCache.blockFetcher.filter;
-                configFile = ''
-                  dbConnectionString = "${datumCache.dbConnectionString}"
-                  server.controlApiToken = "${toString datumCache.controlApiToken}"
-                  server.port = ${toString datumCache.port}
-                  ogmios.address = "ogmios"
-                  ogmios.port = ${toString ogmios.port}
-                  blockFetcher.autoStart = ${nixpkgs.lib.boolToString datumCache.blockFetcher.autoStart}
-                  blockFetcher.firstBlock.slot = ${toString datumCache.blockFetcher.firstBlock.slot}
-                  blockFetcher.firstBlock.id = "${datumCache.blockFetcher.firstBlock.id}"
-                  blockFetcher.filter = "${filter}"
-                '';
               in
               {
                 service = {
@@ -339,11 +319,19 @@
                     "${pkgs.bash}/bin/sh"
                     "-c"
                     ''
-                      ${pkgs.coreutils}/bin/cat <<EOF > config.toml
-                        ${configFile}
-                      EOF
-                      ${pkgs.coreutils}/bin/sleep 1
-                      ${pkgs.ogmios-datum-cache}/bin/ogmios-datum-cache
+                      ${pkgs.ogmios-datum-cache}/bin/ogmios-datum-cache \
+                        --server-api "${toString datumCache.controlApiToken}" \
+                        --server-port ${toString datumCache.port} \
+                        --ogmios-address ogmios \
+                        --ogmios-port ${toString ogmios.port} \
+                        --db-port 5432 \
+                        --db-host postgres \
+                        --db-user "${postgres.user}" \
+                        --db-name "${postgres.db}" \
+                        --db-password "${postgres.password}" \
+                        --block-slot ${toString datumCache.blockFetcher.firstBlock.slot} \
+                        --block-hash "${datumCache.blockFetcher.firstBlock.id}" \
+                        --block-filter "${filter}"
                     ''
                   ];
                 };


### PR DESCRIPTION
Closes #583

Waiting for https://github.com/mlabs-haskell/ogmios-datum-cache/pull/87 to be merged to update the revision 

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
