### PR TITLE
Adjust E2E test to new URLs

### DIFF
--- a/test/E2E/Examples/Gero.purs
+++ b/test/E2E/Examples/Gero.purs
@@ -10,5 +10,5 @@ import Test.E2E.Helpers
   )
 
 runExample :: TestOptions -> TestPlanM Unit
-runExample options = runE2ETest "Gero" options GeroExt geroConfirmAccess
+runExample options = runE2ETest "Wallet" options GeroExt geroConfirmAccess
 

--- a/test/E2E/Examples/Pkh2PkhGero.purs
+++ b/test/E2E/Examples/Pkh2PkhGero.purs
@@ -12,7 +12,7 @@ import Test.E2E.Helpers
   )
 
 runExample :: TestOptions -> TestPlanM Unit
-runExample options = runE2ETest "Pkh2PkhGero" options GeroExt $ \example -> do
+runExample options = runE2ETest "Pkh2Pkh" options GeroExt $ \example -> do
   geroConfirmAccess example
   delaySec 7.0
   geroSign' example

--- a/test/E2E/Helpers.purs
+++ b/test/E2E/Helpers.purs
@@ -13,7 +13,7 @@ import Prelude
 import Contract.Test.E2E
   ( TestOptions
   , withBrowser
-  , WalletExt
+  , WalletExt(NamiExt, GeroExt)
   , resetTestFeedback
   , RunningExample
   , WalletPassword
@@ -45,8 +45,14 @@ import TestM (TestPlanM)
 import Test.Spec.Assertions (shouldSatisfy)
 import Toppokki as Toppokki
 
-exampleUrl :: String -> Toppokki.URL
-exampleUrl exampleName = wrap $ "http://localhost:4008/?" <> exampleName
+walletName :: WalletExt -> String
+walletName NamiExt = "nami"
+walletName GeroExt = "gero"
+
+exampleUrl :: String -> WalletExt -> Toppokki.URL
+exampleUrl exampleName wallet = wrap $ "http://localhost:4008/?" <> exampleName
+  <> ":"
+  <> walletName wallet
 
 testPasswordNami :: WalletPassword
 testPasswordNami = wrap "ctlctlctl"
@@ -68,9 +74,9 @@ runE2ETest
   -> (RunningExample -> Aff a)
   -> TestPlanM Unit
 runE2ETest example opts ext f = test example $ withBrowser opts ext $
-  \browser -> withExample (exampleUrl example) browser
+  \browser -> withExample (exampleUrl example ext) browser
     ( \e -> do
-        liftEffect $ log $ "Start Example " <> example
+        liftEffect $ log $ "Start Example " <> example <> ":" <> walletName ext
         resetTestFeedback (_.main $ unwrap e)
         void $ try $ f e
         delaySec 10.0


### PR DESCRIPTION
Adjusts the E2E tests to use the new URLs. (Doesn't change the test plan or include Flint yet).

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [ ] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
