### PR TITLE
Change `Array TransactionInput` to `Set TransactionInput` inside `TxBody`

### DIFF
--- a/src/Cardano/Types/Transaction.purs
+++ b/src/Cardano/Types/Transaction.purs
@@ -92,6 +92,8 @@ import Data.Map (Map)
 import Data.Maybe (Maybe(Nothing))
 import Data.Monoid (guard)
 import Data.Newtype (class Newtype)
+import Data.Set (Set)
+import Data.Set (union) as Set
 import Data.Show.Generic (genericShow)
 import Data.Symbol (SProxy(SProxy))
 import Data.Tuple (Tuple(Tuple))
@@ -186,7 +188,7 @@ _auxiliaryData = lens' \(Transaction rec@{ auxiliaryData }) ->
 -- requiredSigners is an Array over `VKey`s essentially. But some comments at
 -- the bottom say it's Maybe?
 newtype TxBody = TxBody
-  { inputs :: Array TransactionInput
+  { inputs :: Set TransactionInput
   , outputs :: Array TransactionOutput
   , fee :: Coin
   , ttl :: Maybe Slot
@@ -211,7 +213,7 @@ instance Show TxBody where
 
 instance Semigroup TxBody where
   append (TxBody txB) (TxBody txB') = TxBody
-    { inputs: txB.inputs `union` txB'.inputs
+    { inputs: txB.inputs `Set.union` txB'.inputs
     , outputs: txB.outputs `union` txB'.outputs
     , fee: txB.fee <> txB'.fee
     , ttl: lift2 lowerbound txB.ttl txB'.ttl
@@ -548,7 +550,7 @@ instance Show Certificate where
 --------------------------------------------------------------------------------
 -- `TxBody` Lenses
 --------------------------------------------------------------------------------
-_inputs :: Lens' TxBody (Array TransactionInput)
+_inputs :: Lens' TxBody (Set TransactionInput)
 _inputs = _Newtype <<< prop (SProxy :: SProxy "inputs")
 
 _outputs :: Lens' TxBody (Array TransactionOutput)

--- a/src/Deserialization/Transaction.purs
+++ b/src/Deserialization/Transaction.purs
@@ -120,6 +120,7 @@ import Data.Map as M
 import Data.Maybe (Maybe)
 import Data.Newtype (wrap, unwrap)
 import Data.Ratio (Ratio, reduce)
+import Data.Set (fromFoldable) as Set
 import Data.Traversable (traverse, for)
 import Data.Tuple.Nested (type (/\))
 import Data.UInt (UInt)
@@ -243,6 +244,7 @@ convertTxBody txBody = do
   inputs <-
     _txBodyInputs containerHelper txBody
       # traverse (convertInput >>> cslErr "TransactionInput")
+      <#> Set.fromFoldable
   outputs <-
     _txBodyOutputs containerHelper txBody
       # traverse (convertOutput >>> cslErr "TransactionOutput")

--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -49,6 +49,7 @@ import Cardano.Types.Transaction
   ) as T
 import Cardano.Types.TransactionUnspentOutput (TransactionUnspentOutput)
 import Cardano.Types.Value as Value
+import Data.Foldable (class Foldable)
 import Data.FoldableWithIndex (forWithIndex_)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing))
@@ -699,10 +700,14 @@ convertMint (T.Mint (Value.NonAdaAsset m)) = do
     insertMintAssets mint scripthash assets
   pure mint
 
-convertTxInputs :: Array T.TransactionInput -> Effect TransactionInputs
-convertTxInputs arrInputs = do
+convertTxInputs
+  :: forall (f :: Type -> Type)
+   . Foldable f
+  => f T.TransactionInput
+  -> Effect TransactionInputs
+convertTxInputs fInputs = do
   inputs <- newTransactionInputs
-  traverse_ (convertTxInput >=> addTransactionInput inputs) arrInputs
+  traverse_ (convertTxInput >=> addTransactionInput inputs) fInputs
   pure inputs
 
 convertTxInput :: T.TransactionInput -> Effect TransactionInput

--- a/src/Types/ScriptLookups.purs
+++ b/src/Types/ScriptLookups.purs
@@ -59,7 +59,7 @@ import Control.Monad.Reader.Trans (ReaderT)
 import Control.Monad.State.Trans (StateT, get, gets, put, runStateT)
 import Control.Monad.Trans.Class (lift)
 import Data.Array ((:), singleton, union) as Array
-import Data.Array (filter, insert, mapWithIndex, toUnfoldable, zip)
+import Data.Array (filter, mapWithIndex, toUnfoldable, zip)
 import Data.Bifunctor (lmap)
 import Data.BigInt (BigInt, fromInt)
 import Data.Either (Either(Left, Right), either, note)
@@ -76,6 +76,7 @@ import Data.Map (Map, empty, fromFoldable, lookup, singleton, union)
 import Data.Map (insert, toUnfoldable) as Map
 import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Newtype (class Newtype, over, unwrap, wrap)
+import Data.Set (insert) as Set
 import Data.Show.Generic (genericShow)
 import Data.Symbol (SProxy(SProxy))
 import Data.Traversable (sequence, traverse, traverse_)
@@ -722,7 +723,7 @@ addOwnInput (InputConstraint { txOutRef }) = do
         <#> lmap TypeCheckFailed
     let value = typedTxOutRefValue typedTxOutRef
     -- Must be inserted in order. Hopefully this matches the order under CSL
-    _cpsToTxBody <<< _inputs %= insert txOutRef
+    _cpsToTxBody <<< _inputs %= Set.insert txOutRef
     _valueSpentBalancesInputs <>= provideValue value
 
 -- | Add a typed output and return its value.
@@ -878,7 +879,7 @@ processConstraint mpsMap osMap = do
           -- POTENTIAL FIX ME: Plutus has Tx.TxIn and Tx.PubKeyTxIn -- TxIn
           -- keeps track TransactionInput and TxInType (the input type, whether
           -- consuming script, public key or simple script)
-          _cpsToTxBody <<< _inputs %= insert txo
+          _cpsToTxBody <<< _inputs %= Set.insert txo
           _valueSpentBalancesInputs <>= provideValue amount
         _ -> liftEither $ throwError $ TxOutRefWrongType txo
     MustSpendScriptOutput txo red -> runExceptT do
@@ -903,7 +904,7 @@ processConstraint mpsMap osMap = do
               lookupD <- lookupDatum dHash
               pure $ queryD <|> lookupD
             ExceptT $ attachToCps attachPlutusScript plutusScript
-            _cpsToTxBody <<< _inputs %= insert txo
+            _cpsToTxBody <<< _inputs %= Set.insert txo
             ExceptT $ addDatum dataValue
             let
               -- Create a redeemer with hardcoded execution units then call Ogmios

--- a/test/Fixtures.purs
+++ b/test/Fixtures.purs
@@ -122,6 +122,8 @@ import Data.Either (fromRight)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), fromJust)
 import Data.NonEmpty ((:|))
+import Data.Set (Set)
+import Data.Set (singleton) as Set
 import Data.Tuple.Nested ((/\))
 import Data.UInt as UInt
 import Deserialization.FromBytes (fromBytes)
@@ -229,7 +231,7 @@ txOutputBinaryFixture1 =
 
 -- | Extend this for your needs.
 type SampleTxConfig =
-  { inputs :: Array TransactionInput }
+  { inputs :: Set TransactionInput }
 
 -- | Build a sample transaction using convenient config
 -- | and existing one as a base.
@@ -297,7 +299,7 @@ txFixture1 :: Transaction
 txFixture1 =
   Transaction
     { body: TxBody
-        { inputs: [ txInputFixture1 ]
+        { inputs: Set.singleton txInputFixture1
         , outputs: [ txOutputFixture1 ]
         , fee: Coin $ BigInt.fromInt 177513
         , ttl: Nothing
@@ -328,7 +330,7 @@ txFixture2 :: Transaction
 txFixture2 =
   Transaction
     { body: TxBody
-        { inputs: [ txInputFixture1 ]
+        { inputs: Set.singleton txInputFixture1
         , outputs: [ txOutputFixture2 ]
         , fee: Coin $ BigInt.fromInt 177513
         , ttl: Nothing
@@ -359,7 +361,7 @@ txFixture3 :: Transaction
 txFixture3 =
   Transaction
     { body: TxBody
-        { inputs: [ txInputFixture1 ]
+        { inputs: Set.singleton txInputFixture1
         , outputs:
             [ TransactionOutput
                 { address: keyHashBaseAddress
@@ -469,7 +471,7 @@ txFixture4 :: Transaction
 txFixture4 =
   Transaction
     { body: TxBody
-        { inputs: [ txInputFixture1 ]
+        { inputs: Set.singleton txInputFixture1
         , outputs:
             [ TransactionOutput
                 { address: keyHashBaseAddress

--- a/test/UsedTxOuts.purs
+++ b/test/UsedTxOuts.purs
@@ -8,6 +8,7 @@ import Data.Array (any, singleton, uncons)
 import Data.Foldable (all)
 import Data.Maybe (fromJust)
 import Data.Newtype (unwrap)
+import Data.Set (fromFoldable) as Set
 import Data.Traversable (traverse)
 import Data.UInt (UInt)
 import Mote (test, group)
@@ -87,7 +88,7 @@ buildSampleTransaction =
           }
       ]
   in
-    { tx: mkSampleTx txFixture1 (_ { inputs = usedTxOutRefs })
+    { tx: mkSampleTx txFixture1 (_ { inputs = Set.fromFoldable usedTxOutRefs })
     , usedTxOutRefs: unwrap <$> usedTxOutRefs
     , unusedTxOutRefs: unwrap <$> unusedTxOutRefs
     }


### PR DESCRIPTION
Closes [#](https://github.com/Plutonomicon/cardano-transaction-lib/issues/641) .

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [ ] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
