### PR TITLE
add the keys to the keywallet type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Address.addressToBech32` and `Contract.Address.addressWithNetworkTagToBech32` ([#846](https://github.com/Plutonomicon/cardano-transaction-lib/issues/846))
 - `doc/e2e-testing.md` describes the process of E2E testing. ([#814](https://github.com/Plutonomicon/cardano-transaction-lib/pull/814))
 - Added unzip to the `devShell`. New `purescriptProject.shell` flag `withChromium` also optionally adds Chromium to the `devShell` ([#799](https://github.com/Plutonomicon/cardano-transaction-lib/pull/799))
+- Added paymentKey and stakeKey fields to the record in KeyWallet
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `doc/e2e-testing.md` describes the process of E2E testing. ([#814](https://github.com/Plutonomicon/cardano-transaction-lib/pull/814))
 - Added unzip to the `devShell`. New `purescriptProject.shell` flag `withChromium` also optionally adds Chromium to the `devShell` ([#799](https://github.com/Plutonomicon/cardano-transaction-lib/pull/799))
 - Added paymentKey and stakeKey fields to the record in KeyWallet
+- Added `privatePaymentKeyToFile`, `privateStakeKeyToFile`, `formatPaymentKey` and `formatStakeKey` to `Wallet.KeyFile` for formatting private keys and writing them to files
+- Added `bytesFromPrivateKey` to `Serialization`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `doc/e2e-testing.md` describes the process of E2E testing. ([#814](https://github.com/Plutonomicon/cardano-transaction-lib/pull/814))
 - Added unzip to the `devShell`. New `purescriptProject.shell` flag `withChromium` also optionally adds Chromium to the `devShell` ([#799](https://github.com/Plutonomicon/cardano-transaction-lib/pull/799))
 - Added paymentKey and stakeKey fields to the record in KeyWallet
-- Added `privatePaymentKeyToFile`, `privateStakeKeyToFile`, `formatPaymentKey` and `formatStakeKey` to `Wallet.KeyFile` for formatting private keys and writing them to files
+- Added `formatPaymentKey` and `formatStakeKey` to `Wallet.KeyFile` and `Contract.Wallet` for formatting private keys
+- Added `privatePaymentKeyToFile` and `privateStakeKeyToFile` to `Wallet.KeyFile` and `Contract.Wallet.KeyFile` for writing keys to files
 - Added `bytesFromPrivateKey` to `Serialization`
 
 ### Changed

--- a/src/Contract/Wallet.purs
+++ b/src/Contract/Wallet.purs
@@ -7,6 +7,7 @@ module Contract.Wallet
   , module Wallet.Spec
   , module Wallet.Key
   , module Wallet
+  , module Wallet.KeyFile
   ) where
 
 import Prelude
@@ -30,6 +31,7 @@ import Wallet.Spec
   )
 import Wallet.Key (KeyWallet, privateKeysToKeyWallet) as Wallet
 import Wallet.Key (PrivatePaymentKey, PrivateStakeKey)
+import Wallet.KeyFile (formatPaymentKey, formatStakeKey)
 
 withKeyWallet
   :: forall (r :: Row Type) (a :: Type)

--- a/src/Contract/Wallet/KeyFile.purs
+++ b/src/Contract/Wallet/KeyFile.purs
@@ -1,6 +1,7 @@
 -- | Node-only module. Allows to work with Skeys stored in files.
 module Contract.Wallet.KeyFile
   ( mkKeyWalletFromFiles
+  , module Wallet.KeyFile
   ) where
 
 import Prelude
@@ -11,7 +12,12 @@ import Effect.Aff (Aff)
 import Node.Path (FilePath)
 import Wallet (Wallet) as Wallet
 import Wallet (mkKeyWallet)
-import Wallet.KeyFile (privatePaymentKeyFromFile, privateStakeKeyFromFile)
+import Wallet.KeyFile
+  ( privatePaymentKeyFromFile
+  , privateStakeKeyFromFile
+  , privatePaymentKeyToFile
+  , privateStakeKeyToFile
+  )
 
 -- | Load `PrivateKey`s from `skey` files (the files should be in JSON format as
 -- | accepted by cardano-cli).

--- a/src/Serialization.js
+++ b/src/Serialization.js
@@ -102,6 +102,14 @@ exports._privateKeyFromBytes = maybe => bytes => {
   }
 };
 
+exports._bytesFromPrivateKey = maybe => key => {
+  try {
+    return maybe.just(key.as_bytes());
+  } catch (err) {
+    return maybe.nothing;
+  }
+};
+
 exports.publicKeyHash = pk => pk.hash();
 
 exports.newEd25519Signature = bech32 => () =>

--- a/src/Serialization.purs
+++ b/src/Serialization.purs
@@ -1,5 +1,6 @@
 module Serialization
-  ( convertTransaction
+  ( bytesFromPrivateKey
+  , convertTransaction
   , convertTxBody
   , convertTxInput
   , convertTxOutput
@@ -216,6 +217,9 @@ foreign import publicKeyFromPrivateKey
 
 foreign import _privateKeyFromBytes
   :: MaybeFfiHelper -> RawBytes -> Maybe PrivateKey
+
+foreign import _bytesFromPrivateKey
+  :: MaybeFfiHelper -> PrivateKey -> Maybe RawBytes
 
 foreign import publicKeyHash :: PublicKey -> Ed25519KeyHash
 foreign import newEd25519Signature :: Bech32String -> Effect Ed25519Signature
@@ -591,6 +595,9 @@ publicKeyFromBech32 = _publicKeyFromBech32 maybeFfiHelper
 
 privateKeyFromBytes :: RawBytes -> Maybe PrivateKey
 privateKeyFromBytes = _privateKeyFromBytes maybeFfiHelper
+
+bytesFromPrivateKey :: PrivateKey -> Maybe RawBytes
+bytesFromPrivateKey = _bytesFromPrivateKey maybeFfiHelper
 
 convertCerts :: Array T.Certificate -> Effect Certificates
 convertCerts certs = do

--- a/src/Wallet/Key.purs
+++ b/src/Wallet/Key.purs
@@ -47,6 +47,8 @@ newtype KeyWallet = KeyWallet
   { address :: NetworkId -> Aff Address
   , selectCollateral :: Utxos -> Maybe TransactionUnspentOutput
   , signTx :: Transaction -> Aff Transaction
+  , paymentKey :: PrivatePaymentKey
+  , stakeKey :: Maybe PrivateStakeKey
   }
 
 derive instance Newtype KeyWallet _
@@ -65,6 +67,8 @@ privateKeysToKeyWallet payKey mbStakeKey = KeyWallet
   { address
   , selectCollateral
   , signTx
+  , paymentKey: payKey
+  , stakeKey: mbStakeKey
   }
   where
   address :: NetworkId -> Aff Address

--- a/src/Wallet/Key.purs
+++ b/src/Wallet/Key.purs
@@ -3,6 +3,8 @@ module Wallet.Key
   , PrivatePaymentKey(PrivatePaymentKey)
   , PrivateStakeKey(PrivateStakeKey)
   , privateKeysToKeyWallet
+  , keyWalletPrivatePaymentKey
+  , keyWalletPrivateStakeKey
   ) where
 
 import Prelude
@@ -60,6 +62,12 @@ derive instance Newtype PrivatePaymentKey _
 newtype PrivateStakeKey = PrivateStakeKey PrivateKey
 
 derive instance Newtype PrivateStakeKey _
+
+keyWalletPrivatePaymentKey :: KeyWallet -> PrivatePaymentKey
+keyWalletPrivatePaymentKey = unwrap >>> _.paymentKey
+
+keyWalletPrivateStakeKey :: KeyWallet -> Maybe PrivateStakeKey
+keyWalletPrivateStakeKey = unwrap >>> _.stakeKey
 
 privateKeysToKeyWallet
   :: PrivatePaymentKey -> Maybe PrivateStakeKey -> KeyWallet

--- a/src/Wallet/KeyFile.purs
+++ b/src/Wallet/KeyFile.purs
@@ -5,6 +5,8 @@ module Wallet.KeyFile
   , keyFromFile
   , privatePaymentKeyToFile
   , privateStakeKeyToFile
+  , formatStakeKey
+  , formatPaymentKey
   ) where
 
 import Prelude

--- a/src/Wallet/KeyFile.purs
+++ b/src/Wallet/KeyFile.purs
@@ -23,7 +23,7 @@ import Data.Newtype (wrap)
 import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
-import Effect.Exception (error, throw)
+import Effect.Exception (error)
 import Helpers (liftM)
 import Node.Encoding as Encoding
 import Node.FS.Sync (readTextFile, writeTextFile)

--- a/src/Wallet/KeyFile.purs
+++ b/src/Wallet/KeyFile.purs
@@ -9,7 +9,7 @@ module Wallet.KeyFile
 
 import Prelude
 
-import Aeson(encodeAeson)
+import Aeson (encodeAeson)
 import Cardano.TextEnvelope
   ( TextEnvelopeType
       ( PaymentSigningKeyShelleyed25519
@@ -18,18 +18,18 @@ import Cardano.TextEnvelope
   , textEnvelopeBytes
   )
 import Data.Newtype (wrap)
-import Data.Maybe(Maybe)
+import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Exception (error)
 import Helpers (liftM)
 import Node.Encoding as Encoding
-import Node.FS.Sync (readTextFile,writeTextFile)
+import Node.FS.Sync (readTextFile, writeTextFile)
 import Node.Path (FilePath)
-import Serialization (privateKeyFromBytes,bytesFromPrivateKey)
+import Serialization (privateKeyFromBytes, bytesFromPrivateKey)
 import Serialization.Types (PrivateKey)
 import Types.ByteArray (ByteArray)
-import Types.RawBytes(rawBytesToHex)
+import Types.RawBytes (rawBytesToHex)
 import Wallet.Key
   ( PrivatePaymentKey(PrivatePaymentKey)
   , PrivateStakeKey(PrivateStakeKey)
@@ -53,29 +53,32 @@ privateStakeKeyFromFile filePath = do
     PrivateStakeKey <$> privateKeyFromBytes (wrap bytes)
 
 privatePaymentKeyToFile :: FilePath -> PrivatePaymentKey -> Aff Unit
-privatePaymentKeyToFile filePath key
-  = liftEffect $ writeTextFile Encoding.UTF8 filePath (formatPaymentKey key)
+privatePaymentKeyToFile filePath key = liftEffect $ writeTextFile Encoding.UTF8
+  filePath
+  (formatPaymentKey key)
 
 privateStakeKeyToFile :: FilePath -> PrivateStakeKey -> Aff Unit
-privateStakeKeyToFile filePath key
-  = liftEffect $ writeTextFile Encoding.UTF8 filePath (formatStakeKey key)
+privateStakeKeyToFile filePath key = liftEffect $ writeTextFile Encoding.UTF8
+  filePath
+  (formatStakeKey key)
 
 formatPaymentKey :: PrivatePaymentKey -> String
 formatPaymentKey (PrivatePaymentKey key) = encodeAeson >>> show $
-  { "type" : "PaymentSigningKeyShelley_ed25519",
-    description : "Payment Signing Key",
-    cborHex : keyToCbor key
+  { "type": "PaymentSigningKeyShelley_ed25519"
+  , description: "Payment Signing Key"
+  , cborHex: keyToCbor key
   }
 
 formatStakeKey :: PrivateStakeKey -> String
 formatStakeKey (PrivateStakeKey key) = encodeAeson >>> show $
-  { "type": "StakeSigningKeyShelley_ed25519",
-    description : "Stake Signing Key",
-    cborHex : keyToCbor key
+  { "type": "StakeSigningKeyShelley_ed25519"
+  , description: "Stake Signing Key"
+  , cborHex: keyToCbor key
   }
 
 keyToCbor :: PrivateKey -> Maybe String
-keyToCbor = ((rawBytesToHex >>> (magicPrefix <> _)) <$> _) <<< bytesFromPrivateKey
+keyToCbor = ((rawBytesToHex >>> (magicPrefix <> _)) <$> _) <<<
+  bytesFromPrivateKey
 
 magicPrefix :: String
 magicPrefix = "5820"

--- a/test/PrivateKey.purs
+++ b/test/PrivateKey.purs
@@ -3,6 +3,7 @@ module Test.PrivateKey where
 import Contract.Config (testnetConfig)
 import Prelude
 
+import Aeson(fromString)
 import Cardano.Types.Transaction
   ( Ed25519Signature(Ed25519Signature)
   , Transaction(Transaction)
@@ -16,15 +17,26 @@ import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (unto)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(Just))
+import Data.Newtype(unwrap)
+import Effect.Class(liftEffect)
 import Mote (group, test)
+import Node.Encoding as Encoding
+import Node.FS.Sync (readTextFile,writeTextFile,unlink)
+import Serialization(publicKeyFromPrivateKey,publicKeyHash)
 import Test.Fixtures (txFixture1)
-import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Assertions (shouldEqual,fail)
 import TestM (TestPlanM)
 import Type.Proxy (Proxy(Proxy))
 import Wallet.Spec
   ( PrivatePaymentKeySource(PrivatePaymentKeyFile)
   , PrivateStakeKeySource(PrivateStakeKeyFile)
   , WalletSpec(UseKeys)
+  )
+import Wallet.KeyFile
+  (privatePaymentKeyToFile
+  ,privatePaymentKeyFromFile
+  ,privateStakeKeyFromFile
+  ,privateStakeKeyToFile
   )
 
 suite :: TestPlanM Unit
@@ -60,3 +72,21 @@ suite = do
           ( Ed25519Signature
               "ed25519_sig1w7nkmvk57r6094j9u85r4pddve0hg3985ywl9yzwecx03aa9fnfspl9zmtngmqmczd284lnusjdwkysgukxeq05a548dyepr6vn62qs744wxz"
           )
+    test "privateKeyToFile round-trips" do
+      key <- privatePaymentKeyFromFile "fixtures/test/parsing/PrivateKey/payment.skey"
+      privatePaymentKeyToFile "fixtures/test/parsing/PrivateKey/payment_round_trip.skey" key
+      key2 <- privatePaymentKeyFromFile "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
+      liftEffect $  unlink "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
+      -- converting to pub key hashes to check equality isn't great
+      -- but there aren't Eq instances for PrivateKeys or PublicKeys
+      pkh <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key)
+      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key2)
+      pkh `shouldEqual` pkh2
+    test "stakeKeyToFile round-trips" do
+      key <- privateStakeKeyFromFile "fixtures/test/parsing/PrivateKey/stake.skey"
+      privateStakeKeyToFile "fixtures/test/parsing/PrivateKey/stake_round_trip.skey" key
+      key2 <- privateStakeKeyFromFile "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
+      liftEffect $ unlink "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
+      pkh <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key)
+      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key2)
+      pkh `shouldEqual` pkh2

--- a/test/PrivateKey.purs
+++ b/test/PrivateKey.purs
@@ -3,7 +3,6 @@ module Test.PrivateKey where
 import Contract.Config (testnetConfig)
 import Prelude
 
-import Aeson (fromString)
 import Cardano.Types.Transaction
   ( Ed25519Signature(Ed25519Signature)
   , Transaction(Transaction)
@@ -20,11 +19,10 @@ import Data.Maybe (Maybe(Just))
 import Data.Newtype (unwrap)
 import Effect.Class (liftEffect)
 import Mote (group, test)
-import Node.Encoding as Encoding
-import Node.FS.Sync (readTextFile, writeTextFile, unlink)
+import Node.FS.Sync (unlink)
 import Serialization (publicKeyFromPrivateKey, publicKeyHash)
 import Test.Fixtures (txFixture1)
-import Test.Spec.Assertions (shouldEqual, fail)
+import Test.Spec.Assertions (shouldEqual)
 import TestM (TestPlanM)
 import Type.Proxy (Proxy(Proxy))
 import Wallet.Spec

--- a/test/PrivateKey.purs
+++ b/test/PrivateKey.purs
@@ -3,7 +3,7 @@ module Test.PrivateKey where
 import Contract.Config (testnetConfig)
 import Prelude
 
-import Aeson(fromString)
+import Aeson (fromString)
 import Cardano.Types.Transaction
   ( Ed25519Signature(Ed25519Signature)
   , Transaction(Transaction)
@@ -17,14 +17,14 @@ import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (unto)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(Just))
-import Data.Newtype(unwrap)
-import Effect.Class(liftEffect)
+import Data.Newtype (unwrap)
+import Effect.Class (liftEffect)
 import Mote (group, test)
 import Node.Encoding as Encoding
-import Node.FS.Sync (readTextFile,writeTextFile,unlink)
-import Serialization(publicKeyFromPrivateKey,publicKeyHash)
+import Node.FS.Sync (readTextFile, writeTextFile, unlink)
+import Serialization (publicKeyFromPrivateKey, publicKeyHash)
 import Test.Fixtures (txFixture1)
-import Test.Spec.Assertions (shouldEqual,fail)
+import Test.Spec.Assertions (shouldEqual, fail)
 import TestM (TestPlanM)
 import Type.Proxy (Proxy(Proxy))
 import Wallet.Spec
@@ -33,10 +33,10 @@ import Wallet.Spec
   , WalletSpec(UseKeys)
   )
 import Wallet.KeyFile
-  (privatePaymentKeyToFile
-  ,privatePaymentKeyFromFile
-  ,privateStakeKeyFromFile
-  ,privateStakeKeyToFile
+  ( privatePaymentKeyToFile
+  , privatePaymentKeyFromFile
+  , privateStakeKeyFromFile
+  , privateStakeKeyToFile
   )
 
 suite :: TestPlanM Unit
@@ -73,20 +73,32 @@ suite = do
               "ed25519_sig1w7nkmvk57r6094j9u85r4pddve0hg3985ywl9yzwecx03aa9fnfspl9zmtngmqmczd284lnusjdwkysgukxeq05a548dyepr6vn62qs744wxz"
           )
     test "privateKeyToFile round-trips" do
-      key <- privatePaymentKeyFromFile "fixtures/test/parsing/PrivateKey/payment.skey"
-      privatePaymentKeyToFile "fixtures/test/parsing/PrivateKey/payment_round_trip.skey" key
-      key2 <- privatePaymentKeyFromFile "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
-      liftEffect $  unlink "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
+      key <- privatePaymentKeyFromFile
+        "fixtures/test/parsing/PrivateKey/payment.skey"
+      privatePaymentKeyToFile
+        "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
+        key
+      key2 <- privatePaymentKeyFromFile
+        "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
+      liftEffect $ unlink
+        "fixtures/test/parsing/PrivateKey/payment_round_trip.skey"
       -- converting to pub key hashes to check equality isn't great
       -- but there aren't Eq instances for PrivateKeys or PublicKeys
       pkh <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key)
-      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key2)
+      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey
+        (unwrap key2)
       pkh `shouldEqual` pkh2
     test "stakeKeyToFile round-trips" do
-      key <- privateStakeKeyFromFile "fixtures/test/parsing/PrivateKey/stake.skey"
-      privateStakeKeyToFile "fixtures/test/parsing/PrivateKey/stake_round_trip.skey" key
-      key2 <- privateStakeKeyFromFile "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
-      liftEffect $ unlink "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
+      key <- privateStakeKeyFromFile
+        "fixtures/test/parsing/PrivateKey/stake.skey"
+      privateStakeKeyToFile
+        "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
+        key
+      key2 <- privateStakeKeyFromFile
+        "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
+      liftEffect $ unlink
+        "fixtures/test/parsing/PrivateKey/stake_round_trip.skey"
       pkh <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key)
-      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey (unwrap key2)
+      pkh2 <- liftEffect $ publicKeyHash <$> publicKeyFromPrivateKey
+        (unwrap key2)
       pkh `shouldEqual` pkh2


### PR DESCRIPTION
Closes # .

Downstream we want to test our CLI with plutip. The cli reads wallets from files so we need a way to get the plain keys out of KeyWallets.

This is the alternative (less breaking thanks) solution suggested by @klntsky in #859 

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] The integration and unit tests have been run (`npm run test`) locally
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
