### PR TITLE
Don't format node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := bash
 ps-sources := $(shell fd -epurs)
 nix-sources := $(shell fd -enix --exclude='spago*')
 hs-sources := $(shell fd . './server/src' './server/exe' -ehs)
-js-sources := $(shell fd -ejs)
+js-sources := $(shell fd -ejs -Enode_modules)
 ps-entrypoint := Examples.AlwaysSucceeds
 ps-bundle = spago bundle-module -m ${ps-entrypoint} --to output.js
 


### PR DESCRIPTION
Fixes 'argument list too long' on `make format`

Closes # .

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
