### PR TITLE
`DecodeAeson` instance for `Transaction`

### DIFF
--- a/src/Helpers.purs
+++ b/src/Helpers.purs
@@ -22,15 +22,23 @@ module Helpers
   , notImplemented
   , showWithParens
   , uIntToBigInt
+  , aesonObject
+  , aesonArray
   ) where
 
 import Prelude
 
+import Aeson
+  ( Aeson
+  , JsonDecodeError(TypeMismatch)
+  , caseAesonObject
+  , caseAesonArray
+  )
 import Control.Monad.Error.Class (class MonadError, throwError)
 import Data.Array (union)
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
-import Data.Either (Either(Right), either)
+import Data.Either (Either(Left, Right), either)
 import Data.Function (on)
 import Data.JSDate (now)
 import Data.List.Lazy as LL
@@ -50,6 +58,7 @@ import Effect (Effect)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (log)
 import Effect.Exception (throw)
+import Foreign.Object (Object)
 import Partial.Unsafe (unsafePartial)
 import Prim.TypeError (class Warn, Text)
 
@@ -219,3 +228,20 @@ showWithParens
   -> a -- the inner type.
   -> String
 showWithParens ctorName x = "(" <> ctorName <> " (" <> show x <> "))"
+
+-- | Helper for assuming we get an `Object`
+aesonObject
+  :: forall (a :: Type)
+   . (Object Aeson -> Either JsonDecodeError a)
+  -> Aeson
+  -> Either JsonDecodeError a
+aesonObject = caseAesonObject (Left (TypeMismatch "Expected Object"))
+
+-- | Helper for assuming we get an `Array`
+aesonArray
+  :: forall (a :: Type)
+   . (Array Aeson -> Either JsonDecodeError a)
+  -> Aeson
+  -> Either JsonDecodeError a
+aesonArray = caseAesonArray (Left (TypeMismatch "Expected Array"))
+

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -27,8 +27,6 @@ module QueryM.Ogmios
   , TxHash
   , UtxoQR(..)
   , UtxoQueryResult(..)
-  , aesonArray
-  , aesonObject
   , evaluateTxCall
   , queryProtocolParametersCall
   , queryChainTipCall
@@ -47,8 +45,6 @@ import Aeson
   , class EncodeAeson
   , Aeson
   , JsonDecodeError(TypeMismatch)
-  , caseAesonArray
-  , caseAesonObject
   , caseAesonString
   , decodeAeson
   , encodeAeson'
@@ -93,7 +89,7 @@ import Data.UInt (UInt)
 import Data.UInt as UInt
 import Foreign.Object (Object)
 import Foreign.Object as FO
-import Helpers (showWithParens)
+import Helpers (showWithParens, aesonObject, aesonArray)
 import QueryM.JsonWsp
   ( JsonWspCall
   , JsonWspRequest
@@ -1037,22 +1033,6 @@ parseUtxoQueryResult = aesonArray $ foldl insertFunc (Right Map.empty)
       txOutRef <- parseTxOutRef txOutRefJson
       txOut <- parseTxOut txOutJson
       Map.insert txOutRef txOut <$> acc
-
--- helper for assuming we get an object
-aesonObject
-  :: forall (a :: Type)
-   . (Object Aeson -> Either JsonDecodeError a)
-  -> Aeson
-  -> Either JsonDecodeError a
-aesonObject = caseAesonObject (Left (TypeMismatch "Expected Object"))
-
--- helper for assumming we get an array
-aesonArray
-  :: forall (a :: Type)
-   . (Array Aeson -> Either JsonDecodeError a)
-  -> Aeson
-  -> Either JsonDecodeError a
-aesonArray = caseAesonArray (Left (TypeMismatch "Expected Array"))
 
 -- parser for txOutRef
 parseTxOutRef :: Aeson -> Either JsonDecodeError OgmiosTxOutRef

--- a/src/Types/Interval.purs
+++ b/src/Types/Interval.purs
@@ -97,6 +97,7 @@ import Helpers
   , liftM
   , mkErrorRecord
   , showWithParens
+  , aesonObject
   )
 import Partial.Unsafe (unsafePartial)
 import Plutus.Types.DataSchema
@@ -111,7 +112,6 @@ import QueryM.Ogmios
   ( EraSummaries(EraSummaries)
   , EraSummary(EraSummary)
   , SystemStart
-  , aesonObject
   )
 import Serialization.Address (Slot(Slot))
 import ToData (class ToData, genericToData)


### PR DESCRIPTION
Closes #575 

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [ ] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
