### PR TITLE
Brian/plutip wallet spec

### DIFF
--- a/src/BalanceTx/BalanceTx.purs
+++ b/src/BalanceTx/BalanceTx.purs
@@ -52,7 +52,7 @@ module BalanceTx
 
 import Prelude
 
-import Aeson(Aeson)
+import Aeson (Aeson)
 import BalanceTx.UtxoMinAda (adaOnlyUtxoMinAdaValue, utxoMinAdaValue)
 import Cardano.Types.Transaction
   ( Redeemer(Redeemer)
@@ -120,7 +120,10 @@ import QueryM
   , getWalletCollateral
   , evaluateTxOgmios
   ) as QueryM
-import QueryM.Ogmios (TxEvaluationR(TxEvaluationSuccess,TxEvaluationFailure),CostMap) as Ogmios
+import QueryM.Ogmios
+  ( TxEvaluationR(TxEvaluationSuccess, TxEvaluationFailure)
+  , CostMap
+  ) as Ogmios
 import QueryM.Utxos (utxosAt, filterLockedUtxos)
 import ReindexRedeemers (ReindexErrors, reindexSpentScriptRedeemers')
 import Serialization (convertTransaction, toBytes) as Serialization
@@ -326,7 +329,8 @@ evalExUnitsAndMinFee' unattachedTx =
     -- Evaluate transaction ex units:
     evalResult <- lift $ evalTxExecutionUnits attachedTx
     case evalResult of
-      Ogmios.TxEvaluationFailure aeson -> except $ Left $ OgmiosEvaluationError aeson
+      Ogmios.TxEvaluationFailure aeson -> except $ Left $ OgmiosEvaluationError
+        aeson
       Ogmios.TxEvaluationSuccess rdmrPtrExUnitsList -> do
         let
           -- Set execution units received from the server:

--- a/src/Contract/Test/Plutip.purs
+++ b/src/Contract/Test/Plutip.purs
@@ -17,4 +17,4 @@ import Plutip.Types
   , InitialUTxODistribution
   , class UtxoDistribution
   ) as X
-import Contract.Wallet (withKeyWallet) as X
+import Contract.Wallet (withWalletSpec) as X

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -48,6 +48,7 @@ module QueryM
   , mkQueryRuntime
   , mkRequest
   , mkRequestAff
+  , mkWalletBySpec
   , module ServerConfig
   , ownPaymentPubKeyHash
   , ownPubKeyHash

--- a/src/QueryM/Ogmios.purs
+++ b/src/QueryM/Ogmios.purs
@@ -26,7 +26,7 @@ module QueryM.Ogmios
   , SlotLength(SlotLength)
   , SubmitTxR(SubmitTxSuccess, SubmitFail)
   , SystemStart(SystemStart)
-  , TxEvaluationR(TxEvaluationSuccess,TxEvaluationFailure)
+  , TxEvaluationR(TxEvaluationSuccess, TxEvaluationFailure)
   , TxHash
   , UtxoQR(UtxoQR)
   , UtxoQueryResult
@@ -481,13 +481,13 @@ instance Show TxEvaluationR where
 instance DecodeAeson TxEvaluationR where
   decodeAeson = aesonObject $ \obj ->
     (TxEvaluationFailure <$> getField obj "EvaluationFailure") <|>
-    -- Putting the falure case first gives better errors in some cases
-    (do
-      rdmrPtrExUnitsList :: Array (String /\ Aeson) <-
-        ForeignObject.toUnfoldable <$> getField obj "EvaluationResult"
-      TxEvaluationSuccess <<< Map.fromFoldable <$>
-        traverse decodeRdmrPtrExUnitsItem rdmrPtrExUnitsList
-    )
+      -- Putting the falure case first gives better errors in some cases
+      ( do
+          rdmrPtrExUnitsList :: Array (String /\ Aeson) <-
+            ForeignObject.toUnfoldable <$> getField obj "EvaluationResult"
+          TxEvaluationSuccess <<< Map.fromFoldable <$>
+            traverse decodeRdmrPtrExUnitsItem rdmrPtrExUnitsList
+      )
     where
     decodeRdmrPtrExUnitsItem
       :: String /\ Aeson

--- a/test/Ogmios/EvaluateTx.purs
+++ b/test/Ogmios/EvaluateTx.purs
@@ -5,7 +5,6 @@ import Prelude
 import Aeson (decodeAeson, JsonDecodeError(TypeMismatch))
 import Data.Either (Either(Left, Right))
 import Data.Map (toUnfoldable) as Map
-import Data.Newtype (unwrap)
 import Data.Tuple.Nested (type (/\), (/\))
 import Effect.Class (liftEffect)
 import Mote (group, test)
@@ -13,11 +12,11 @@ import Test.Fixtures
   ( ogmiosEvaluateTxInvalidPointerFormatFixture
   , ogmiosEvaluateTxValidRespFixture
   )
-import Test.Spec.Assertions (shouldEqual, shouldSatisfy)
+import Test.Spec.Assertions (shouldEqual, shouldSatisfy,fail)
 import TestM (TestPlanM)
 import Types.Natural (fromInt')
 import Types.RedeemerTag (RedeemerTag(Mint, Spend))
-import QueryM.Ogmios (TxEvaluationR, ExecutionUnits, RedeemerPointer)
+import QueryM.Ogmios (TxEvaluationR(TxEvaluationFailure,TxEvaluationSuccess), ExecutionUnits, RedeemerPointer)
 
 suite :: TestPlanM Unit
 suite = do
@@ -26,8 +25,10 @@ suite = do
       test "Successfully decodes a valid response" do
         txEvalR :: Either JsonDecodeError TxEvaluationR <-
           decodeAeson <$> liftEffect ogmiosEvaluateTxValidRespFixture
-        (Map.toUnfoldable <<< unwrap <$> txEvalR) `shouldEqual`
-          Right ogmiosEvaluateTxValidRespDecoded
+        case txEvalR of
+          Left err -> fail $ "JSON decodeing failed with:" <> show err
+          Right (TxEvaluationFailure aeson) -> fail $ "Evaluation failed with:" <> show aeson
+          Right (TxEvaluationSuccess response) -> Map.toUnfoldable response `shouldEqual` ogmiosEvaluateTxValidRespDecoded
 
       test "Fails to decode a response with invalid redeemer pointer format" do
         txEvalR :: Either JsonDecodeError TxEvaluationR <-

--- a/test/Ogmios/EvaluateTx.purs
+++ b/test/Ogmios/EvaluateTx.purs
@@ -12,11 +12,15 @@ import Test.Fixtures
   ( ogmiosEvaluateTxInvalidPointerFormatFixture
   , ogmiosEvaluateTxValidRespFixture
   )
-import Test.Spec.Assertions (shouldEqual, shouldSatisfy,fail)
+import Test.Spec.Assertions (shouldEqual, shouldSatisfy, fail)
 import TestM (TestPlanM)
 import Types.Natural (fromInt')
 import Types.RedeemerTag (RedeemerTag(Mint, Spend))
-import QueryM.Ogmios (TxEvaluationR(TxEvaluationFailure,TxEvaluationSuccess), ExecutionUnits, RedeemerPointer)
+import QueryM.Ogmios
+  ( TxEvaluationR(TxEvaluationFailure, TxEvaluationSuccess)
+  , ExecutionUnits
+  , RedeemerPointer
+  )
 
 suite :: TestPlanM Unit
 suite = do
@@ -27,8 +31,10 @@ suite = do
           decodeAeson <$> liftEffect ogmiosEvaluateTxValidRespFixture
         case txEvalR of
           Left err -> fail $ "JSON decodeing failed with:" <> show err
-          Right (TxEvaluationFailure aeson) -> fail $ "Evaluation failed with:" <> show aeson
-          Right (TxEvaluationSuccess response) -> Map.toUnfoldable response `shouldEqual` ogmiosEvaluateTxValidRespDecoded
+          Right (TxEvaluationFailure aeson) -> fail $ "Evaluation failed with:"
+            <> show aeson
+          Right (TxEvaluationSuccess response) -> Map.toUnfoldable response
+            `shouldEqual` ogmiosEvaluateTxValidRespDecoded
 
       test "Fails to decode a response with invalid redeemer pointer format" do
         txEvalR :: Either JsonDecodeError TxEvaluationR <-

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -43,7 +43,7 @@ import Contract.Transaction
 import Contract.TxConstraints as Constraints
 import Contract.Value (CurrencySymbol, TokenName)
 import Contract.Value as Value
-import Contract.Wallet (withKeyWallet)
+import Contract.Wallet (withWalletSpec)
 import Control.Monad.Error.Class (withResource)
 import Control.Monad.Reader (asks)
 import Control.Parallel (parallel, sequential)
@@ -153,9 +153,9 @@ suite = do
           ] /\
             [ BigInt.fromInt 2_000_000_000 ]
       runPlutipContract config distribution \(alice /\ bob) -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pure unit -- sign, balance, submit, etc.
-        withKeyWallet bob do
+        withWalletSpec bob do
           pure unit -- sign, balance, submit, etc.
 
     test "runPlutipContract: Pkh2Pkh" do
@@ -166,7 +166,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pkh <- liftedM "Failed to get own PKH" ownPaymentPubKeyHash
           let
             constraints :: Constraints.TxConstraints Void Void
@@ -196,8 +196,8 @@ suite = do
             ]
       withPlutipContractEnv config distribution \env (alice /\ bob) ->
         sequential ado
-          parallel $ runContractInEnv env $ withKeyWallet alice do
-            bobPkh <- liftedM "Failed to get PKH" $ withKeyWallet bob
+          parallel $ runContractInEnv env $ withWalletSpec alice do
+            bobPkh <- liftedM "Failed to get PKH" $ withWalletSpec bob
               ownPaymentPubKeyHash
             let
               constraints :: Constraints.TxConstraints Void Void
@@ -214,8 +214,8 @@ suite = do
             bsTx <-
               liftedE $ balanceAndSignTxE ubTx
             submitAndLog bsTx
-          parallel $ runContractInEnv env $ withKeyWallet bob do
-            alicePkh <- liftedM "Failed to get PKH" $ withKeyWallet alice
+          parallel $ runContractInEnv env $ withWalletSpec bob do
+            alicePkh <- liftedM "Failed to get PKH" $ withWalletSpec alice
               ownPaymentPubKeyHash
             let
               constraints :: Constraints.TxConstraints Void Void
@@ -242,7 +242,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           mp <- alwaysMintsPolicy
           cs <- liftContractAffM "Cannot get cs" $ Value.scriptCurrencySymbol mp
           tn <- liftContractM "Cannot make token name"
@@ -289,7 +289,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           tn1 <- mkTokenName "Token with a long name"
           tn2 <- mkTokenName "Token"
           mp1 /\ cs1 <- mkCurrencySymbol mintingPolicyRdmrInt1
@@ -332,7 +332,7 @@ suite = do
           , BigInt.fromInt 5_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pkh <- liftedM "Failed to get own PKH" ownPaymentPubKeyHash
           let
             constraints :: Constraints.TxConstraints Void Void
@@ -370,7 +370,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           validator <- AlwaysSucceeds.alwaysSucceedsScript
           vhash <- liftContractAffM "Couldn't hash validator"
             $ validatorHash validator


### PR DESCRIPTION
Closes # .

Downstream we want to test our CLI with plutip. The cli reads wallets from files so we need plutip to provide wallets in a type that's still possible to serialize into a file.

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
