### PR TITLE
Upgrade `ogmios-datum-cache`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1693,17 +1693,17 @@
         "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
-        "lastModified": 1656090737,
-        "narHash": "sha256-zan1OMF5/O7lfYAA9y4JgveEVKK2Pw9tWBVYbMcPUto=",
+        "lastModified": 1656671352,
+        "narHash": "sha256-EO3WrQnCXK+Lg8PNG2TK8iQxn5Zo+x7pmYFf1qWs0fk=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "98b1c4f2badc7ab1efe4be188ee9f9f5e4e54bb0",
+        "rev": "1c7a4af3f18bd3fa94a59e5a52e0ad6d974233e8",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "98b1c4f2badc7ab1efe4be188ee9f9f5e4e54bb0",
+        "rev": "1c7a4af3f18bd3fa94a59e5a52e0ad6d974233e8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
     # for the purescript project
     ogmios.url = "github:mlabs-haskell/ogmios/e406801eaeb32b28cd84357596ca1512bff27741";
-    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/98b1c4f2badc7ab1efe4be188ee9f9f5e4e54bb0";
+    ogmios-datum-cache.url = "github:mlabs-haskell/ogmios-datum-cache/1c7a4af3f18bd3fa94a59e5a52e0ad6d974233e8";
     # so named because we also need a different version of the repo below
     # in the server inputs and we use this one just for the `cardano-cli`
     # executables

--- a/flake.nix
+++ b/flake.nix
@@ -347,6 +347,8 @@
                     "-c"
                     ''
                       ${pkgs.ogmios-datum-cache}/bin/ogmios-datum-cache \
+                        --log-level warn \
+                        --use-latest \
                         --server-api "${toString datumCache.controlApiToken}" \
                         --server-port ${toString datumCache.port} \
                         --ogmios-address ogmios \


### PR DESCRIPTION
Closes #602.
Closes #608
 I also added two flags that make using ODC nicer (`--log-level warn` and `--use-latest`)