### PR TITLE
get rid of needing docker for launching ctl-runtime-deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2594,18 +2594,14 @@
         ]
       },
       "locked": {
-        "lastModified": 1654880012,
-        "narHash": "sha256-dNKFrjKGs0OwrXWd3eiPZVKgINIDQjdCDWX5nT6/wHA=",
-        "owner": "mlabs-haskell",
-        "repo": "plutip",
-        "rev": "ab17dc2a4828d72570ee91770c8a75b849c15144",
-        "type": "github"
+        "lastModified": 1656331256,
+        "narHash": "sha256-WQSFSCA2BJUquvxZruIr2gm2WN9Rm6lc/1Sbst+Abuw=",
+        "path": "/home/marijan/workspace/platonic-systems/plutip",
+        "type": "path"
       },
       "original": {
-        "owner": "mlabs-haskell",
-        "ref": "plutip-server",
-        "repo": "plutip",
-        "type": "github"
+        "path": "/home/marijan/workspace/platonic-systems/plutip",
+        "type": "path"
       }
     },
     "plutus": {

--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,38 @@
         "type": "github"
       }
     },
+    "HTTP_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "Win32-network": {
       "flake": false,
       "locked": {
@@ -79,6 +111,68 @@
         "owner": "input-output-hk",
         "repo": "Win32-network",
         "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "type": "github"
+      }
+    },
+    "Win32-network_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627315969,
+        "narHash": "sha256-Hesb5GXSx0IwKSIi42ofisVELcQNX6lwHcoZcbaDiqc=",
+        "owner": "input-output-hk",
+        "repo": "Win32-network",
+        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "Win32-network",
+        "rev": "3825d3abf75f83f406c1f7161883c438dac7277d",
+        "type": "github"
+      }
+    },
+    "bot-plutus-interface": {
+      "inputs": {
+        "Win32-network": "Win32-network_3",
+        "cardano-addresses": "cardano-addresses_2",
+        "cardano-base": "cardano-base_3",
+        "cardano-config": "cardano-config_2",
+        "cardano-crypto": "cardano-crypto_3",
+        "cardano-ledger": "cardano-ledger_3",
+        "cardano-node": "cardano-node_3",
+        "cardano-prelude": "cardano-prelude_3",
+        "cardano-wallet": "cardano-wallet_2",
+        "flake-compat": "flake-compat_4",
+        "flat": "flat_3",
+        "goblins": "goblins_3",
+        "haskell-nix": "haskell-nix_3",
+        "iohk-monitoring-framework": "iohk-monitoring-framework_3",
+        "iohk-nix": "iohk-nix_2",
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "optparse-applicative": "optparse-applicative_2",
+        "ouroboros-network": "ouroboros-network_3",
+        "plutus": "plutus_2",
+        "plutus-apps": "plutus-apps",
+        "purescript-bridge": "purescript-bridge",
+        "servant-purescript": "servant-purescript"
+      },
+      "locked": {
+        "lastModified": 1651488509,
+        "narHash": "sha256-WVTYecS6UY0rcxofYj6gBe9yag7Lo63pu/VsC9iyqqs=",
+        "owner": "mlabs-haskell",
+        "repo": "bot-plutus-interface",
+        "rev": "9ca5939b3b6ef1d052318f25ac88444baea52d8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "repo": "bot-plutus-interface",
+        "rev": "9ca5939b3b6ef1d052318f25ac88444baea52d8b",
         "type": "github"
       }
     },
@@ -117,6 +211,40 @@
       }
     },
     "cabal-32_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_5": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -184,6 +312,40 @@
         "type": "github"
       }
     },
+    "cabal-34_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
       "flake": false,
       "locked": {
@@ -218,6 +380,23 @@
         "type": "github"
       }
     },
+    "cabal-36_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cardano-addresses": {
       "flake": false,
       "locked": {
@@ -232,6 +411,23 @@
         "owner": "input-output-hk",
         "repo": "cardano-addresses",
         "rev": "d2f86caa085402a953920c6714a0de6a50b655ec",
+        "type": "github"
+      }
+    },
+    "cardano-addresses_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639584472,
+        "narHash": "sha256-Eyu7PVYk1oQLp/Hd43S2PW+PojyAT/Rr48Xng6sbtIU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-addresses",
+        "rev": "71006f9eb956b0004022e80aadd4ad50d837b621",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-addresses",
+        "rev": "71006f9eb956b0004022e80aadd4ad50d837b621",
         "type": "github"
       }
     },
@@ -269,6 +465,23 @@
         "type": "github"
       }
     },
+    "cardano-base_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635841753,
+        "narHash": "sha256-OXKsJ1UTj5kJ9xaThM54ZmxFAiFINTPKd4JQa4dPmEU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "41545ba3ac6b3095966316a99883d678b5ab8da8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "41545ba3ac6b3095966316a99883d678b5ab8da8",
+        "type": "github"
+      }
+    },
     "cardano-config": {
       "flake": false,
       "locked": {
@@ -283,6 +496,23 @@
         "owner": "input-output-hk",
         "repo": "cardano-config",
         "rev": "fe7855e981072d392513f9cf3994e0b6eba40d7d",
+        "type": "github"
+      }
+    },
+    "cardano-config_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634339627,
+        "narHash": "sha256-jQbwcfNJ8am7Q3W+hmTFmyo3wp3QItquEH//klNiofI=",
+        "owner": "input-output-hk",
+        "repo": "cardano-config",
+        "rev": "e9de7a2cf70796f6ff26eac9f9540184ded0e4e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-config",
+        "rev": "e9de7a2cf70796f6ff26eac9f9540184ded0e4e6",
         "type": "github"
       }
     },
@@ -336,6 +566,23 @@
         "type": "github"
       }
     },
+    "cardano-crypto_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1604244485,
+        "narHash": "sha256-2Fipex/WjIRMrvx6F3hjJoAeMtFd2wGnZECT0kuIB9k=",
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "f73079303f663e028288f9f4a9e08bcca39a923e",
+        "type": "github"
+      }
+    },
     "cardano-ledger": {
       "flake": false,
       "locked": {
@@ -354,6 +601,23 @@
       }
     },
     "cardano-ledger_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639498285,
+        "narHash": "sha256-lRNfkGMHnpPO0T19FZY5BnuRkr0zTRZIkxZVgHH0fys=",
+        "owner": "input-output-hk",
+        "repo": "cardano-ledger",
+        "rev": "1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-ledger",
+        "rev": "1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5",
+        "type": "github"
+      }
+    },
+    "cardano-ledger_3": {
       "flake": false,
       "locked": {
         "lastModified": 1639498285,
@@ -431,6 +695,35 @@
         "type": "github"
       }
     },
+    "cardano-node_3": {
+      "inputs": {
+        "customConfig": "customConfig_2",
+        "haskellNix": "haskellNix_2",
+        "iohkNix": "iohkNix_2",
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "cardano-node",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1640022647,
+        "narHash": "sha256-M+YnF7Zj/7QK2pu0T75xNVaX0eEeijtBH8yz+jEHIMM=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "814df2c146f5d56f8c35a681fe75e85b905aed5d",
+        "type": "github"
+      }
+    },
     "cardano-prelude": {
       "flake": false,
       "locked": {
@@ -449,6 +742,23 @@
       }
     },
     "cardano-prelude_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1617089317,
+        "narHash": "sha256-kgX3DKyfjBb8/XcDEd+/adlETsFlp5sCSurHWgsFAQI=",
+        "owner": "input-output-hk",
+        "repo": "cardano-prelude",
+        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-prelude",
+        "rev": "bb4ed71ba8e587f672d06edf9d2e376f4b055555",
+        "type": "github"
+      }
+    },
+    "cardano-prelude_3": {
       "flake": false,
       "locked": {
         "lastModified": 1617089317,
@@ -513,6 +823,38 @@
         "type": "github"
       }
     },
+    "cardano-shell_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
     "cardano-wallet": {
       "flake": false,
       "locked": {
@@ -530,7 +872,39 @@
         "type": "github"
       }
     },
+    "cardano-wallet_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1642494510,
+        "narHash": "sha256-A3im2IkoumUx3NzgPooaXGC18/iYxbEooMa9ho93/6o=",
+        "owner": "input-output-hk",
+        "repo": "cardano-wallet",
+        "rev": "a5085acbd2670c24251cf8d76a4e83c77a2679ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-wallet",
+        "rev": "a5085acbd2670c24251cf8d76a4e83c77a2679ba",
+        "type": "github"
+      }
+    },
     "customConfig": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_2": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -626,6 +1000,38 @@
         "type": "github"
       }
     },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -671,6 +1077,36 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flat": {
       "flake": false,
       "locked": {
@@ -689,6 +1125,23 @@
       }
     },
     "flat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1628771504,
+        "narHash": "sha256-lRFND+ZnZvAph6ZYkr9wl9VAx41pb3uSFP8Wc7idP9M=",
+        "owner": "input-output-hk",
+        "repo": "flat",
+        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flat",
+        "rev": "ee59880f47ab835dbd73bea0847dab7869fc20d8",
+        "type": "github"
+      }
+    },
+    "flat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1628771504,
@@ -756,6 +1209,40 @@
         "type": "github"
       }
     },
+    "ghc-8.6.5-iohk_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
     "goblins": {
       "flake": false,
       "locked": {
@@ -774,6 +1261,23 @@
       }
     },
     "goblins_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1598362523,
+        "narHash": "sha256-z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=",
+        "owner": "input-output-hk",
+        "repo": "goblins",
+        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "goblins",
+        "rev": "cde90a2b27f79187ca8310b6549331e59595e7ba",
+        "type": "github"
+      }
+    },
+    "goblins_3": {
       "flake": false,
       "locked": {
         "lastModified": 1598362523,
@@ -823,6 +1327,38 @@
       }
     },
     "hackage_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644887696,
+        "narHash": "sha256-o4gltv4npUl7+1gEQIcrRqZniwqC9kK8QsPaftlrawc=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6ff64aa49b88e75dd6e0bbd2823c2a92c9174fa5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_5": {
       "flake": false,
       "locked": {
         "lastModified": 1644887696,
@@ -916,6 +1452,45 @@
         "type": "github"
       }
     },
+    "haskell-nix_3": {
+      "inputs": {
+        "HTTP": "HTTP_5",
+        "cabal-32": "cabal-32_5",
+        "cabal-34": "cabal-34_5",
+        "cabal-36": "cabal-36_3",
+        "cardano-shell": "cardano-shell_5",
+        "flake-utils": "flake-utils_5",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
+        "hackage": "hackage_5",
+        "hpc-coveralls": "hpc-coveralls_5",
+        "nix-tools": "nix-tools_5",
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_5",
+        "nixpkgs-2105": "nixpkgs-2105_5",
+        "nixpkgs-2111": "nixpkgs-2111_4",
+        "nixpkgs-unstable": "nixpkgs-unstable_5",
+        "old-ghc-nix": "old-ghc-nix_5",
+        "stackage": "stackage_5"
+      },
+      "locked": {
+        "lastModified": 1644944726,
+        "narHash": "sha256-jJWdP/3Ne1y1akC3m9rSO5ItRoBc4UTdVQZBCuPmmrM=",
+        "owner": "L-as",
+        "repo": "haskell.nix",
+        "rev": "45c583b5580c130487eb5a342679f0bdbc2b23fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "L-as",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
@@ -944,6 +1519,44 @@
         "owner": "input-output-hk",
         "repo": "haskell.nix",
         "rev": "19052d83fda811dd39216e3fc197c980abd037fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_2": {
+      "inputs": {
+        "HTTP": "HTTP_4",
+        "cabal-32": "cabal-32_4",
+        "cabal-34": "cabal-34_4",
+        "cardano-shell": "cardano-shell_4",
+        "flake-utils": "flake-utils_4",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
+        "hackage": "hackage_4",
+        "hpc-coveralls": "hpc-coveralls_4",
+        "nix-tools": "nix-tools_4",
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "cardano-node",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_4",
+        "nixpkgs-2105": "nixpkgs-2105_4",
+        "nixpkgs-2111": "nixpkgs-2111_3",
+        "nixpkgs-unstable": "nixpkgs-unstable_4",
+        "old-ghc-nix": "old-ghc-nix_4",
+        "stackage": "stackage_4"
+      },
+      "locked": {
+        "lastModified": 1639098904,
+        "narHash": "sha256-7VrCNEaKGLm4pTOS11dt1dRL2033oqrNCfal0uONsqA=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "b18c6ce0867fee77f12ecf41dc6c67f7a59d9826",
         "type": "github"
       },
       "original": {
@@ -1051,6 +1664,38 @@
         "type": "github"
       }
     },
+    "hpc-coveralls_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
     "hydra": {
       "inputs": {
         "nix": "nix",
@@ -1108,6 +1753,23 @@
         "type": "github"
       }
     },
+    "iohk-monitoring-framework_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624367860,
+        "narHash": "sha256-QE3QRpIHIABm+qCP/wP4epbUx0JmSJ9BMePqWEd3iMY=",
+        "owner": "input-output-hk",
+        "repo": "iohk-monitoring-framework",
+        "rev": "46f994e216a1f8b36fe4669b47b2a7011b0e153c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-monitoring-framework",
+        "rev": "46f994e216a1f8b36fe4669b47b2a7011b0e153c",
+        "type": "github"
+      }
+    },
     "iohk-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
@@ -1118,6 +1780,22 @@
         "owner": "input-output-hk",
         "repo": "iohk-nix",
         "rev": "cecab9c71d1064f05f1615eead56ac0b9196bc20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohk-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643251385,
+        "narHash": "sha256-Czbd69lg0ARSZfC18V6h+gtPMioWDAEVPbiHgL2x9LM=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "9d6ee3dcb3482f791e40ed991ad6fc649b343ad4",
         "type": "github"
       },
       "original": {
@@ -1139,6 +1817,29 @@
         "owner": "input-output-hk",
         "repo": "iohk-nix",
         "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "cardano-node",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1633964277,
+        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
         "type": "github"
       },
       "original": {
@@ -1232,6 +1933,38 @@
         "type": "github"
       }
     },
+    "nix-tools_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1632864508,
@@ -1280,6 +2013,38 @@
       }
     },
     "nixpkgs-2003_3": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_4": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_5": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -1359,6 +2124,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-2105_4": {
+      "locked": {
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_5": {
+      "locked": {
+        "lastModified": 1642244250,
+        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2111": {
       "locked": {
         "lastModified": 1648744337,
@@ -1376,6 +2173,38 @@
       }
     },
     "nixpkgs-2111_2": {
+      "locked": {
+        "lastModified": 1644510859,
+        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_3": {
+      "locked": {
+        "lastModified": 1638410074,
+        "narHash": "sha256-MQYI4k4XkoTzpeRjq5wl+1NShsl1CKq8MISFuZ81sWs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b80f23502f8e902612a8c631dfce383e1c56596",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_4": {
       "locked": {
         "lastModified": 1644510859,
         "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
@@ -1439,6 +2268,38 @@
       }
     },
     "nixpkgs-unstable_3": {
+      "locked": {
+        "lastModified": 1644486793,
+        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_4": {
+      "locked": {
+        "lastModified": 1635295995,
+        "narHash": "sha256-sGYiXjFlxTTMNb4NSkgvX+knOOTipE6gqwPUQpxNF+c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "22a500a3f87bbce73bd8d777ef920b43a636f018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_5": {
       "locked": {
         "lastModified": 1644486793,
         "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
@@ -1592,7 +2453,58 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "optparse-applicative": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1628901899,
+        "narHash": "sha256-uQx+SEYsCH7JcG3xAT0eJck9yq3y0cvx49bvItLLer8=",
+        "owner": "input-output-hk",
+        "repo": "optparse-applicative",
+        "rev": "7497a29cb998721a9068d5725d49461f2bba0e7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "optparse-applicative",
+        "rev": "7497a29cb998721a9068d5725d49461f2bba0e7a",
+        "type": "github"
+      }
+    },
+    "optparse-applicative_2": {
       "flake": false,
       "locked": {
         "lastModified": 1628901899,
@@ -1643,6 +2555,59 @@
         "type": "github"
       }
     },
+    "ouroboros-network_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639752881,
+        "narHash": "sha256-fZ6FfG2z6HWDxjIHycLPSQHoYtfUmWZOX7lfAUE+s6M=",
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "d2d219a86cda42787325bb8c20539a75c2667132",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ouroboros-network",
+        "rev": "d2d219a86cda42787325bb8c20539a75c2667132",
+        "type": "github"
+      }
+    },
+    "plutip": {
+      "inputs": {
+        "bot-plutus-interface": "bot-plutus-interface",
+        "flake-compat": "flake-compat_5",
+        "haskell-nix": [
+          "plutip",
+          "bot-plutus-interface",
+          "haskell-nix"
+        ],
+        "iohk-nix": [
+          "plutip",
+          "bot-plutus-interface",
+          "iohk-nix"
+        ],
+        "nixpkgs": [
+          "plutip",
+          "bot-plutus-interface",
+          "haskell-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1654880012,
+        "narHash": "sha256-dNKFrjKGs0OwrXWd3eiPZVKgINIDQjdCDWX5nT6/wHA=",
+        "owner": "mlabs-haskell",
+        "repo": "plutip",
+        "rev": "ab17dc2a4828d72570ee91770c8a75b849c15144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "ref": "plutip-server",
+        "repo": "plutip",
+        "type": "github"
+      }
+    },
     "plutus": {
       "flake": false,
       "locked": {
@@ -1660,7 +2625,41 @@
         "type": "github"
       }
     },
+    "plutus-apps": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644841368,
+        "narHash": "sha256-OX4+S7fFUqXRz935wQqdcEm1I6aqg0udSdP19XJtSAk=",
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "7f543e21d4945a2024e46c572303b9c1684a5832",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "7f543e21d4945a2024e46c572303b9c1684a5832",
+        "type": "github"
+      }
+    },
     "plutus_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1642505687,
+        "narHash": "sha256-Pl3M9rMEoiEKRsTdDr4JwNnRo5Xs4uN66uVpOfaMCfE=",
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "cc72a56eafb02333c96f662581b57504f8f8992f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "cc72a56eafb02333c96f662581b57504f8f8992f",
+        "type": "github"
+      }
+    },
+    "plutus_3": {
       "flake": false,
       "locked": {
         "lastModified": 1632818067,
@@ -1678,6 +2677,23 @@
       }
     },
     "purescript-bridge": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1642802224,
+        "narHash": "sha256-/SbnmXrB9Y2rrPd6E79Iu5RDaKAKozIl685HQ4XdQTU=",
+        "owner": "input-output-hk",
+        "repo": "purescript-bridge",
+        "rev": "47a1f11825a0f9445e0f98792f79172efef66c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "purescript-bridge",
+        "rev": "47a1f11825a0f9445e0f98792f79172efef66c00",
+        "type": "github"
+      }
+    },
+    "purescript-bridge_2": {
       "flake": false,
       "locked": {
         "lastModified": 1612544328,
@@ -1723,12 +2739,30 @@
         "ogmios-datum-cache": "ogmios-datum-cache",
         "optparse-applicative": "optparse-applicative",
         "ouroboros-network": "ouroboros-network_2",
-        "plutus": "plutus_2",
-        "purescript-bridge": "purescript-bridge",
-        "servant-purescript": "servant-purescript"
+        "plutip": "plutip",
+        "plutus": "plutus_3",
+        "purescript-bridge": "purescript-bridge_2",
+        "servant-purescript": "servant-purescript_2"
       }
     },
     "servant-purescript": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1642798070,
+        "narHash": "sha256-DH9ISydu5gxvN4xBuoXVv1OhYCaqGOtzWlACdJ0H64I=",
+        "owner": "input-output-hk",
+        "repo": "servant-purescript",
+        "rev": "44e7cacf109f84984cd99cd3faf185d161826963",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "servant-purescript",
+        "rev": "44e7cacf109f84984cd99cd3faf185d161826963",
+        "type": "github"
+      }
+    },
+    "servant-purescript_2": {
       "flake": false,
       "locked": {
         "lastModified": 1612956215,
@@ -1793,6 +2827,38 @@
         "type": "github"
       }
     },
+    "stackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639012797,
+        "narHash": "sha256-hiLyBa5XFBvxD+BcYPKyYd/0dNMccxAuywFNqYtIIvs=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "9ea6ea359da91c75a71e334b25aa7dc5ddc4b2c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644887829,
+        "narHash": "sha256-tjUXJpqB7MMnqM4FF5cdtZipfratUcTKRQVA6F77sEQ=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "db8bdef6588cf4f38e6069075ba76f0024381f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
     "utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -1800,6 +2866,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -475,7 +475,7 @@
           # test. This will need to be run via a Hercules `effect`
           checks = {
             ctl-unit-test = project.runPursTest {
-              testMain = "Test.Unit";
+              testMain = "CTL.Test.Unit";
               sources = [ "src" "test" "fixtures" ];
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,7 @@
             shell = {
               packages = [
                 (hsProjectFor system).hsPkgs.ctl-server.components.exes.ctl-server
+                pkgs.postgresql
                 pkgs.ogmios
                 pkgs.cardano-cli
                 pkgs.ogmios-datum-cache

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios";
     ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache";
+    plutip.url = "github:mlabs-haskell/plutip/plutip-server";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables
@@ -149,6 +150,7 @@
         ogmios-datum-cache =
           inputs.ogmios-datum-cache.defaultPackage.${system};
         ogmios = ogmios.packages.${system}."ogmios:exe:ogmios";
+        plutip-server = inputs.plutip.packages.${system}."plutip:exe:plutip-server";
         cardano-cli = cardano-node-exe.packages.${system}.cardano-cli;
         purescriptProject = import ./nix { inherit system; pkgs = prev; };
         buildCtlRuntime = buildCtlRuntime system;
@@ -422,6 +424,7 @@
                 pkgs.ogmios
                 pkgs.cardano-cli
                 pkgs.ogmios-datum-cache
+                pkgs.plutip-server
                 pkgs.nixpkgs-fmt
                 pkgs.fd
                 pkgs.arion

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "npm run unit-test && npm run integration-test",
     "integration-test": "spago run --main Test.Integration",
-    "unit-test": "spago run --main Test.Unit",
+    "unit-test": "spago run --main CTL.Test.Unit",
     "dev": "make run-dev",
     "build": "make run-build"
   },

--- a/spago-packages.nix
+++ b/spago-packages.nix
@@ -53,6 +53,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "aff-retry" = pkgs.stdenv.mkDerivation {
+        name = "aff-retry";
+        version = "v1.2.1";
+        src = pkgs.fetchgit {
+          url = "https://github.com/Unisay/purescript-aff-retry.git";
+          rev = "936fad803e3610f149df724ead288657a905cb84";
+          sha256 = "08651ly153ywzviab0ipd0zrhwdr8nz4xfym45dlpbgabgrh8pra";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "affjax" = pkgs.stdenv.mkDerivation {
         name = "affjax";
         version = "v12.0.0";
@@ -552,6 +564,18 @@ let
           url = "https://github.com/purescript-contrib/purescript-js-date.git";
           rev = "a6834eef986e3af0490cb672dc4a8b4b089dcb15";
           sha256 = "1dpiwn65qww862ilpfbd06gwfazpxvz3jwvsjsdrcxqqfcbjp8n8";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
+    "js-timers" = pkgs.stdenv.mkDerivation {
+        name = "js-timers";
+        version = "v5.0.1";
+        src = pkgs.fetchgit {
+          url = "https://github.com/purescript-contrib/purescript-js-timers.git";
+          rev = "86afef13f457b9506acdfe88559ee18f1cd2c2d8";
+          sha256 = "0008paz0qkz5n1pfrzagkkac6jny9z2rd1ij10ww2k1pkb9cy59z";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";
@@ -1176,6 +1200,18 @@ let
           url = "https://github.com/purescript/purescript-tailrec.git";
           rev = "5fbf0ac05dc6ab1a228b2897630195eb7483b962";
           sha256 = "1jjl2q2hyhjcdxpamzr1cdlxhmq2bl170x5p3jajb9zgwkqx0x22";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
+    "test-unit" = pkgs.stdenv.mkDerivation {
+        name = "test-unit";
+        version = "v16.0.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/bodil/purescript-test-unit.git";
+          rev = "56d06897b621df5d2f619433d19ababb5bb8ebd1";
+          sha256 = "0qz903phxkgrn7qdz1xi49bydkf5cbxssyb4xk029zi4lshb35mw";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";

--- a/spago.dhall
+++ b/spago.dhall
@@ -50,6 +50,7 @@ You can edit this file as you like.
   , "prelude"
   , "profunctor"
   , "profunctor-lenses"
+  , "aff-retry"
   , "quickcheck"
   , "quickcheck-laws"
   , "rationals"

--- a/src/Plutip/Server.purs
+++ b/src/Plutip/Server.purs
@@ -42,10 +42,8 @@ import Effect.Aff.Retry
   , recovering
   )
 import Effect.Class (liftEffect)
-import Effect.Console (log)
 import Effect.Exception (throw)
 import Helpers (fromJustEff, fromRightEff)
-import Node.Buffer as Bf
 import Node.ChildProcess
   ( ChildProcess
   , defaultExecSyncOptions
@@ -231,7 +229,7 @@ startPostgresServer pgConfig _ = do
             <> " -d postgres"
         )
         defaultExecSyncOptions
-  liftEffect $ log =<< Bf.toString Encoding.UTF8 =<< execSync
+  liftEffect $ void $ execSync
     ( "psql -h " <> pgConfig.host <> " -p " <> UInt.toString pgConfig.port
         <> " -d postgres"
         <> " -c \"CREATE ROLE "
@@ -241,7 +239,7 @@ startPostgresServer pgConfig _ = do
         <> "';\""
     )
     defaultExecSyncOptions
-  liftEffect $ log =<< Bf.toString Encoding.UTF8 =<< execSync
+  liftEffect $ void $ execSync
     ( "createdb -h " <> pgConfig.host <> " -p " <> UInt.toString pgConfig.port
         <> " -U "
         <> pgConfig.user

--- a/src/Plutip/Server.purs
+++ b/src/Plutip/Server.purs
@@ -231,7 +231,6 @@ startPostgresServer pgConfig _ = do
             <> " -d postgres"
         )
         defaultExecSyncOptions
-  -- liftEffect $ log =<< Bf.toString Encoding.UTF8  =<< execSync ("createuser --createdb --superuser " <> pgConfig.user <> " -h '" <> pgConfig.host <> "' -p " <> UInt.toString pgConfig.port) defaultExecSyncOptions
   liftEffect $ log =<< Bf.toString Encoding.UTF8 =<< execSync
     ( "psql -h " <> pgConfig.host <> " -p " <> UInt.toString pgConfig.port
         <> " -d postgres"

--- a/src/Plutip/Types.purs
+++ b/src/Plutip/Types.purs
@@ -29,11 +29,12 @@ type PlutipConfig =
   , ogmiosDatumCacheConfig :: ServerConfig
   , ctlServerConfig :: ServerConfig
   -- Should be synchronized with `defaultConfig.postgres` in `flake.nix`
-  , ogmiosDatumCachePostgresConfig :: OdcPostgresConfig
+  , postgresConfig :: PostgresConfig
   }
 
-type OdcPostgresConfig =
-  { port :: UInt
+type PostgresConfig =
+  { host :: String
+  , port :: UInt
   , user :: String
   , password :: String
   , dbname :: String

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.Integration as Integration
-import Test.Unit as Unit
+import CTL.Test.Unit as Unit
 import Test.Utils as Utils
 
 main :: Effect Unit

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -73,7 +73,7 @@ config =
       }
   , postgresConfig:
       { host: "127.0.0.1"
-      , port: UInt.fromInt 5432
+      , port: UInt.fromInt 54321
       , user: "ctxlib"
       , password: "ctxlib"
       , dbname: "ctxlib"

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -43,7 +43,7 @@ main = launchAff_ do
 
 config :: PlutipConfig
 config =
-  { host: "localhost"
+  { host: "127.0.0.1"
   , port: UInt.fromInt 8082
   , logLevel: Trace
   , distribution:
@@ -55,21 +55,21 @@ config =
   -- Server configs are used to deploy the corresponding services:
   , ogmiosConfig:
       { port: UInt.fromInt 1337
-      , host: "localhost"
+      , host: "127.0.0.1"
       , secure: false
       }
   , ogmiosDatumCacheConfig:
       { port: UInt.fromInt 9999
-      , host: "localhost"
+      , host: "127.0.0.1"
       , secure: false
       }
   , ctlServerConfig:
       { port: UInt.fromInt 8081
-      , host: "localhost"
+      , host: "127.0.0.1"
       , secure: false
       }
   , postgresConfig:
-      { host: "localhost"
+      { host: "127.0.0.1"
       , port: UInt.fromInt 5432
       , user: "ctxlib"
       , password: "ctxlib"

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -68,8 +68,9 @@ config =
       , host: "localhost"
       , secure: false
       }
-  , ogmiosDatumCachePostgresConfig:
-      { port: UInt.fromInt 5432
+  , postgresConfig:
+      { host: "localhost"
+      , port: UInt.fromInt 5432
       , user: "ctxlib"
       , password: "ctxlib"
       , dbname: "ctxlib"

--- a/test/Unit.purs
+++ b/test/Unit.purs
@@ -1,4 +1,4 @@
-module Test.Unit (main, testPlan) where
+module CTL.Test.Unit (main, testPlan) where
 
 import Prelude
 
@@ -24,7 +24,7 @@ import Test.OgmiosDatumCache as OgmiosDatumCache
 import Test.Utils as Utils
 import TestM (TestPlanM)
 
--- Run with `spago test --main Test.Unit`
+-- Run with `spago test --main CTL.Test.Unit`
 main :: Effect Unit
 main = launchAff_ do
   Utils.interpret testPlan


### PR DESCRIPTION
Closes # .
In this PR I introduce a `startPostgres` and a `startPlutipServer` function, which enable us to get rid of the need to manually start a `plutip-runtime` and `plutip-server.
One is now able to just run the test without any other steps being required. A developer can just
```
nix develop
spago test -m Plutip.Server
```

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
