### PR TITLE
Better handling of first-time WS connections + Fix reconnecting behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Removed `Contract.Wallet.mkGeroWallet` and `Contract.Wallet.mkNamiWallet` - `Aff` versions should be used instead.
 - Added `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
 - Improved error response handling for Ogmios
+- Improved WebSocket UX: first connection error now leads to termination. Fixed automatic reconnection of WebSockets (#591)
 
 ### Added
 

--- a/flake.nix
+++ b/flake.nix
@@ -199,8 +199,8 @@
           controlApiToken = "";
           blockFetcher = {
             firstBlock = {
-              slot = 54066900;
-              id = "6eb2542a85f375d5fd6cbc1c768707b0e9fe8be85b7b1dd42a85017a70d2623d";
+              slot = 61625527;
+              id = "3afd8895c7b270f8250b744ec8d2b3c53ee2859c9d5711d906c47fe51b800988";
             };
             autoStart = true;
             startFromLast = false;

--- a/src/JsWebSocket.js
+++ b/src/JsWebSocket.js
@@ -32,16 +32,21 @@ exports._mkWebSocket = logger => url => () => {
   return ws;
 };
 
-// _onWsConnect :: WebSocket -> (Unit -> Effect Unit) -> Effect Unit
+// _onWsConnect :: WebSocket -> (Unit -> Effect Unit) -> Effect ListenerRef
 exports._onWsConnect = ws => fn => () => {
   ws.addEventListener('open', fn);
+  return fn;
 };
+
+// _removeOnWsConnect :: JsWebSocket -> ListenerRef -> Effect Unit
+exports._removeOnWsConnect = ws => listener => () =>
+  ws.removeEventListener('open', listener);
 
 // _onWsError
 //   :: WebSocket
 //   -> (String -> Effect Unit) -- logger
 //   -> (String -> Effect Unit) -- handler
-//   -> Effect Listener
+//   -> Effect ListenerRef
 exports._onWsError = ws => logger => fn => () => {
   const listener = function (event) {
     const str = event.toString();
@@ -57,7 +62,7 @@ exports._onWsError = ws => logger => fn => () => {
 //  -> ListenerRef
 //  -> Effect Unit
 exports._removeOnWsError = ws => listener => () =>
-  ws.removeEventListener(listener);
+  ws.removeEventListener('error', listener);
 
 
 // _onWsMessage

--- a/src/JsWebSocket.js
+++ b/src/JsWebSocket.js
@@ -36,7 +36,7 @@ exports._mkWebSocket = logger => url => () => {
   };
 };
 
-// _onWsConnect :: WebSocket -> (Unit -> Effect Unit) -> Effect ListenerRef
+// _onWsConnect :: WebSocket -> (Unit -> Effect Unit) -> Effect Unit
 exports._onWsConnect = ws => fn => () =>
   ws.addEventListener('open', fn);
 
@@ -61,7 +61,6 @@ exports._onWsError = ws => logger => fn => () => {
 //  -> Effect Unit
 exports._removeOnWsError = ws => listener => () =>
   ws.removeEventListener('error', listener);
-
 
 // _onWsMessage
 //   :: WebSocket

--- a/src/JsWebSocket.purs
+++ b/src/JsWebSocket.purs
@@ -9,6 +9,7 @@ module JsWebSocket
   , _onWsMessage
   , _wsSend
   , _wsReconnect
+  , _removeOnWsConnect
   , _wsClose
   , _wsWatch
   ) where
@@ -32,7 +33,10 @@ foreign import _mkWebSocket
   -> Url
   -> Effect JsWebSocket
 
-foreign import _onWsConnect :: JsWebSocket -> (Effect Unit) -> Effect Unit
+foreign import _onWsConnect
+  :: JsWebSocket -> (Effect Unit) -> Effect ListenerRef
+
+foreign import _removeOnWsConnect :: JsWebSocket -> ListenerRef -> Effect Unit
 
 foreign import _onWsMessage
   :: JsWebSocket

--- a/src/JsWebSocket.purs
+++ b/src/JsWebSocket.purs
@@ -9,7 +9,6 @@ module JsWebSocket
   , _onWsMessage
   , _wsSend
   , _wsReconnect
-  , _removeOnWsConnect
   , _wsClose
   , _wsWatch
   ) where
@@ -34,9 +33,7 @@ foreign import _mkWebSocket
   -> Effect JsWebSocket
 
 foreign import _onWsConnect
-  :: JsWebSocket -> (Effect Unit) -> Effect ListenerRef
-
-foreign import _removeOnWsConnect :: JsWebSocket -> ListenerRef -> Effect Unit
+  :: JsWebSocket -> (Effect Unit) -> Effect Unit
 
 foreign import _onWsMessage
   :: JsWebSocket

--- a/src/JsWebSocket.purs
+++ b/src/JsWebSocket.purs
@@ -1,11 +1,14 @@
 module JsWebSocket
   ( JsWebSocket
+  , ListenerRef
   , Url
   , _mkWebSocket
   , _onWsConnect
   , _onWsError
+  , _removeOnWsError
   , _onWsMessage
   , _wsSend
+  , _wsReconnect
   , _wsClose
   , _wsWatch
   ) where
@@ -18,6 +21,9 @@ import Effect (Effect)
 -- Websocket Basics
 --------------------------------------------------------------------------------
 foreign import data JsWebSocket :: Type
+
+-- | Opaque listener reference that allows to cancel a listener
+foreign import data ListenerRef :: Type
 
 type Url = String
 
@@ -38,10 +44,19 @@ foreign import _onWsError
   :: JsWebSocket
   -> (String -> Effect Unit) -- logger
   -> (String -> Effect Unit) -- handler
+  -> Effect ListenerRef
+
+-- | Call `removeEventListener` for a given listener.
+foreign import _removeOnWsError
+  :: JsWebSocket
+  -> ListenerRef
   -> Effect Unit
 
 foreign import _wsSend
   :: JsWebSocket -> (String -> Effect Unit) -> String -> Effect Unit
+
+foreign import _wsReconnect
+  :: JsWebSocket -> Effect Unit
 
 foreign import _wsClose :: JsWebSocket -> Effect Unit
 


### PR DESCRIPTION
Closes #591 

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
