### PR TITLE
Fix utxo min-ada-value calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Updated `ogmios-datum-cache` - bug fixes (#542, #526, #589).
 - Improved error response handling for Ogmios (#584).
-- Make protocol parameters part of `QueryConfig`.
+- Made protocol parameters part of `QueryConfig`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `mkKeyWalletFromFile` helper to use `cardano-cli`-style `skey`s.
 - Single `Plutus.Conversion` module exposing all `(Type <-> Plutus Type)` conversion functions.
 - Support for using a `PrivateKey` as a `Wallet`.
-- `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541)
+- `getProtocolParameters` call to retrieve current protocol parameters from Ogmios (#541).
 
 ### Removed
 
@@ -31,18 +31,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 - Updated `ogmios-datum-cache` - bug fixes (#542, #526, #589).
-- Improved error response handling for Ogmios (#584)
+- Improved error response handling for Ogmios (#584).
+- Make protocol parameters part of `QueryConfig`.
 
 ### Fixed
 
 - Handling of invalid UTF8 byte sequences in the Aeson instance for `TokenName`.
-- `Types.ScriptLookups.require` function naming caused problems with WebPack (#593)
+- `Types.ScriptLookups.require` function naming caused problems with WebPack (#593).
+- UTxO Min-Ada-Value calculation.
 
 ## [1.0.1] - 2022-06-17
 
 ### Fixed
 
-- `mustBeSignedBy` now sets the `Ed25519KeyHash` corresponding to the provided `PaymentPubKeyHash` directly. Previously, this constraint would fail as there was no way to provide a matching `PaymentPubKey` as a lookup. Note that this diverges from Plutus as the `paymentPubKey` lookup is always required in that implementation
+- `mustBeSignedBy` now sets the `Ed25519KeyHash` corresponding to the provided `PaymentPubKeyHash` directly. Previously, this constraint would fail as there was no way to provide a matching `PaymentPubKey` as a lookup. Note that this diverges from Plutus as the `paymentPubKey` lookup is always required in that implementation.
 
 ## [1.0.0] - 2022-06-10
 

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -61,7 +61,6 @@ import Constants.Alonzo
   ( adaOnlyWords
   , coinSize
   , pidSize
-  , protocolParamUTxOCostPerWord
   , utxoEntrySizeWithoutVal
   )
 import Control.Monad.Except.Trans (ExceptT(ExceptT), except, runExceptT)

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -99,7 +99,6 @@ import QueryM
   , getWalletCollateral
   , evalTxExecutionUnits
   )
-import QueryM.ProtocolParameters (getProtocolParameters)
 import QueryM.Utxos (utxosAt)
 import ReindexRedeemers (ReindexErrors, reindexSpentScriptRedeemers')
 import Serialization.Address (Address, addressPaymentCred, withStakeCredential)
@@ -470,7 +469,7 @@ balanceTx unattachedTx@(UnattachedUnbalancedTx { unbalancedTx: t }) = do
     -> UnattachedUnbalancedTx
     -> QueryM (Either BalanceTxError UnattachedUnbalancedTx)
   loop utxoIndex' ownAddr' prevMinUtxos' unattachedTx' = do
-    uTxOCostPerWord <- getProtocolParameters <#> unwrap >>> _.uTxOCostPerWord
+    uTxOCostPerWord <- asks _.pparams <#> unwrap >>> _.uTxOCostPerWord
     let
       Transaction { body: txBody'@(TxBody txB) } =
         unattachedTx' ^. _transaction'
@@ -1019,5 +1018,5 @@ getInputValue utxos (TxBody txBody) =
 
 getAdaOnlyUtxoMinValue :: QueryM BigInt
 getAdaOnlyUtxoMinValue =
-  getProtocolParameters <#>
+  asks _.pparams <#>
     unwrap >>> _.uTxOCostPerWord >>> unwrap >>> mul adaOnlyWords

--- a/src/Constants/Alonzo.purs
+++ b/src/Constants/Alonzo.purs
@@ -1,9 +1,7 @@
 module Constants.Alonzo
   ( adaOnlyWords
   , coinSize
-  , minAdaTxOut
   , pidSize
-  , protocolParamUTxOCostPerWord
   , utxoEntrySizeWithoutVal
   ) where
 
@@ -11,11 +9,6 @@ import Prelude
 
 import Cardano.Types.Value (Coin(Coin))
 import Data.BigInt (BigInt, fromInt)
-
--- https://playground.plutus.iohkdev.io/doc/haddock/plutus-pab/html/src/Cardano.Api.ProtocolParameters.html
--- Shelley params, is this unchanged?
-protocolParamUTxOCostPerWord :: Coin
-protocolParamUTxOCostPerWord = Coin $ fromInt 1
 
 -- words
 -- https://github.com/input-output-hk/cardano-ledger/blob/master/doc/explanations/min-utxo-alonzo.rst
@@ -29,10 +22,6 @@ pidSize = fromInt 28
 -- https://cardano-ledger.readthedocs.io/en/latest/explanations/min-utxo-mary.html
 coinSize :: BigInt
 coinSize = fromInt 2
-
--- Minimum required Ada for each tx output.
-minAdaTxOut :: Coin
-minAdaTxOut = Coin $ fromInt 2_000_000
 
 -- An ada-only UTxO entry is 29 words. More details about min utxo
 -- calculation can be found here:

--- a/src/Constants/Alonzo.purs
+++ b/src/Constants/Alonzo.purs
@@ -5,9 +5,6 @@ module Constants.Alonzo
   , utxoEntrySizeWithoutVal
   ) where
 
-import Prelude
-
-import Cardano.Types.Value (Coin(Coin))
 import Data.BigInt (BigInt, fromInt)
 
 -- words

--- a/src/Contract/Monad.purs
+++ b/src/Contract/Monad.purs
@@ -93,6 +93,8 @@ import QueryM
   , mkWsUrl
   ) as QueryM
 import QueryM (QueryM, QueryMExtended, QueryConfig)
+import QueryM.Ogmios (ProtocolParameters)
+import QueryM.ProtocolParameters (getProtocolParametersAff) as Ogmios
 import Record as Record
 import Serialization.Address (NetworkId(TestnetId))
 import Types.UsedTxOuts (newUsedTxOuts)
@@ -186,6 +188,7 @@ mkContractConfig
   ogmiosWs <- QueryM.mkOgmiosWebSocketAff logLevel params.ogmiosConfig
   datumCacheWs <- QueryM.mkDatumCacheWebSocketAff logLevel
     params.datumCacheConfig
+  pparams <- Ogmios.getProtocolParametersAff ogmiosWs logLevel
   usedTxOuts <- newUsedTxOuts
   let
     queryConfig =
@@ -196,6 +199,7 @@ mkContractConfig
       , wallet
       , datumCacheWs
       , serverConfig: params.ctlServerConfig
+      , pparams
       }
   pure $ wrap $ queryConfig `Record.union` params.extraConfig
 
@@ -313,6 +317,7 @@ configWithLogLevel networkId wallet logLevel = do
   ogmiosWs <- QueryM.mkOgmiosWebSocketAff logLevel QueryM.defaultOgmiosWsConfig
   datumCacheWs <-
     QueryM.mkDatumCacheWebSocketAff logLevel QueryM.defaultDatumCacheWsConfig
+  pparams <- Ogmios.getProtocolParametersAff ogmiosWs logLevel
   usedTxOuts <- newUsedTxOuts
   pure $ ContractConfig
     { ogmiosWs
@@ -322,6 +327,7 @@ configWithLogLevel networkId wallet logLevel = do
     , serverConfig: QueryM.defaultServerConfig
     , networkId
     , logLevel
+    , pparams
     }
 
 -- Logging effects

--- a/src/Contract/Monad.purs
+++ b/src/Contract/Monad.purs
@@ -93,7 +93,6 @@ import QueryM
   , mkWsUrl
   ) as QueryM
 import QueryM (QueryM, QueryMExtended, QueryConfig)
-import QueryM.Ogmios (ProtocolParameters)
 import QueryM.ProtocolParameters (getProtocolParametersAff) as Ogmios
 import Record as Record
 import Serialization.Address (NetworkId(TestnetId))

--- a/src/Contract/ProtocolParameters/Alonzo.purs
+++ b/src/Contract/ProtocolParameters/Alonzo.purs
@@ -3,8 +3,6 @@ module Contract.ProtocolParameters.Alonzo (module Alonzo) where
 import Constants.Alonzo
   ( adaOnlyWords
   , coinSize
-  , minAdaTxOut
   , pidSize
-  , protocolParamUTxOCostPerWord
   , utxoEntrySizeWithoutVal
   ) as Alonzo

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -864,11 +864,11 @@ mkDatumCacheRequest = mkRequest
 
 -- | Builds an Ogmios request action using `QueryM`
 mkRequest
-  :: forall (request :: Type) (response :: Type) (listeners :: Type)
-   . QueryM listeners
+  :: forall (request :: Type) (response :: Type) (listeners' :: Type)
+   . QueryM listeners'
   -> QueryM JsWebSocket
   -> JsonWsp.JsonWspCall request response
-  -> (listeners -> ListenerSet request response)
+  -> (listeners' -> ListenerSet request response)
   -> request
   -> QueryM response
 mkRequest getListeners getWebSocket jsonWspCall getLs inp = do
@@ -879,12 +879,12 @@ mkRequest getListeners getWebSocket jsonWspCall getLs inp = do
 
 -- | Builds an Ogmios request action using `Aff`
 mkRequestAff
-  :: forall (request :: Type) (response :: Type) (listeners :: Type)
-   . listeners
+  :: forall (request :: Type) (response :: Type) (listeners' :: Type)
+   . listeners'
   -> JsWebSocket
   -> LogLevel
   -> JsonWsp.JsonWspCall request response
-  -> (listeners -> ListenerSet request response)
+  -> (listeners' -> ListenerSet request response)
   -> request
   -> Aff response
 mkRequestAff listeners webSocket logLevel jsonWspCall getLs inp = do

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -864,34 +864,34 @@ mkDatumCacheRequest = mkRequest
 
 -- | Builds an Ogmios request action using `QueryM`
 mkRequest
-  :: forall (request :: Type) (response :: Type) (listeners' :: Type)
-   . QueryM listeners'
+  :: forall (request :: Type) (response :: Type) (listeners :: Type)
+   . QueryM listeners
   -> QueryM JsWebSocket
   -> JsonWsp.JsonWspCall request response
-  -> (listeners' -> ListenerSet request response)
+  -> (listeners -> ListenerSet request response)
   -> request
   -> QueryM response
 mkRequest getListeners getWebSocket jsonWspCall getLs inp = do
   ws <- getWebSocket
-  listeners <- getListeners
+  listeners' <- getListeners
   logLevel <- asks _.logLevel
-  liftAff $ mkRequestAff listeners ws logLevel jsonWspCall getLs inp
+  liftAff $ mkRequestAff listeners' ws logLevel jsonWspCall getLs inp
 
 -- | Builds an Ogmios request action using `Aff`
 mkRequestAff
-  :: forall (request :: Type) (response :: Type) (listeners' :: Type)
-   . listeners'
+  :: forall (request :: Type) (response :: Type) (listeners :: Type)
+   . listeners
   -> JsWebSocket
   -> LogLevel
   -> JsonWsp.JsonWspCall request response
-  -> (listeners' -> ListenerSet request response)
+  -> (listeners -> ListenerSet request response)
   -> request
   -> Aff response
-mkRequestAff listeners webSocket logLevel jsonWspCall getLs inp = do
+mkRequestAff listeners' webSocket logLevel jsonWspCall getLs inp = do
   { body, id } <- liftEffect $ JsonWsp.buildRequest jsonWspCall inp
   let
     respLs :: ListenerSet request response
-    respLs = getLs listeners
+    respLs = getLs listeners'
 
     affFunc :: (Either Error response -> Effect Unit) -> Effect Canceler
     affFunc cont = do

--- a/src/QueryM/ProtocolParameters.purs
+++ b/src/QueryM/ProtocolParameters.purs
@@ -1,11 +1,13 @@
 -- | A module to get protocol parameters via Ogmios request
 module QueryM.ProtocolParameters
   ( getProtocolParameters
+  , module GetProtocolParametersAff
   ) where
 
-import Prelude
+import Prelude (unit)
 
 import QueryM (QueryM, mkOgmiosRequest)
+import QueryM (getProtocolParametersAff) as GetProtocolParametersAff
 import QueryM.Ogmios (queryProtocolParametersCall, ProtocolParameters)
 
 getProtocolParameters :: QueryM ProtocolParameters


### PR DESCRIPTION
This PR fixes utxo min-ada-value calculation (according to [Min-Ada-Value Calculation in Alonzo](https://github.com/input-output-hk/cardano-ledger/blob/master/doc/explanations/min-utxo-alonzo.rst)) and also closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/612.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
