### PR TITLE
Add more details for CTL version bumps, add wallets to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@
 
 ### Light wallet support
 
-Support is planned for the following light wallets, roughly in order of implementation:
+Support is planned for the following light wallets:
 
 - [x] [Nami](https://namiwallet.io/)
 - [x] [Gero](https://gerowallet.io/)
+- [ ] [Flint](https://flint-wallet.com/)
+- [ ] [Lace](https://www.lace.io/)
 - [ ] [Typhon](https://typhonwallet.io/)
 - [ ] [Yoroi](https://yoroi-wallet.com/)
 - [ ] [Eternl (formerly CCvault)](https://eternl.io/)

--- a/doc/ctl-as-dependency.md
+++ b/doc/ctl-as-dependency.md
@@ -180,13 +180,33 @@ We have recenly set up a small scaffolding repository for projects wishing to ad
 
 Unfortunately, the process of upgrading CTL is fairly involved. This is in part due to the complexity of the project and in part due to features inherent to Spago's approach to dependency management. The following assumes that you are using a project based on Nix flakes and using our overlay as outlined above.
 
-Make sure to perform **all** of the following steps, otherwise you will probably encounter difficult-to-debug issues:
+Make sure to perform **all** of the following steps, otherwise you **will** encounter difficult-to-debug issues:
 
-- Update the `rev` you're using for CTL in your flake `inputs`
-  - **Note**: Nix might throw an error about CTL following a "non-existent input" after doing this. The best way to solve this is to upgrade the version of Nix that you're using. Otherwise, `nix flake lock --update-input <NAME>`, where `NAME` is the one you're using for CTL in your `inputs`, should solve this
-- Update the CTL `version` in your `packages.dhall`. Make sure that this is the exact same revision as in your flake inputs
-- Possibly update the `dependencies` section for CTL in your `packages.dhall`
-  - You can find a list of CTL's dependencies in our own `spago.dhall` (but make sure to check at the correct revision)
-  - You might also need to add new transitive git dependencies if CTL has added any to its own direct dependencies (i.e. you need to copy the matching stanzas from CTL's `packages.dhall` to your own; these are under the `additions` record in CTL's `packages.dhall`)
-- Run `spago2nix generate` and make sure to stage and commit the resulting `spago-packages.nix` if it has changed
-- If CTL has added any JS dependencies, these will also need to be added to your own `package.json`
+1. **Update your flake input**
+  - Update the `rev` you're using for CTL in your flake `inputs`
+    - **Note**: Nix might throw an error about CTL following a "non-existent input" after doing this. The best way to solve this is to upgrade the version of Nix that you're using. Otherwise, `nix flake lock --update-input <NAME>`, where `NAME` is the one you're using for CTL in your `inputs`, should solve this
+2. **Update your Purescript dependencies**
+  - Update the CTL `version` in your `packages.dhall`. Make sure that this is the exact same revision as in your flake inputs
+  - Possibly update the `dependencies` section for CTL in your `packages.dhall`
+    - You can find a list of CTL's dependencies in our own `spago.dhall` (but make sure to check at the correct revision)
+    - You might also need to add new transitive git dependencies if CTL has added any to its own direct dependencies (i.e. you need to copy the matching stanzas from CTL's `packages.dhall` to your own; these are contained in the `additions` record in CTL's `packages.dhall`)
+      - For example, if the following package `foo` is added to CTL's `additions` (in `packages.dhall`) between your old revision and the one you're upgrading to:
+        ```dhall
+
+        let additions =
+              { foo =
+                { dependencies =
+                  [ "bar"
+                  , "baz"
+                  ]
+                }
+              -- ...
+              }
+        ```
+        You also need to add the same package, identically, to your own `packages.dhall`, otherwise the compiler will not be able to find it
+  - Run `spago2nix generate` and make sure to stage and commit the resulting `spago-packages.nix` if it has changed
+3. **Update your JS dependencies**
+  - If CTL has added any JS dependencies, these will also need to be added to your own `package.json` 
+  - Similarly, if any of CTL's JS dependencies have changed versions, you will need to use the **exact** same version in your own `package.json`
+  - That is, avoid using the `~` or `^` prefixes (e.g use versions like `"^1.6.51"` instead of `"^1.6.51"`)
+  - If you're using a `package-lock.json` (which is _highly_ recommended), you can update the lockfile with `npm i --package-lock-only`

--- a/doc/ctl-as-dependency.md
+++ b/doc/ctl-as-dependency.md
@@ -210,5 +210,5 @@ Make sure to perform **all** of the following steps, otherwise you **will** enco
 3. **Update your JS dependencies**
   - If CTL has added any JS dependencies, these will also need to be added to your own `package.json` 
   - Similarly, if any of CTL's JS dependencies have changed versions, you will need to use the **exact** same version in your own `package.json`
-  - That is, avoid using the `~` or `^` prefixes (e.g use versions like `"^1.6.51"` instead of `"^1.6.51"`)
+  - That is, avoid using the `~` or `^` prefixes (e.g use versions like `"1.6.51"` instead of `"^1.6.51"`)
   - If you're using a `package-lock.json` (which is _highly_ recommended), you can update the lockfile with `npm i --package-lock-only`

--- a/doc/ctl-as-dependency.md
+++ b/doc/ctl-as-dependency.md
@@ -200,6 +200,8 @@ Make sure to perform **all** of the following steps, otherwise you **will** enco
                   , "baz"
                   ]
                 }
+              , repo = "https://github.com/quux/foo.git"
+              , version = "0000000000000000000000000000000000000000"
               -- ...
               }
         ```


### PR DESCRIPTION
Closes #671 

Also expands the the section of `doc/ctl-as-dependency.md` that concerns upgrades