### PR TITLE
Add FromMetadata and ToMetadata instances for CurrencySymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Utxos.getWalletBalance` call to get all available assets as a single `Value` ([#590](https://github.com/Plutonomicon/cardano-transaction-lib/issues/590))
 - `balanceAndSignTxs` balances and signs multiple transactions while taking care to use transaction inputs only once.
 - Ability to load stake keys from files when using `KeyWallet` ([#635](https://github.com/Plutonomicon/cardano-transaction-lib/issues/635))
+- `FromMetadata` and `ToMetadata` instances for `Contract.Value.CurrencySymbol`
 
 ### Removed
 

--- a/src/Plutus/Types/CurrencySymbol.purs
+++ b/src/Plutus/Types/CurrencySymbol.purs
@@ -28,13 +28,17 @@ import Serialization.Hash (ScriptHash, scriptHashFromBytes, scriptHashToBytes)
 import ToData (class ToData)
 import Types.ByteArray (ByteArray)
 import Types.Scripts (MintingPolicyHash(MintingPolicyHash))
+import Metadata.FromMetadata (class FromMetadata)
+import Metadata.ToMetadata (class ToMetadata)
 
 newtype CurrencySymbol = CurrencySymbol ByteArray
 
 derive newtype instance Eq CurrencySymbol
 derive newtype instance Ord CurrencySymbol
 derive newtype instance FromData CurrencySymbol
+derive newtype instance FromMetadata CurrencySymbol
 derive newtype instance ToData CurrencySymbol
+derive newtype instance ToMetadata CurrencySymbol
 
 instance DecodeAeson CurrencySymbol where
   decodeAeson = caseAesonObject


### PR DESCRIPTION
Provide `From/ToMetadata` instances for `CurrencySymbol` from `Plutus.Types` (reexported by `Contract.Value`).

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
