### PR TITLE
Fix parsing of `OgmiosTxOut`

### DIFF
--- a/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
+++ b/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
@@ -73,7 +73,7 @@ $schema ogmiosTxOut
         $property-schema $string
         $property-name "value"
         $property-schema valueType
-        $property-name "datum"
+        $property-name "datumHash"
         $property-schema datumType
 
 $schema valueType

--- a/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
+++ b/fixtures/schemata/JsonWsp/UtxoQueryResponse.medea
@@ -74,7 +74,8 @@ $schema ogmiosTxOut
         $property-name "value"
         $property-schema valueType
         $property-name "datumHash"
-        $property-schema datumType
+        $property-schema datumHashType
+        $additional-properties-allowed
 
 $schema valueType
     $type
@@ -86,7 +87,7 @@ $schema valueType
         $property-schema assetsType
         $optional-property
 
-$schema datumType
+$schema datumHashType
     $type
         $null
         $string

--- a/fixtures/test/parsing/JsonWsp/UtxoQueryResponse.json
+++ b/fixtures/test/parsing/JsonWsp/UtxoQueryResponse.json
@@ -7,23 +7,15 @@
     "result": [
       [
         {
-          "txId": "1ae7bbe9ed3d0205b3704446678c3a9e777ba41a65a3115d066dd4eabe295839",
-          "index": 0
+          "index": 0,
+          "txId": "c6a1c03c473753c932277634a39e8a3bacf4ae792eac174ab1e1b272d142db1f"
         },
         {
-          "address": "addr_test1qr7g8nrv76fc7k4ueqwecljxx9jfwvsgawhl55hck3n8uwaz26mpcwu58zdkhpdnc6nuq3fa8vylc8ak9qvns7r2dsysp7ll4d",
-          "value": {
-            "coins": 1000000000,
-            "assets": {
-                "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4.815d": 2,
-                "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4.a56e":9,
-                "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56":15,
-                "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5.f7c5951ec5":9,
-                "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2":12,
-                "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2.bbe6":13
-            }
-          },
-          "datum": null
+          "address": "addr_test1qpsfwsr4eqjfe49md9wpnyp3ws5emf4z3k6xqagvm880zgnk2wgk4wl2rz04eaqmq9fnxhyn56az0c4d3unvcvg2yw4qmkmv4t",
+          "datum": null,
+          "datumHash": null,
+          "script": null,
+          "value": { "assets": {}, "coins": 20186944 }
         }
       ]
     ],

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -1105,7 +1105,7 @@ parseTxOut :: Aeson -> Either JsonDecodeError OgmiosTxOut
 parseTxOut = aesonObject $ \o -> do
   address <- getField o "address"
   value <- parseValue o
-  let datum = hush $ getField o "datum"
+  let datum = hush $ getField o "datumHash"
   pure $ { address, value, datum }
 
 -- parses the `Value` type


### PR DESCRIPTION
Fixes parsing of Babbage-era transactions. From changelog for Ogmios v5.5.0: 

> Similarly, Alonzo transaction outputs will now contain a `datumHash` field, carrying the datum hash digest. However, they will also contain a `datum` field with the exact same value for backward compatibility reason. In Babbage however, transaction outputs will carry either `datum` or `datumHash` depending on the case; and `datum` will only contain inline `datums`;


### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
