### PR TITLE
make plutip use WalletSpec instead of KeyWallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Address.addressToBech32` and `Contract.Address.addressWithNetworkTagToBech32` ([#846](https://github.com/Plutonomicon/cardano-transaction-lib/issues/846))
 - `doc/e2e-testing.md` describes the process of E2E testing. ([#814](https://github.com/Plutonomicon/cardano-transaction-lib/pull/814))
 - Added unzip to the `devShell`. New `purescriptProject.shell` flag `withChromium` also optionally adds Chromium to the `devShell` ([#799](https://github.com/Plutonomicon/cardano-transaction-lib/pull/799))
+- Exposed `mkWalletBySpec` in `QuerryM`
 
 ### Changed
 
@@ -68,6 +69,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The [`ctl-scaffold`](https://github.com/mlabs-haskell/ctl-scaffold) repository has been archived and deprecated and its contents moved to `templates.ctl-scaffold` in the CTL flake ([#760](https://github.com/Plutonomicon/cardano-transaction-lib/issues/760)).
 - The CTL `overlay` output has been deprecated and replaced by `overlays.purescript` and `overlays.runtime` ([#796](https://github.com/Plutonomicon/cardano-transaction-lib/issues/796)).
 - `buildCtlRuntime` and `launchCtlRuntime` now take an `extraServices` argument to add `docker-compose` services to the resulting Arion expression ([#769](https://github.com/Plutonomicon/cardano-transaction-lib/issues/769)).
+- Replaced `withKeyWallet` with `withWalletSpec`
+- `withPlutipContractEnv` and `runPlutipContract` now use `WalletSpec`s instead of `KeyWallet`s
 
 ### Removed
 

--- a/src/Contract/Test/Plutip.purs
+++ b/src/Contract/Test/Plutip.purs
@@ -17,4 +17,4 @@ import Plutip.Types
   , InitialUTxODistribution
   , class UtxoDistribution
   ) as X
-import Contract.Wallet (withKeyWallet) as X
+import Contract.Wallet (withWalletSpec) as X

--- a/src/Contract/Wallet.purs
+++ b/src/Contract/Wallet.purs
@@ -19,8 +19,8 @@ import Data.Lens.Common (simple)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(Just))
-import Effect.Aff.Class(liftAff)
-import QueryM(mkWalletBySpec)
+import Effect.Aff.Class (liftAff)
+import QueryM (mkWalletBySpec)
 import Serialization (privateKeyFromBytes) as Serialization
 import Type.Proxy (Proxy(Proxy))
 import Wallet (isGeroAvailable, isNamiAvailable) as Wallet

--- a/src/Plutip/Types.purs
+++ b/src/Plutip/Types.purs
@@ -55,8 +55,8 @@ import Types.ByteArray (hexToByteArray)
 import Types.RawBytes (RawBytes(RawBytes))
 import Wallet.Key (PrivatePaymentKey(PrivatePaymentKey))
 import Wallet.Spec
-  (WalletSpec(UseKeys)
-  ,PrivatePaymentKeySource(PrivatePaymentKeyValue)
+  ( WalletSpec(UseKeys)
+  , PrivatePaymentKeySource(PrivatePaymentKeyValue)
   )
 
 type PlutipConfig =
@@ -208,7 +208,7 @@ instance UtxoDistribution Unit Unit where
 instance UtxoDistribution InitialUTxO WalletSpec where
   encodeDistribution amounts = [ amounts ]
   decodeWallets [ (PrivateKeyResponse key) ] =
-    pure $ UseKeys ( PrivatePaymentKeyValue $ PrivatePaymentKey key) Nothing
+    pure $ UseKeys (PrivatePaymentKeyValue $ PrivatePaymentKey key) Nothing
   decodeWallets _ = Nothing
 
 instance
@@ -219,5 +219,6 @@ instance
   decodeWallets = Array.uncons >>> case _ of
     Nothing -> Nothing
     Just { head: PrivateKeyResponse key, tail } ->
-      Tuple (UseKeys (PrivatePaymentKeyValue $ PrivatePaymentKey key) Nothing) <$>
-        decodeWallets tail
+      Tuple (UseKeys (PrivatePaymentKeyValue $ PrivatePaymentKey key) Nothing)
+        <$>
+          decodeWallets tail

--- a/src/QueryM.purs
+++ b/src/QueryM.purs
@@ -48,6 +48,7 @@ module QueryM
   , mkQueryRuntime
   , mkRequest
   , mkRequestAff
+  , mkWalletBySpec
   , module ServerConfig
   , ownPaymentPubKeyHash
   , ownPubKeyHash

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -44,7 +44,7 @@ import Contract.Transaction
 import Contract.TxConstraints as Constraints
 import Contract.Value (CurrencySymbol, TokenName)
 import Contract.Value as Value
-import Contract.Wallet (withKeyWallet)
+import Contract.Wallet (withWalletSpec)
 import Control.Monad.Error.Class (withResource)
 import Control.Monad.Reader (asks)
 import Control.Parallel (parallel, sequential)
@@ -155,9 +155,9 @@ suite = do
           ] /\
             [ BigInt.fromInt 2_000_000_000 ]
       runPlutipContract config distribution \(alice /\ bob) -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pure unit -- sign, balance, submit, etc.
-        withKeyWallet bob do
+        withWalletSpec bob do
           pure unit -- sign, balance, submit, etc.
 
     test "runPlutipContract: Pkh2Pkh" do
@@ -168,7 +168,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pkh <- liftedM "Failed to get own PKH" ownPaymentPubKeyHash
           let
             constraints :: Constraints.TxConstraints Void Void
@@ -198,8 +198,8 @@ suite = do
             ]
       withPlutipContractEnv config distribution \env (alice /\ bob) ->
         sequential ado
-          parallel $ runContractInEnv env $ withKeyWallet alice do
-            bobPkh <- liftedM "Failed to get PKH" $ withKeyWallet bob
+          parallel $ runContractInEnv env $ withWalletSpec alice do
+            bobPkh <- liftedM "Failed to get PKH" $ withWalletSpec bob
               ownPaymentPubKeyHash
             let
               constraints :: Constraints.TxConstraints Void Void
@@ -216,8 +216,8 @@ suite = do
             bsTx <-
               liftedE $ balanceAndSignTxE ubTx
             submitAndLog bsTx
-          parallel $ runContractInEnv env $ withKeyWallet bob do
-            alicePkh <- liftedM "Failed to get PKH" $ withKeyWallet alice
+          parallel $ runContractInEnv env $ withWalletSpec bob do
+            alicePkh <- liftedM "Failed to get PKH" $ withWalletSpec alice
               ownPaymentPubKeyHash
             let
               constraints :: Constraints.TxConstraints Void Void
@@ -244,7 +244,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           mp <- alwaysMintsPolicy
           cs <- liftContractAffM "Cannot get cs" $ Value.scriptCurrencySymbol mp
           tn <- liftContractM "Cannot make token name"
@@ -291,7 +291,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           tn1 <- mkTokenName "Token with a long name"
           tn2 <- mkTokenName "Token"
           mp1 /\ cs1 <- mkCurrencySymbol mintingPolicyRdmrInt1
@@ -331,7 +331,7 @@ suite = do
           , BigInt.fromInt 100_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           pkh <- liftedM "Failed to get own PKH" ownPaymentPubKeyHash
           let
             constraints :: Constraints.TxConstraints Void Void
@@ -369,7 +369,7 @@ suite = do
           , BigInt.fromInt 2_000_000_000
           ]
       runPlutipContract config distribution \alice -> do
-        withKeyWallet alice do
+        withWalletSpec alice do
           validator <- AlwaysSucceeds.alwaysSucceedsScript
           vhash <- liftContractAffM "Couldn't hash validator"
             $ validatorHash validator


### PR DESCRIPTION
Closes # .

Downstream we want to test our CLI with plutip. The cli reads wallets from files so we need plutip to provide wallets in a type that's still possible to serialize into a file.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
