### PR TITLE
Remove compile-time warning for utxosAt

### DIFF
--- a/src/QueryM/Utxos.purs
+++ b/src/QueryM/Utxos.purs
@@ -27,7 +27,6 @@ import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import Effect.Exception (throw)
 import Helpers as Helpers
-import Prim.TypeError (class Warn, Text)
 import QueryM (QueryM, getWalletAddress, getWalletCollateral, mkOgmiosRequest)
 import QueryM.Ogmios as Ogmios
 import Serialization.Address (Address)
@@ -44,11 +43,7 @@ import Wallet (Wallet(Gero, Nami, KeyWallet))
 -- | Gets utxos at an (internal) `Address` in terms of (internal) `Cardano.Transaction.Types`.
 -- | Results may vary depending on `Wallet` type.
 utxosAt
-  :: Warn
-       ( Text
-           "`utxosAt`: Querying for UTxOs by address is deprecated. See https://github.com/Plutonomicon/cardano-transaction-lib/issues/536."
-       )
-  => Address
+  :: Address
   -> QueryM (Maybe UtxoM)
 utxosAt = mkUtxoQuery
   <<< mkOgmiosRequest Ogmios.queryUtxosAtCall _.utxo


### PR DESCRIPTION
Closes #777

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [ ] **All** existing examples have been run locally against a fully-synced testnet node
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`)
