### PR TITLE
Add missing export

### DIFF
--- a/src/BalanceTx.purs
+++ b/src/BalanceTx.purs
@@ -20,7 +20,11 @@ module BalanceTx
       , EvalExUnitsAndMinFeeError'
       , TxInputLockedError'
       )
-  , BalanceTxInsError(InsufficientTxInputs, BalanceTxInsCannotMinus)
+  , BalanceTxInsError
+      ( InsufficientTxInputs
+      , BalanceTxInsCannotMinus
+      , UtxoLookupFailedFor
+      )
   , CannotMinusError(CannotMinus)
   , EvalExUnitsAndMinFeeError
       ( EvalMinFeeError


### PR DESCRIPTION
CI is failing on `develop` due to missing data constructor export