### PR TITLE
Change from vasil-qa to vasil-dev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,15 +289,15 @@
     "cardano-configurations": {
       "flake": false,
       "locked": {
-        "lastModified": 1654780718,
-        "narHash": "sha256-r/PkeY5SeboTdYkFWK85orefwvycM1BletOxENkisFc=",
-        "owner": "jy14898",
+        "lastModified": 1655361562,
+        "narHash": "sha256-b/z5RSgqTMQpEUSD4nbrBAr86PcQs+n6EMtn/YPeyj4=",
+        "owner": "input-output-hk",
         "repo": "cardano-configurations",
-        "rev": "865cdc6f245b603da21f137d2582a5b89f570e66",
+        "rev": "08e6c0572d5d48049fab521995b29607e0a91a9e",
         "type": "github"
       },
       "original": {
-        "owner": "jy14898",
+        "owner": "input-output-hk",
         "repo": "cardano-configurations",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,7 @@
     # Repository with network parameters
     cardano-configurations = {
       # Override with "path:/path/to/cardano-configurations";
-      # TODO: https://github.com/Plutonomicon/cardano-transaction-lib/issues/525
-      #       Switch to official when it's updated
-      # url = "github:input-output-hk/cardano-configurations/chore/vasil-qa";
-      url = "github:jy14898/cardano-configurations";
+      url = "github:input-output-hk/cardano-configurations";
       flake = false;
     };
     easy-purescript-nix = {
@@ -172,7 +169,7 @@
       defaultConfig = final: with final; {
         inherit (inputs) cardano-configurations;
         network = {
-          name = "vasil-qa";
+          name = "vasil-dev";
           magic = 9; # use `null` for mainnet
         };
         node = { port = 3001; };
@@ -239,7 +236,7 @@
           services = {
             cardano-node = {
               service = {
-                image = "inputoutput/cardano-node:1.35.0-rc1";
+                image = "inputoutput/cardano-node:1.35.0-rc4";
                 ports = [ (bindPort node.port) ];
                 volumes = [
                   "${config.cardano-configurations}/network/${config.network.name}/cardano-node:/config"


### PR DESCRIPTION
Closes #525, also upgrades the node docker image to the latest release candidate.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
