### PR TITLE
Fix title/link in `getting-started.md`

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -174,7 +174,7 @@ One major caveat to using CTL in its current state is that we have no equivalent
 
 ## Testing
 
-### Without light wallet
+### Without a light wallet
 
 We provide `KeyWallet` to enable testing outside of the browser, or in-browser without a light wallet installed. To generate a key, you can use `cardano-cli` as follows:
 


### PR DESCRIPTION
The table of contents has a dead link due to the title not being correct, this is the fix

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [ ] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
