### PR TITLE
Better logging for queryDispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Handling of invalid UTF8 byte sequences in the Aeson instance for `TokenName`.
 - `Types.ScriptLookups.require` function naming caused problems with WebPack (#593)
+- Bad logging in `queryDispatch` that didn't propagate error messages (#615)
 
 ## [1.0.1] - 2022-06-17
 

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -29,10 +29,12 @@ import Aeson
   )
 import Control.Alt ((<|>))
 import Data.Either (Either(Left))
+import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(Nothing, Just))
 import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Show.Generic (genericShow)
 import Data.Traversable (traverse)
 import Data.Tuple.Nested (type (/\), (/\))
 import QueryM.JsonWsp (JsonWspCall, mkCallType)
@@ -68,7 +70,10 @@ type JsonWspResponse =
 newtype GetDatumByHashR = GetDatumByHashR (Maybe Datum)
 
 derive instance Newtype GetDatumByHashR _
-derive newtype instance Show GetDatumByHashR
+derive instance Generic GetDatumByHashR _
+
+instance Show GetDatumByHashR where
+  show = genericShow
 
 instance DecodeAeson GetDatumByHashR where
   decodeAeson r = GetDatumByHashR <$>
@@ -86,7 +91,10 @@ instance DecodeAeson GetDatumByHashR where
 newtype GetDatumsByHashesR = GetDatumsByHashesR (Map DataHash Datum)
 
 derive instance Newtype GetDatumsByHashesR _
-derive newtype instance Show GetDatumsByHashesR
+derive instance Generic GetDatumsByHashesR _
+
+instance Show GetDatumsByHashesR where
+  show = genericShow
 
 instance DecodeAeson GetDatumsByHashesR where
   decodeAeson r =

--- a/src/QueryM/DatumCacheWsp.purs
+++ b/src/QueryM/DatumCacheWsp.purs
@@ -68,6 +68,7 @@ type JsonWspResponse =
 newtype GetDatumByHashR = GetDatumByHashR (Maybe Datum)
 
 derive instance Newtype GetDatumByHashR _
+derive newtype instance Show GetDatumByHashR
 
 instance DecodeAeson GetDatumByHashR where
   decodeAeson r = GetDatumByHashR <$>
@@ -85,6 +86,7 @@ instance DecodeAeson GetDatumByHashR where
 newtype GetDatumsByHashesR = GetDatumsByHashesR (Map DataHash Datum)
 
 derive instance Newtype GetDatumsByHashesR _
+derive newtype instance Show GetDatumsByHashesR
 
 instance DecodeAeson GetDatumsByHashesR where
   decodeAeson r =

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -457,7 +457,10 @@ newtype TxEvaluationR = TxEvaluationR
         { memory :: Natural, steps :: Natural }
   }
 
-derive newtype instance Show TxEvaluationR
+derive instance Generic TxEvaluationR _
+
+instance Show TxEvaluationR where
+  show = genericShow
 
 instance DecodeAeson TxEvaluationR where
   decodeAeson _ = Left

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -457,6 +457,8 @@ newtype TxEvaluationR = TxEvaluationR
         { memory :: Natural, steps :: Natural }
   }
 
+derive newtype instance Show TxEvaluationR
+
 instance DecodeAeson TxEvaluationR where
   decodeAeson _ = Left
     (TypeMismatch "DecodeAeson TxEvaluationR is not implemented")

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -24,7 +24,8 @@ import Aeson
 import Data.Const (Const)
 import Data.Either (Either(Right), either)
 import Data.Foldable (sequence_)
-import Data.Maybe (Maybe, maybe)
+import Data.Maybe (Maybe(Just), maybe)
+import Data.Newtype (wrap)
 import Effect.Aff (Aff, error)
 import Effect.Aff.Class (liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
@@ -36,7 +37,7 @@ import Node.Path (FilePath)
 import Test.Spec (Spec, describe, it, pending)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter (consoleReporter)
-import Test.Spec.Runner (runSpec)
+import Test.Spec.Runner (defaultConfig, runSpec')
 import TestM (TestPlanM)
 import Type.Proxy (Proxy)
 
@@ -49,7 +50,8 @@ foreign import unsafeCall
 interpret :: TestPlanM Unit -> Aff Unit
 interpret spif = do
   plan <- planT spif
-  runSpec [ consoleReporter ] $ go plan
+  runSpec' defaultConfig { timeout = Just (wrap 10000.0) } [ consoleReporter ] $
+    go plan
   where
   go :: Plan (Const Void) (Aff Unit) -> Spec Unit
   go =


### PR DESCRIPTION
This PR improves logging by propagating the errors into the error message that is actually shown to the user.

Also a small refactoring.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
