### PR TITLE
Bump Ogmios version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1415,17 +1415,17 @@
         "wai-routes": "wai-routes"
       },
       "locked": {
-        "lastModified": 1660207573,
-        "narHash": "sha256-0qVptS5PGIG+cdPp1OmDNE2n0hZ/ArNbU+2qqzrrSm4=",
+        "lastModified": 1660637986,
+        "narHash": "sha256-0I+yfuva9pg6pPHeWNO73oPRxCjh8I4ER0Egxf8XKdk=",
         "owner": "mlabs-haskell",
         "repo": "ogmios",
-        "rev": "496fd7555131eab2a0b5702011a260064a145824",
+        "rev": "9c04524d45de2c417ddda9e7ab0d587a54954c57",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "ogmios",
-        "rev": "496fd7555131eab2a0b5702011a260064a145824",
+        "rev": "9c04524d45de2c417ddda9e7ab0d587a54954c57",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
     # for the purescript project
     ogmios = {
-      url = "github:mlabs-haskell/ogmios/496fd7555131eab2a0b5702011a260064a145824";
+      url = "github:mlabs-haskell/ogmios/9c04524d45de2c417ddda9e7ab0d587a54954c57";
       inputs = {
         haskell-nix.follows = "haskell-nix";
         nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Part of #906. The new Ogmios version pulls in all of v5.5.4 from upstream