### PR TITLE
Return error if no utxo is specified for a tx input & Fix transaction inputs locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ This release adds support for running CTL contracts against Babbage-era nodes. *
 - `Types.ScriptLookups.require` function naming caused problems with WebPack ([#593](https://github.com/Plutonomicon/cardano-transaction-lib/pull/593))
 - Bad logging in `queryDispatch` that didn't propagate error messages ([#615](https://github.com/Plutonomicon/cardano-transaction-lib/pull/615))
 - UTxO Min-Ada-Value calculation ([#611](https://github.com/Plutonomicon/cardano-transaction-lib/pull/611))
+- Discarding invalid inputs in `txInsValues` instead of yielding an error ([#696](https://github.com/Plutonomicon/cardano-transaction-lib/pull/696))
+- Locking transaction inputs before the actual balancing of the transaction ([#696](https://github.com/Plutonomicon/cardano-transaction-lib/pull/696))
 
 ## [1.1.0] - 2022-06-30
 

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -105,7 +105,6 @@ import Cardano.Types.Transaction
 import Cardano.Types.Transaction (Transaction)
 import Contract.Monad (Contract, liftedE, liftedM, wrapContract)
 import Control.Monad.Error.Class (try, catchError, throwError)
-import Control.Monad.Except.Trans (runExceptT)
 import Control.Monad.Reader (asks, runReaderT, ReaderT)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Either (Either, hush)
@@ -113,7 +112,7 @@ import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Show.Generic (genericShow)
-import Data.Traversable (class Traversable, fold, for_, traverse)
+import Data.Traversable (class Traversable, for_, traverse)
 import Data.Tuple.Nested (type (/\))
 import Effect.Class (liftEffect)
 import Effect.Exception (Error, throw)
@@ -148,8 +147,7 @@ import Types.UnbalancedTransaction
   , emptyUnbalancedTx
   ) as UnbalancedTx
 import Types.UsedTxOuts
-  ( TxOutRefUnlockKeys
-  , UsedTxOuts
+  ( UsedTxOuts
   , lockTransactionInputs
   , unlockTransactionInputs
   )


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/687

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
