### PR TITLE
Vasil test fixes - remove times/slots too far in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `AbsSlot` and related functions have been removed in favour of `Slot`
 - Modules `Metadata.Seabug` and `Metadata.Seabug.Share`
 - `POST /eval-ex-units` Haskell server endpoint ([#665](https://github.com/Plutonomicon/cardano-transaction-lib/pull/665))
+- Truncated test fixtures for time/slots inside `AffInterface` to test time/slots not too far into the future which can be problematic during hardforks https://github.com/Plutonomicon/cardano-transaction-lib/pull/676
 
 ### Changed
 

--- a/test/AffInterface.purs
+++ b/test/AffInterface.purs
@@ -169,10 +169,44 @@ testPosixTimeToSlot = do
       -- here https://cardano.stackexchange.com/questions/7034/how-to-convert-posixtime-to-slot-number-on-cardano-testnet/7035#7035
       -- `timeWhenSlotChangedTo1Sec = POSIXTime 1595967616000` - exactly
       -- divisible by 1 second.
+
+      -- *Testing far into the future note during hardforks:*
+      -- It's worth noting that testing values "in" the recent era summary may
+      -- fail during hardforks. This is because the last element's `end`
+      -- field may be non null, meaning there is a limit to how far we can go
+      -- into the future for reliable slot/time conversion (an exception like
+      -- `CannotFindSlotInEraSummaries` is raised in this case).
+      -- This `end` field presumably changes to `null` after the the initial
+      -- period is over and things stabilise.
+      -- For example, at the time of writing (start of Vasil hardfork during
+      -- Babbage era), the *last* era summary element is
+      -- ```
+      -- {
+      --   "start": {
+      --     "time": 92880000,
+      --     "slot": 62510400,
+      --     "epoch": 215
+      --   },
+      --   "end": {
+      --     "time": 93312000,
+      --     "slot": 62942400,
+      --     "epoch": 216
+      --   },
+      --   "parameters": {
+      --     "epochLength": 432000,
+      --     "slotLength": 1,
+      --     "safeZone": 129600
+      --   }
+      -- }
+      -- ```
+      -- Note, `end` isn't null. This means any time "after" 93312000 will raise
+      -- `CannotFindSlotInEraSummaries` an exception. So adding a time far
+      -- into the future for `posixTimes` below will raise this exception.
+      -- Notice also how 93312000 - 92880000 is a relatively small period of
+      -- time so I expect this will change to `null` once things stabilise.
       posixTimes = mkPosixTime <$>
         [ "1603636353000"
         , "1613636755000"
-        , "1753645721000"
         ]
     traverse_ (idTest eraSummaries sysStart identity) posixTimes
     -- With Milliseconds, we generally round down, provided the aren't at the
@@ -208,10 +242,11 @@ testSlotToPosixTime = do
   traceQueryConfig >>= flip runQueryM do
     eraSummaries <- getEraSummaries
     sysStart <- getSystemStart
+    -- See *Testing far into the future note during hardforks:* for details on
+    -- how far into the future we test with slots when a hardfork occurs.
     let
       slots = mkSlot <$>
-        [ 395930213
-        , 58278567
+        [ 58278567
         , 48272312
         , 39270783
         , 957323


### PR DESCRIPTION
Based on https://github.com/Plutonomicon/cardano-transaction-lib/pull/675.

Time related tests are failing due to the recent hard fork as we are testing times too far into the future and the `end` field is populated from the era summary. I would expect this will return to null once things stabilise.

I've added lots of comments explaining what happened.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
