### PR TITLE
Vasil features: update protocol params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This release adds support for running CTL contracts against Babbage-era nodes. *
 - Modules `Metadata.Seabug` and `Metadata.Seabug.Share`
 - `POST /eval-ex-units` Haskell server endpoint ([#665](https://github.com/Plutonomicon/cardano-transaction-lib/pull/665))
 - Truncated test fixtures for time/slots inside `AffInterface` to test time/slots not too far into the future which can be problematic during hardforks https://github.com/Plutonomicon/cardano-transaction-lib/pull/676
-- `d` and `extraEntropy` protocol parameters from protocol paramters update proporsal
+- `d` and `extraEntropy` protocol parameters from protocol parameters update proposal
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This release adds support for running CTL contracts against Babbage-era nodes. *
 - Modules `Metadata.Seabug` and `Metadata.Seabug.Share`
 - `POST /eval-ex-units` Haskell server endpoint ([#665](https://github.com/Plutonomicon/cardano-transaction-lib/pull/665))
 - Truncated test fixtures for time/slots inside `AffInterface` to test time/slots not too far into the future which can be problematic during hardforks https://github.com/Plutonomicon/cardano-transaction-lib/pull/676
+- `d` and `extraEntropy` protocol parameters from protocol paramters update proporsal
 
 ### Changed
 

--- a/src/Cardano/Types/Transaction.purs
+++ b/src/Cardano/Types/Transaction.purs
@@ -331,8 +331,6 @@ type ProtocolParamUpdate =
   , poolPledgeInfluence :: Maybe UnitInterval
   , expansionRate :: Maybe UnitInterval
   , treasuryGrowthRate :: Maybe UnitInterval
-  , d :: Maybe UnitInterval
-  , extraEntropy :: Maybe Nonce
   , protocolVersion :: Maybe (Array ProtocolVersion)
   , minPoolCost :: Maybe BigNum
   , adaPerUtxoByte :: Maybe BigNum

--- a/src/Deserialization/Transaction.js
+++ b/src/Deserialization/Transaction.js
@@ -225,8 +225,6 @@ exports._unpackProtocolParamUpdate = maybe => ppu => {
         poolPledgeInfluence: optional(ppu.pool_pledge_influence()),
         expansionRate: optional(ppu.expansion_rate()),
         treasuryGrowthRate: optional(ppu.treasury_growth_rate()),
-        d: optional(ppu.d()),
-        extraEntropy: optional(ppu.extra_entropy()),
         protocolVersion: optional(ppu.protocol_version()),
         minPoolCost: optional(ppu.min_pool_cost()),
         adaPerUtxoByte: optional(ppu.ada_per_utxo_byte()),

--- a/src/Deserialization/Transaction.purs
+++ b/src/Deserialization/Transaction.purs
@@ -507,8 +507,6 @@ convertProtocolParamUpdate cslPpu = do
     , poolPledgeInfluence: _unpackUnitInterval <$> ppu.poolPledgeInfluence
     , expansionRate: _unpackUnitInterval <$> ppu.expansionRate
     , treasuryGrowthRate: _unpackUnitInterval <$> ppu.treasuryGrowthRate
-    , d: _unpackUnitInterval <$> ppu.d
-    , extraEntropy: convertNonce <$> ppu.extraEntropy
     , protocolVersion
     , minPoolCost: ppu.minPoolCost
     , adaPerUtxoByte: ppu.adaPerUtxoByte
@@ -714,8 +712,6 @@ foreign import _unpackProtocolParamUpdate
          Maybe Csl.UnitInterval
      , treasuryGrowthRate ::
          Maybe Csl.UnitInterval
-     , d :: Maybe Csl.UnitInterval
-     , extraEntropy :: Maybe Csl.Nonce
      , protocolVersion :: Maybe Csl.ProtocolVersions
      , minPoolCost :: Maybe Csl.BigNum
      , adaPerUtxoByte :: Maybe Csl.BigNum

--- a/test/Fixtures.purs
+++ b/test/Fixtures.purs
@@ -465,9 +465,6 @@ proposedProtocolParameterUpdates1 = ProposedProtocolParameterUpdates $
         , expansionRate: Just { numerator: bigNumOne, denominator: bigNumOne }
         , treasuryGrowthRate: Just
             { numerator: bigNumOne, denominator: bigNumOne }
-        , d: Nothing -- Just { numerator: bigNumOne, denominator: bigNumOne }
-        , extraEntropy: Nothing -- Just $ HashNonce $ hexToByteArrayUnsafe
-        --    "5d677265fa5bb21ce6d8c7502aca70b9316d10e958611f3c6b758f6500000000"
         , protocolVersion: Just
             [ { major: UInt.fromInt 1, minor: UInt.fromInt 1 } ]
         , minPoolCost: Just bigNumOne


### PR DESCRIPTION
Closes #683 

[These](https://github.com/Emurgo/cardano-serialization-lib/pull/460/files) are just deprecations, but I think it's meaningful for us to remove them right now, because we don't really aim at supporting eras except the current one (since we don't handle older eras in Ogmios responses anyway). 

I updated the changelog in this PR in order not to forget (this is technically a breaking change, but it's extremely unlikely we have users of this feature right now).

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
