### PR TITLE
Change `ScriptOutput` to `TransactionOutput` inside `utxoIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Types.ScriptLookups.require` function naming caused problems with WebPack (#593).
 - UTxO Min-Ada-Value calculation.
 
+## [1.1.0] - 2022-06-30
+
+### Fixed
+
+- Changed `utxoIndex` inside an `UnbalancedTx` to be a `Map` with value s`TransactionOutput` instead of `ScriptOutput` so there is no conversion in the balancer to `ScriptOutput`. This means the balancer can spend UTxOs from different wallets instead of just the current wallet and script addresses.
+
+
 ## [1.0.1] - 2022-06-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-- Changed `utxoIndex` inside an `UnbalancedTx` to be a `Map` with value s`TransactionOutput` instead of `ScriptOutput` so there is no conversion in the balancer to `ScriptOutput`. This means the balancer can spend UTxOs from different wallets instead of just the current wallet and script addresses.
+- Changed `utxoIndex` inside an `UnbalancedTx` to be a `Map` with values `TransactionOutput` instead of `ScriptOutput` so there is no conversion in the balancer to `ScriptOutput`. This means the balancer can spend UTxOs from different wallets instead of just the current wallet and script addresses.
 
 
 ## [1.0.1] - 2022-06-17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-transaction-lib",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-transaction-lib",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -104,7 +104,6 @@ import QueryM.Utxos (utxosAt, filterUnusedUtxos)
 import ReindexRedeemers (ReindexErrors, reindexSpentScriptRedeemers')
 import Serialization.Address (Address, addressPaymentCred, withStakeCredential)
 import Transaction (setScriptDataHash)
-import TxOutput (utxoIndexToUtxo)
 import Types.Natural (toBigInt) as Natural
 import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
 import Types.Transaction (DataHash, TransactionInput)
@@ -442,7 +441,7 @@ balanceTx unattachedTx@(UnattachedUnbalancedTx { unbalancedTx: t }) = do
       -- Combines utxos at the user address and those from any scripts
       -- involved with the contract in the unbalanced transaction.
       allUtxos :: Utxo
-      allUtxos = utxos `Map.union` utxoIndexToUtxo networkId utxoIndex
+      allUtxos = utxos `Map.union` utxoIndex
 
       -- After adding collateral, we need to balance the inputs and
       -- non-Ada outputs before looping, i.e. we need to add input fees

--- a/src/TxOutput.purs
+++ b/src/TxOutput.purs
@@ -9,7 +9,6 @@ module TxOutput
   , transactionOutputToOgmiosTxOut
   , transactionOutputToScriptOutput
   , txOutRefToTransactionInput
-  , utxoIndexToUtxo
   ) where
 
 import Prelude
@@ -21,9 +20,7 @@ import Address
   )
 import Cardano.Types.Transaction
   ( TransactionOutput(TransactionOutput)
-  , Utxo
   ) as Transaction
-import Data.Map (Map)
 import Data.Maybe (Maybe(Nothing, Just), maybe)
 import Data.Newtype (unwrap, wrap)
 import Scripts (validatorHashEnterpriseAddress)
@@ -151,13 +148,3 @@ ogmiosDatumHashToDatumHash str = hexToByteArray str <#> wrap
 -- | Converts an internal `DataHash` to an Ogmios datumhash `String`
 datumHashToOgmiosDatumHash :: DataHash -> String
 datumHashToOgmiosDatumHash = byteArrayToHex <<< unwrap
-
---------------------------------------------------------------------------------
--- Conversion between Utxo types
---------------------------------------------------------------------------------
--- | Converts a utxoIndex from `UnbalancedTx` to `Utxo`.
-utxoIndexToUtxo
-  :: NetworkId
-  -> Map Transaction.TransactionInput UTx.ScriptOutput
-  -> Transaction.Utxo
-utxoIndexToUtxo networkId = map (scriptOutputToTransactionOutput networkId)

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -72,7 +72,7 @@ import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Lens.Types (Lens')
 import Data.List (List(Nil, Cons))
-import Data.Map (Map, empty, fromFoldable, lookup, mapMaybe, singleton, union)
+import Data.Map (Map, empty, fromFoldable, lookup, singleton, union)
 import Data.Map (insert, toUnfoldable) as Map
 import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Newtype (class Newtype, over, unwrap, wrap)
@@ -108,7 +108,6 @@ import Transaction
   , attachRedeemer
   , setScriptDataHash
   )
-import TxOutput (transactionOutputToScriptOutput)
 import Types.Any (Any)
 import Types.Datum (DataHash, Datum)
 import Types.Interval
@@ -692,11 +691,9 @@ updateUtxoIndex
 updateUtxoIndex = runExceptT do
   txOutputs <- use _lookups <#> unwrap >>> _.txOutputs
   networkId <- lift getNetworkId
-  let
-    cTxOutputs = map (fromPlutusTxOutput networkId) txOutputs
-    txOutsMap = mapMaybe transactionOutputToScriptOutput cTxOutputs
+  let cTxOutputs = map (fromPlutusTxOutput networkId) txOutputs
   -- Left bias towards original map, hence `flip`:
-  _unbalancedTx <<< _utxoIndex %= flip union txOutsMap
+  _unbalancedTx <<< _utxoIndex %= flip union cTxOutputs
 
 -- Note, we don't use the redeemer here, unlike Plutus because of our lack of
 -- `TxIn` datatype.

--- a/src/Types/UnbalancedTransaction.purs
+++ b/src/Types/UnbalancedTransaction.purs
@@ -13,6 +13,7 @@ import Prelude
 
 import Cardano.Types.Transaction
   ( Transaction
+  , TransactionOutput
   , PublicKey(PublicKey)
   , Vkey(Vkey)
   , RequiredSigner(RequiredSigner)
@@ -71,7 +72,7 @@ payPubKeyRequiredSigner (PaymentPubKey (PublicKey bech32)) =
 -- | Resembles `UnbalancedTx` from `plutus-apps`.
 newtype UnbalancedTx = UnbalancedTx
   { transaction :: Transaction
-  , utxoIndex :: Map TransactionInput ScriptOutput
+  , utxoIndex :: Map TransactionInput TransactionOutput
   }
 
 derive instance Newtype UnbalancedTx _
@@ -88,7 +89,7 @@ _transaction = lens'
       transaction
       \tx -> UnbalancedTx rec { transaction = tx }
 
-_utxoIndex :: Lens' UnbalancedTx (Map TransactionInput ScriptOutput)
+_utxoIndex :: Lens' UnbalancedTx (Map TransactionInput TransactionOutput)
 _utxoIndex = lens'
   \(UnbalancedTx rec@{ utxoIndex }) ->
     Tuple


### PR DESCRIPTION
Closes # https://github.com/Plutonomicon/cardano-transaction-lib/issues/647. Backporting will be done separately with cherry picks, this should probably be checked and merged before https://github.com/Plutonomicon/cardano-transaction-lib/pull/651 the backporting was created to allow for emergency use of the change.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
