### PR TITLE
 Add ports check before attempting to start plutip runtime 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Transaction.submitE` like submit but uses an `Either (Array Aeson) TransactionHash` to handle a SubmitFail response from ogmios
 - `Contract.Chain.waitNSlots`,  `Contract.Chain.currentSlot` and `Contract.Chain.currentTime` a function to wait at least `N` number of slots and functions to get the current time in `Slot` or `POSIXTime`. ([#740](https://github.com/Plutonomicon/cardano-transaction-lib/issues/740))
 - `project.launchSearchablePursDocs` to create an `apps` output for serving Pursuit documentation locally ([#816](https://github.com/Plutonomicon/cardano-transaction-lib/issues/816))
+- A check for port availability before Plutip runtime initialization attempt ([#837](https://github.com/Plutonomicon/cardano-transaction-lib/issues/837))
 
 ### Changed
 

--- a/src/Plutip/PortCheck.js
+++ b/src/Plutip/PortCheck.js
@@ -1,0 +1,24 @@
+const net = require("net");
+
+exports._isPortAvailable = port => () =>
+  new Promise((resolve, reject) => {
+    const server = net
+      .createServer()
+      .once("error", function (err) {
+        if (err.code == "EADDRINUSE") {
+          resolve(false);
+        } else {
+          reject(
+            "Failed check for port availability (port: " +
+              port +
+              ", error: " +
+              err.code +
+              ")"
+          );
+        }
+      })
+      .once("listening", () => {
+        server.once("close", () => resolve(true)).close();
+      })
+      .listen(port);
+  });

--- a/src/Plutip/PortCheck.purs
+++ b/src/Plutip/PortCheck.purs
@@ -1,0 +1,15 @@
+module Plutip.PortCheck
+  ( isPortAvailable
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Data.UInt (UInt, toInt)
+import Effect (Effect)
+import Effect.Aff (Aff)
+
+foreign import _isPortAvailable :: Int -> Effect (Promise Boolean)
+
+isPortAvailable :: UInt -> Aff Boolean
+isPortAvailable = toAffE <<< _isPortAvailable <<< toInt

--- a/src/Plutip/Server.purs
+++ b/src/Plutip/Server.purs
@@ -17,6 +17,7 @@ import Affjax.ResponseFormat as Affjax.ResponseFormat
 import Contract.Address (NetworkId(MainnetId))
 import Contract.Monad (Contract, ContractEnv(ContractEnv), runContractInEnv)
 import Control.Monad.Error.Class (withResource)
+import Data.Array as Array
 import Data.Bifunctor (lmap)
 import Data.Either (Either(Left), either)
 import Data.HTTP.Method as Method
@@ -25,6 +26,9 @@ import Data.Newtype (unwrap, wrap)
 import Data.Posix.Signal (Signal(SIGINT))
 import Data.String.CodeUnits as String
 import Data.String.Pattern (Pattern(Pattern))
+import Data.Traversable (for, foldMap)
+import Data.Tuple.Nested ((/\))
+import Data.UInt (UInt)
 import Data.UInt as UInt
 import Effect (Effect)
 import Effect.Aff (Aff, Milliseconds(Milliseconds))
@@ -45,6 +49,7 @@ import Node.ChildProcess
   , kill
   , spawn
   )
+import Plutip.PortCheck (isPortAvailable)
 import Plutip.Spawn
   ( NewOutputAction(Success, NoOp)
   , killOnExit
@@ -93,7 +98,8 @@ withPlutipContractEnv
   -> distr
   -> (ContractEnv () -> wallets -> Aff a)
   -> Aff a
-withPlutipContractEnv plutipCfg distr cont =
+withPlutipContractEnv plutipCfg distr cont = do
+  configCheck plutipCfg
   withPlutipServer $
     withPlutipCluster \response ->
       withWallets response \wallets ->
@@ -119,7 +125,7 @@ withPlutipContractEnv plutipCfg distr cont =
   withPostgres :: ClusterStartupParameters -> Aff a -> Aff a
   withPostgres response =
     withResource (startPostgresServer plutipCfg.postgresConfig response)
-      stopChildProcess <<< const
+      (stopPostgresServer plutipCfg.postgresConfig.port) <<< const
 
   withOgmios :: ClusterStartupParameters -> Aff a -> Aff a
   withOgmios response =
@@ -149,6 +155,27 @@ withPlutipContractEnv plutipCfg distr cont =
   -- a version of Contract.Monad.stopContractEnv without a compile-time warning
   stopContractEnv :: ContractEnv () -> Effect Unit
   stopContractEnv env = stopQueryRuntime (unwrap env).runtime
+
+-- | Throw an exception if `PlutipConfig` contains ports that are occupied.
+configCheck :: PlutipConfig -> Aff Unit
+configCheck cfg = do
+  let
+    services =
+      [ cfg.port /\ "plutip-server"
+      , cfg.ogmiosConfig.port /\ "ogmios"
+      , cfg.ogmiosDatumCacheConfig.port /\ "ogmios-datum-cache"
+      , cfg.ctlServerConfig.port /\ "ctl-server"
+      , cfg.postgresConfig.port /\ "postgres"
+      ]
+  occupiedServices <- Array.catMaybes <$> for services \(port /\ service) -> do
+    isPortAvailable port <#> if _ then Nothing else Just (port /\ service)
+  unless (Array.null occupiedServices) do
+    liftEffect $ throw $
+      "Unable to run the following services, because the ports are occupied:\
+      \\n" <> foldMap printServiceEntry occupiedServices
+  where
+  printServiceEntry (port /\ service) =
+    "- " <> service <> " (port: " <> show (UInt.toInt port) <> ")\n"
 
 startPlutipCluster
   :: forall (distr :: Type) (wallets :: Type)
@@ -298,6 +325,16 @@ startPostgresServer pgConfig _ = do
     )
     defaultExecSyncOptions
   pure pgChildProcess
+
+-- | Kill postgres and wait for it to stop listening
+stopPostgresServer :: UInt -> ChildProcess -> Aff Unit
+stopPostgresServer port childProcess = do
+  stopChildProcess childProcess
+  void $ recovering defaultRetryPolicy ([ \_ _ -> pure true ])
+    \_ -> do
+      isAvailable <- isPortAvailable port
+      unless isAvailable do
+        liftEffect $ throw "retry"
 
 startOgmiosDatumCache
   :: PlutipConfig

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -68,7 +68,7 @@ import Examples.MintsMultipleTokens
   , mintingPolicyRdmrInt2
   , mintingPolicyRdmrInt3
   )
-import Mote (group, skip, test)
+import Mote (group, test)
 import Plutip.Server
   ( startPlutipCluster
   , startPlutipServer
@@ -362,7 +362,7 @@ suite = do
           unless (locked # Map.isEmpty) do
             liftEffect $ throw "locked inputs map is not empty"
 
-    skip $ test "runPlutipContract: AlwaysSucceeds" do
+    test "runPlutipContract: AlwaysSucceeds" do
       let
         distribution :: InitialUTxO
         distribution =


### PR DESCRIPTION
Closes #837

- Also unskips the test that is no more flaky after #830

### Pre-review checklist

- [x] All code has been formatted using our config (`make format` for Purescript, `nixpkgs-fmt` for Nix)
- [x] All Purescript imports are explicit, including constructors
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
