### PR TITLE
Make sure `haskell-nix.overlay` has been applied

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -437,7 +437,7 @@
 
             - [Documentation](https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc)
 
-            - [Pursuit docs](https://plutonomicon.github.io/cardano-transaction-lib/)
+            - [Generated docs](https://plutonomicon.github.io/cardano-transaction-lib/)
 
             - [Discord server]( https://discord.gg/c8kZWxzJ)
 

--- a/flake.nix
+++ b/flake.nix
@@ -427,14 +427,18 @@
 
             To enter the Nix environment and start working on it, run `nix develop`
 
-            Please also see
-              - Our documentation at https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc
-              - Our Pursuit docs at https://plutonomicon.github.io/cardano-transaction-lib/
-              - Our Discord server https://discord.gg/c8kZWxzJ
+            Please also see our
+
+            - [Documentation](https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc)
+
+            - [Pursuit docs](https://plutonomicon.github.io/cardano-transaction-lib/)
+
+            - [Discord server]( https://discord.gg/c8kZWxzJ)
 
             If you encounter problems and/or want to report a bug, you can open
-            an issue at https://github.com/Plutonomicon/cardano-transaction-lib/issues.
-            Please search for existing issues before!
+            an issue [here](https://github.com/Plutonomicon/cardano-transaction-lib/issues).
+
+            Please search for existing issues beforehand!
 
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -314,7 +314,7 @@
             buildCtlRuntime = buildCtlRuntime final;
             launchCtlRuntime = launchCtlRuntime final;
             inherit cardano-configurations;
-          } //
+          }
           # if `haskell-nix.overlay` has not been applied, we cannot use the
           # package set to build the `hsProjectFor`. We don't want to always
           # add haskell.nix's overlay or use the `ctl-server` from our own
@@ -325,9 +325,15 @@
           #
           # We can check for the necessary attribute and then apply the overlay
           # if necessary
-          nixpkgs.lib.optionalAttrs
+          // nixpkgs.lib.optionalAttrs
             (!(builtins.hasAttr "haskell-nix" prev))
-            (haskell-nix.overlay final prev);
+            (haskell-nix.overlay final prev)
+          # Similarly, we need to make sure that `libsodium-vrf` is available
+          # for the Haskell server
+          // nixpkgs.lib.optionalAttrs
+            (!(builtins.hasAttr "libsodium-vrf" prev))
+            (iohk-nix.overlays.crypto final prev)
+        ;
       };
 
       # flake from haskell.nix project

--- a/templates/ctl-scaffold/README.md
+++ b/templates/ctl-scaffold/README.md
@@ -4,10 +4,14 @@ Welcome to your new CTL project!
 
 To enter the Nix environment and start working on it, run `nix develop`
 
-Please also see
+Please also see our
 
-- Our documentation at https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc
-- Our Pursuit docs at https://plutonomicon.github.io/cardano-transaction-lib/
-- Our Discord server https://discord.gg/c8kZWxzJ
+- [Documentation](https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc)
 
-If you encounter problems and/or want to report a bug, you can open an issue at https://github.com/Plutonomicon/cardano-transaction-lib/issues. Please search for existing issues before!
+- [Pursuit docs](https://plutonomicon.github.io/cardano-transaction-lib/)
+
+- [Discord server](https://discord.gg/c8kZWxzJ)
+
+If you encounter problems and/or want to report a bug, you can open an issue [here](https://github.com/Plutonomicon/cardano-transaction-lib/issues).
+
+Please search for existing issues beforehand!

--- a/templates/ctl-scaffold/README.md
+++ b/templates/ctl-scaffold/README.md
@@ -8,7 +8,7 @@ Please also see our
 
 - [Documentation](https://github.com/Plutonomicon/cardano-transaction-lib/tree/develop/doc)
 
-- [Pursuit docs](https://plutonomicon.github.io/cardano-transaction-lib/)
+- [Generated docs](https://plutonomicon.github.io/cardano-transaction-lib/)
 
 - [Discord server](https://discord.gg/c8kZWxzJ)
 

--- a/templates/ctl-scaffold/flake.lock
+++ b/templates/ctl-scaffold/flake.lock
@@ -600,17 +600,17 @@
         "servant-purescript": "servant-purescript_2"
       },
       "locked": {
-        "lastModified": 1659338089,
-        "narHash": "sha256-czjhC4uDnc8GXnmyGohnNCVV1/azmhH4jTCNp4JAucE=",
+        "lastModified": 1659696564,
+        "narHash": "sha256-dLoJFsnPDd10yfCVCfwOXeol/u2qO/yC0rzGfNlcytc=",
         "owner": "Plutonomicon",
         "repo": "cardano-transaction-lib",
-        "rev": "ec38c06c77c1b75a7e7f1dcb215db7816e44b339",
+        "rev": "dd79ed2cabed08d8f82925c2cfddb288f7228f6d",
         "type": "github"
       },
       "original": {
         "owner": "Plutonomicon",
         "repo": "cardano-transaction-lib",
-        "rev": "ec38c06c77c1b75a7e7f1dcb215db7816e44b339",
+        "rev": "dd79ed2cabed08d8f82925c2cfddb288f7228f6d",
         "type": "github"
       }
     },
@@ -1510,17 +1510,17 @@
         "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
-        "lastModified": 1658378474,
-        "narHash": "sha256-BGZNLo7ABgg6iFY84nYua6jgl8EqhM8bI2bLnLB+z8Q=",
+        "lastModified": 1659358988,
+        "narHash": "sha256-YKabPu9FDvUNmSR7+MNwLwiURv4lWQr13r1CuoS3qhM=",
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "1e618a1949667ea3eb972fbaccf34414e8d17e89",
+        "rev": "47f01a1d9f7dc5cc5246c0c228e5cf5f5ba44399",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios-datum-cache",
-        "rev": "1e618a1949667ea3eb972fbaccf34414e8d17e89",
+        "rev": "47f01a1d9f7dc5cc5246c0c228e5cf5f5ba44399",
         "type": "github"
       }
     },

--- a/templates/ctl-scaffold/flake.nix
+++ b/templates/ctl-scaffold/flake.nix
@@ -10,7 +10,7 @@
       type = "github";
       owner = "Plutonomicon";
       repo = "cardano-transaction-lib";
-      rev = "ec38c06c77c1b75a7e7f1dcb215db7816e44b339";
+      rev = "dd79ed2cabed08d8f82925c2cfddb288f7228f6d";
     };
     nixpkgs.follows = "ctl/nixpkgs";
   };

--- a/templates/ctl-scaffold/packages.dhall
+++ b/templates/ctl-scaffold/packages.dhall
@@ -362,7 +362,7 @@ let additions =
           , "variant"
           ]
         , repo = "https://github.com/Plutonomicon/cardano-transaction-lib.git"
-        , version = "ec38c06c77c1b75a7e7f1dcb215db7816e44b339"
+        , version = "dd79ed2cabed08d8f82925c2cfddb288f7228f6d"
         }
       }
 in upstream // additions

--- a/templates/ctl-scaffold/spago-packages.nix
+++ b/templates/ctl-scaffold/spago-packages.nix
@@ -211,11 +211,11 @@ let
 
     "cardano-transaction-lib" = pkgs.stdenv.mkDerivation {
         name = "cardano-transaction-lib";
-        version = "ec38c06c77c1b75a7e7f1dcb215db7816e44b339";
+        version = "dd79ed2cabed08d8f82925c2cfddb288f7228f6d";
         src = pkgs.fetchgit {
           url = "https://github.com/Plutonomicon/cardano-transaction-lib.git";
-          rev = "ec38c06c77c1b75a7e7f1dcb215db7816e44b339";
-          sha256 = "1hdr821ag39hipw136mkyvbma99lcy41mckrbq3cz7c3ic5y2f3k";
+          rev = "dd79ed2cabed08d8f82925c2cfddb288f7228f6d";
+          sha256 = "1myabkcprimwsa1gqfxaxpz2bsjx1vy0k5ghr5sds3fgr4b0kfkl";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";


### PR DESCRIPTION
Fixes an issue introduced in #817. In order to avoid instantiating our own `nixpkgs` (and using our own version of haskell.nix, which can cause painful issues for users), we add `ctl-server` to `overlays.runtime` using the `hsProjectFor` function. If users aren't using haskell.nix themselves, `haskell-nix` will be missing from the package set and `ctl-server` can't be built. This fixes it by checking if that attribute is present and if not applying the overlay

I also fixed the template `welcomeText` so it gets formatted correctly