### PR TITLE
Only include the necessary cost models during transaction finalization

### DIFF
--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -832,6 +832,7 @@ convertCostmdls (T.Costmdls cs) = do
   costmdls <- newCostmdls
   -- TODO Check the traversal order of the costmodels map isn't important for
   --      mixed language transactions
+  --      https://github.com/Plutonomicon/cardano-transaction-lib/issues/764
   forWithIndex_ cs \language costModel -> do
     language' <- case language of
       S.PlutusV1 -> newPlutusV1

--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -830,9 +830,6 @@ convertValue val = do
 convertCostmdls :: T.Costmdls -> Effect Costmdls
 convertCostmdls (T.Costmdls cs) = do
   costmdls <- newCostmdls
-  -- TODO Check the traversal order of the costmodels map isn't important for
-  --      mixed language transactions
-  --      https://github.com/Plutonomicon/cardano-transaction-lib/issues/764
   forWithIndex_ cs \language costModel -> do
     language' <- case language of
       S.PlutusV1 -> newPlutusV1

--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -830,15 +830,14 @@ convertValue val = do
 convertCostmdls :: T.Costmdls -> Effect Costmdls
 convertCostmdls (T.Costmdls cs) = do
   costmdls <- newCostmdls
-  let
-    loadCostModel lang lang' = do
-      costModel <-
-        convertCostModel <=< fromJustEff
-          ("`" <> show lang <> "` not found in `Costmdls`")
-          $ Map.lookup lang cs
-      costmdlsSetCostModel costmdls lang' costModel
-  loadCostModel S.PlutusV1 =<< newPlutusV1
-  loadCostModel S.PlutusV2 =<< newPlutusV2
+  -- TODO Check the traversal order of the costmodels map isn't important for
+  --      mixed language transactions
+  forWithIndex_ cs \language costModel -> do
+    language' <- case language of
+      S.PlutusV1 -> newPlutusV1
+      S.PlutusV2 -> newPlutusV2
+    costModel' <- convertCostModel costModel
+    costmdlsSetCostModel costmdls language' costModel'
   pure costmdls
 
 convertCostModel :: T.CostModel -> Effect CostModel


### PR DESCRIPTION
Fixes being able to run scripts (well, some of the examples now) on the `babbage` branch

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
