### PR TITLE
Fix locking bug

### DIFF
--- a/examples/AlwaysSucceeds.purs
+++ b/examples/AlwaysSucceeds.purs
@@ -13,7 +13,6 @@ import Contract.Monad
   , liftContractAffM
   , liftContractM
   , liftedE
-  , liftedM
   , logInfo'
   , runContract_
   , traceTestnetContractConfig
@@ -24,7 +23,7 @@ import Contract.Scripts (Validator, ValidatorHash, validatorHash)
 import Contract.Transaction
   ( TransactionHash
   , TransactionInput(TransactionInput)
-  , balanceAndSignTx
+  , balanceAndSignTxE
   , submit
   )
 import Contract.TxConstraints (TxConstraints)
@@ -106,8 +105,7 @@ buildBalanceSignAndSubmitTx
   -> Contract () TransactionHash
 buildBalanceSignAndSubmitTx lookups constraints = do
   ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-  bsTx <-
-    liftedM "Failed to balance/sign tx" $ balanceAndSignTx ubTx
+  bsTx <- liftedE $ balanceAndSignTxE ubTx
   txId <- submit bsTx
   logInfo' $ "Tx ID: " <> show txId
   pure txId

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -473,7 +473,7 @@ balanceTx unattachedTx@(UnattachedUnbalancedTx { unbalancedTx: t }) = do
         _transaction' .~ ubcTx'
     -- Return excess Ada change to wallet:
     unsignedTx <- ExceptT $
-      returnAdaChangeAndFinalizeFees ownAddr availableUtxos nonAdaBalancedCollTx
+      returnAdaChangeAndFinalizeFees ownAddr allUtxos nonAdaBalancedCollTx
         <#>
           lmap ReturnAdaChangeError'
     -- Sort inputs at the very end so it behaves as a Set:


### PR DESCRIPTION
`returnAdaChangeAndFinalizeFees` must be given `allUtxos` for balancing.

Closes # .

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [ ] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
