### PR TITLE
Rewrite the balancing algorithm so that tx is always pre-balanced before ex units calculation

### DIFF
--- a/src/BalanceTx/BalanceTx.purs
+++ b/src/BalanceTx/BalanceTx.purs
@@ -37,7 +37,7 @@ module BalanceTx
 
 import Prelude
 
-import BalanceTx.UtxoMinAda (adaOnlyUtxoMinAdaValue, utxoMinAdaValue)
+import BalanceTx.UtxoMinAda (utxoMinAdaValue)
 import Cardano.Types.Transaction
   ( Redeemer(Redeemer)
   , Transaction(Transaction)
@@ -100,7 +100,7 @@ import Data.Traversable (traverse, traverse_)
 import Data.Tuple (fst, snd)
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Class (class MonadEffect, liftEffect)
-import QueryM (ClientError, QueryM)
+import QueryM (QueryM)
 import QueryM (evaluateTxOgmios, getWalletAddress) as QueryM
 import QueryM.MinFee (calculateMinFee) as QueryM
 import QueryM.Ogmios

--- a/src/BalanceTx/BalanceTx.purs
+++ b/src/BalanceTx/BalanceTx.purs
@@ -126,11 +126,7 @@ import Transaction (setScriptDataHash)
 import Types.Natural (toBigInt) as Natural
 import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
 import Types.Transaction (TransactionInput)
-import Types.UnbalancedTransaction
-  ( UnbalancedTx(UnbalancedTx)
-  , _transaction
-  , _utxoIndex
-  )
+import Types.UnbalancedTransaction (UnbalancedTx, _transaction, _utxoIndex)
 import Untagged.Union (asOneOf)
 
 --------------------------------------------------------------------------------

--- a/src/BalanceTx/Error.purs
+++ b/src/BalanceTx/Error.purs
@@ -1,0 +1,218 @@
+module BalanceTx.Error
+  ( Actual(Actual)
+  , BalanceTxError
+      ( CouldNotConvertScriptOutputToTxInput
+      , CouldNotGetCollateral
+      , CouldNotGetUtxos
+      , CouldNotGetWalletAddress
+      , ExUnitsEvaluationFailed
+      , InsufficientTxInputs
+      , ReindexRedeemersError
+      , UtxoLookupFailedFor
+      , UtxoMinAdaValueCalculationFailed
+      )
+  , Expected(Expected)
+  , printTxEvaluationFailure
+  ) where
+
+import Prelude
+
+import Cardano.Types.Transaction (Redeemer(Redeemer))
+import Cardano.Types.Value (Value)
+import Data.Array (catMaybes, filter, uncons) as Array
+import Data.Bifunctor (bimap)
+import Data.BigInt (toString) as BigInt
+import Data.Either (Either(Left, Right), either, isLeft)
+import Data.Foldable (find, foldl, foldMap, length)
+import Data.FoldableWithIndex (foldMapWithIndex)
+import Data.Function (applyN)
+import Data.Generic.Rep (class Generic)
+import Data.Int (toStringAs, decimal, ceil, toNumber)
+import Data.Maybe (Maybe(Just, Nothing))
+import Data.Newtype (class Newtype)
+import Data.Show.Generic (genericShow)
+import Data.String (Pattern(Pattern))
+import Data.String.CodePoints (length) as String
+import Data.String.Common (joinWith, split) as String
+import Data.String.Utils (padEnd)
+import Data.Tuple (snd)
+import Data.Tuple.Nested (type (/\), (/\))
+import QueryM.Ogmios
+  ( TxEvaluationFailure(UnparsedError, ScriptFailures)
+  , RedeemerPointer
+  , ScriptFailure
+      ( ExtraRedeemers
+      , MissingRequiredDatums
+      , MissingRequiredScripts
+      , ValidatorFailed
+      , UnknownInputReferencedByRedeemer
+      , NonScriptInputReferencedByRedeemer
+      , IllFormedExecutionBudget
+      , NoCostModelForLanguage
+      )
+  ) as Ogmios
+import ReindexRedeemers (ReindexErrors)
+import Types.Natural (toBigInt) as Natural
+import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
+import Types.Transaction (TransactionInput)
+
+data BalanceTxError
+  = CouldNotConvertScriptOutputToTxInput
+  | CouldNotGetCollateral
+  | CouldNotGetUtxos
+  | CouldNotGetWalletAddress
+  | ExUnitsEvaluationFailed UnattachedUnbalancedTx Ogmios.TxEvaluationFailure
+  | InsufficientTxInputs Expected Actual
+  | ReindexRedeemersError ReindexErrors
+  | UtxoLookupFailedFor TransactionInput
+  | UtxoMinAdaValueCalculationFailed
+
+derive instance Generic BalanceTxError _
+
+instance Show BalanceTxError where
+  show (ExUnitsEvaluationFailed tx failure) =
+    "ExUnitsEvaluationFailed: " <> printTxEvaluationFailure tx failure
+  show e = genericShow e
+
+newtype Actual = Actual Value
+
+derive instance Generic Actual _
+derive instance Newtype Actual _
+
+instance Show Actual where
+  show = genericShow
+
+newtype Expected = Expected Value
+
+derive instance Generic Expected _
+derive instance Newtype Expected _
+
+instance Show Expected where
+  show = genericShow
+
+--------------------------------------------------------------------------------
+-- Failure parsing for Ogmios.EvaluateTx
+--------------------------------------------------------------------------------
+
+type WorkingLine = String
+type FrozenLine = String
+
+type PrettyString = Array (Either WorkingLine FrozenLine)
+
+runPrettyString :: PrettyString -> String
+runPrettyString ary = String.joinWith "" (either identity identity <$> ary)
+
+freeze :: PrettyString -> PrettyString
+freeze ary = either Right Right <$> ary
+
+line :: String -> PrettyString
+line s =
+  case Array.uncons lines of
+    Nothing -> []
+    Just { head, tail } -> [ head ] <> freeze tail
+  where
+  lines = Left <<< (_ <> "\n") <$> String.split (Pattern "\n") s
+
+bullet :: PrettyString -> PrettyString
+bullet ary = freeze (bimap ("- " <> _) ("  " <> _) <$> ary)
+
+number :: PrettyString -> PrettyString
+number ary = freeze (foldl go [] ary)
+  where
+  biggestPrefix :: String
+  biggestPrefix = toStringAs decimal (length (Array.filter isLeft ary)) <> ". "
+
+  width :: Int
+  width = ceil (toNumber (String.length biggestPrefix) / 2.0) * 2
+
+  numberLine :: Int -> String -> String
+  numberLine i l = padEnd width (toStringAs decimal (i + 1) <> ". ") <> l
+
+  indentLine :: String -> String
+  indentLine = applyN ("  " <> _) (width / 2)
+
+  go :: PrettyString -> Either WorkingLine FrozenLine -> PrettyString
+  go b a = b <> [ bimap (numberLine $ length b) indentLine a ]
+
+-- | Pretty print the failure response from Ogmios's EvaluateTx endpoint.
+-- | Exported to allow testing, use `Test.Ogmios.Aeson.printEvaluateTxFailures`
+-- | to visually verify the printing of errors without a context on fixtures.
+printTxEvaluationFailure
+  :: UnattachedUnbalancedTx -> Ogmios.TxEvaluationFailure -> String
+printTxEvaluationFailure (UnattachedUnbalancedTx { redeemersTxIns }) e =
+  runPrettyString $ case e of
+    Ogmios.UnparsedError error -> line $ "Unknown error: " <> error
+    Ogmios.ScriptFailures sf -> line "Script failures:" <> bullet
+      (foldMapWithIndex printScriptFailures sf)
+  where
+  lookupRedeemerPointer
+    :: Ogmios.RedeemerPointer -> Maybe (Redeemer /\ Maybe TransactionInput)
+  lookupRedeemerPointer ptr = flip find redeemersTxIns
+    $ \(Redeemer rdmr /\ _) -> rdmr.tag == ptr.redeemerTag && rdmr.index ==
+        Natural.toBigInt ptr.redeemerIndex
+
+  printRedeemerPointer :: Ogmios.RedeemerPointer -> PrettyString
+  printRedeemerPointer ptr =
+    line
+      ( show ptr.redeemerTag <> ":" <> BigInt.toString
+          (Natural.toBigInt ptr.redeemerIndex)
+      )
+
+  -- TODO Investigate if more details can be printed, for example minting
+  -- policy/minted assets
+  -- https://github.com/Plutonomicon/cardano-transaction-lib/issues/881
+  printRedeemerDetails :: Ogmios.RedeemerPointer -> PrettyString
+  printRedeemerDetails ptr =
+    let
+      mbRedeemerTxIn = lookupRedeemerPointer ptr
+      mbData = mbRedeemerTxIn <#> \(Redeemer r /\ _) -> "Redeemer: " <> show
+        r.data
+      mbTxIn = (mbRedeemerTxIn >>= snd) <#> \txIn -> "Input: " <> show txIn
+    in
+      foldMap line $ Array.catMaybes [ mbData, mbTxIn ]
+
+  printRedeemer :: Ogmios.RedeemerPointer -> PrettyString
+  printRedeemer ptr =
+    printRedeemerPointer ptr <> bullet (printRedeemerDetails ptr)
+
+  printScriptFailure :: Ogmios.ScriptFailure -> PrettyString
+  printScriptFailure = case _ of
+    Ogmios.ExtraRedeemers ptrs -> line "Extra redeemers:" <> bullet
+      (foldMap printRedeemer ptrs)
+    Ogmios.MissingRequiredDatums { provided, missing }
+    -> line "Supplied with datums:"
+      <> bullet (foldMap (foldMap line) provided)
+      <> line "But missing required datums:"
+      <> bullet (foldMap line missing)
+    Ogmios.MissingRequiredScripts { resolved, missing }
+    -> line "Supplied with scripts:"
+      <> bullet
+        ( foldMapWithIndex
+            (\ptr scr -> printRedeemer ptr <> line ("Script: " <> scr))
+            resolved
+        )
+      <> line "But missing required scripts:"
+      <> bullet (foldMap line missing)
+    Ogmios.ValidatorFailed { error, traces } -> line error <> line "Trace:" <>
+      number
+        (foldMap line traces)
+    Ogmios.UnknownInputReferencedByRedeemer txIn -> line
+      ("Unknown input referenced by redeemer: " <> show txIn)
+    Ogmios.NonScriptInputReferencedByRedeemer txIn -> line
+      ("Non script input referenced by redeemer: " <> show txIn)
+    Ogmios.IllFormedExecutionBudget Nothing -> line
+      ("Ill formed execution budget: Execution budget missing")
+    Ogmios.IllFormedExecutionBudget (Just { memory, steps }) ->
+      line "Ill formed execution budget:"
+        <> bullet
+          ( line ("Memory: " <> BigInt.toString (Natural.toBigInt memory))
+              <> line ("Steps: " <> BigInt.toString (Natural.toBigInt steps))
+          )
+    Ogmios.NoCostModelForLanguage language -> line
+      ("No cost model for language \"" <> language <> "\"")
+
+  printScriptFailures
+    :: Ogmios.RedeemerPointer -> Array Ogmios.ScriptFailure -> PrettyString
+  printScriptFailures ptr sfs = printRedeemer ptr <> bullet
+    (foldMap printScriptFailure sfs)
+

--- a/src/BalanceTx/ExUnitsAndMinFee.purs
+++ b/src/BalanceTx/ExUnitsAndMinFee.purs
@@ -1,0 +1,162 @@
+module BalanceTx.ExUnitsAndMinFee
+  ( evalExUnitsAndMinFee
+  , finalizeTransaction
+  ) where
+
+import Prelude
+
+import BalanceTx.Error
+  ( BalanceTxError
+      ( ExUnitsEvaluationFailed
+      , ReindexRedeemersError
+      )
+  )
+import Cardano.Types.Transaction
+  ( Redeemer(Redeemer)
+  , Transaction
+  , _inputs
+  , _plutusData
+  , _redeemers
+  , _witnessSet
+  )
+import Control.Monad.Reader.Class (asks)
+import Control.Monad.Trans.Class (lift)
+import BalanceTx.Helpers (_body', _redeemersTxIns)
+import BalanceTx.Types
+  ( BalanceTxM
+  , FinalizedTransaction(FinalizedTransaction)
+  , PrebalancedTransaction(PrebalancedTransaction)
+  )
+import Control.Monad.Except.Trans (ExceptT(ExceptT))
+import Data.Array (findIndex, fromFoldable, uncons) as Array
+import Data.Bifunctor (lmap)
+import Data.BigInt (BigInt)
+import Data.Either (Either)
+import Data.Lens.Getter ((^.))
+import Data.Lens.Index (ix) as Lens
+import Data.Lens.Setter ((.~), (?~), (%~))
+import Data.Map (fromFoldable, toUnfoldable) as Map
+import Data.Maybe (Maybe(Just, Nothing), fromMaybe, maybe)
+import Data.Newtype (unwrap, wrap)
+import Data.Tuple (fst)
+import Data.Tuple.Nested ((/\), type (/\))
+import Effect.Class (liftEffect)
+import QueryM (QueryM)
+import QueryM (evaluateTxOgmios) as QueryM
+import QueryM.MinFee (calculateMinFee) as QueryM
+import QueryM.Ogmios (TxEvaluationResult(TxEvaluationResult)) as Ogmios
+import ReindexRedeemers (ReindexErrors, reindexSpentScriptRedeemers')
+import Serialization (convertTransaction, toBytes) as Serialization
+import Transaction (setScriptDataHash)
+import Types.Natural (toBigInt) as Natural
+import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
+import Types.Transaction (TransactionInput)
+import Types.UnbalancedTransaction (_transaction)
+import Untagged.Union (asOneOf)
+
+evalTxExecutionUnits
+  :: Transaction
+  -> UnattachedUnbalancedTx
+  -> BalanceTxM Ogmios.TxEvaluationResult
+evalTxExecutionUnits tx unattachedTx = do
+  txBytes <- liftEffect
+    ( wrap <<< Serialization.toBytes <<< asOneOf <$>
+        Serialization.convertTransaction tx
+    )
+  ExceptT $ QueryM.evaluateTxOgmios txBytes
+    <#> lmap (ExUnitsEvaluationFailed unattachedTx) <<< unwrap
+
+-- Calculates the execution units needed for each script in the transaction
+-- and the minimum fee, including the script fees.
+-- Returns a tuple consisting of updated `UnattachedUnbalancedTx` and
+-- the minimum fee.
+evalExUnitsAndMinFee
+  :: PrebalancedTransaction -> BalanceTxM (UnattachedUnbalancedTx /\ BigInt)
+evalExUnitsAndMinFee (PrebalancedTransaction unattachedTx) = do
+  -- Reindex `Spent` script redeemers:
+  reindexedUnattachedTx <-
+    ExceptT $ reindexRedeemers unattachedTx <#> lmap ReindexRedeemersError
+  -- Reattach datums and redeemers before evaluating ex units:
+  let attachedTx = reattachDatumsAndRedeemers reindexedUnattachedTx
+  -- Evaluate transaction ex units:
+  rdmrPtrExUnitsList <- evalTxExecutionUnits attachedTx reindexedUnattachedTx
+  let
+    -- Set execution units received from the server:
+    reindexedUnattachedTxWithExUnits =
+      updateTxExecutionUnits reindexedUnattachedTx rdmrPtrExUnitsList
+  -- Attach datums and redeemers, set the script integrity hash:
+  FinalizedTransaction finalizedTx <- lift $
+    finalizeTransaction reindexedUnattachedTxWithExUnits
+  -- Calculate the minimum fee for a transaction:
+  minFee <- ExceptT $ QueryM.calculateMinFee finalizedTx <#> pure <<< unwrap
+  pure $ reindexedUnattachedTxWithExUnits /\ minFee
+
+-- | Attaches datums and redeemers, sets the script integrity hash,
+-- | for use after reindexing.
+finalizeTransaction
+  :: UnattachedUnbalancedTx -> QueryM FinalizedTransaction
+finalizeTransaction reindexedUnattachedTxWithExUnits =
+  let
+    attachedTxWithExUnits =
+      reattachDatumsAndRedeemers reindexedUnattachedTxWithExUnits
+    ws = attachedTxWithExUnits ^. _witnessSet # unwrap
+    redeemers = fromMaybe mempty ws.redeemers
+    datums = wrap <$> fromMaybe mempty ws.plutusData
+  in
+    do
+      costModels <- asks (_.runtime >>> _.pparams >>> unwrap >>> _.costModels)
+      liftEffect $ FinalizedTransaction <$>
+        setScriptDataHash costModels redeemers datums attachedTxWithExUnits
+
+reindexRedeemers
+  :: UnattachedUnbalancedTx
+  -> QueryM (Either ReindexErrors UnattachedUnbalancedTx)
+reindexRedeemers
+  unattachedTx@(UnattachedUnbalancedTx { redeemersTxIns }) =
+  let
+    inputs = Array.fromFoldable $ unattachedTx ^. _body' <<< _inputs
+  in
+    reindexSpentScriptRedeemers' inputs redeemersTxIns <#>
+      map \redeemersTxInsReindexed ->
+        unattachedTx # _redeemersTxIns .~ redeemersTxInsReindexed
+
+reattachDatumsAndRedeemers :: UnattachedUnbalancedTx -> Transaction
+reattachDatumsAndRedeemers
+  (UnattachedUnbalancedTx { unbalancedTx, datums, redeemersTxIns }) =
+  let
+    transaction = unbalancedTx ^. _transaction
+  in
+    transaction # _witnessSet <<< _plutusData ?~ map unwrap datums
+      # _witnessSet <<< _redeemers ?~ map fst redeemersTxIns
+
+updateTxExecutionUnits
+  :: UnattachedUnbalancedTx
+  -> Ogmios.TxEvaluationResult
+  -> UnattachedUnbalancedTx
+updateTxExecutionUnits unattachedTx rdmrPtrExUnitsList =
+  unattachedTx #
+    _redeemersTxIns %~ flip setRdmrsExecutionUnits rdmrPtrExUnitsList
+
+setRdmrsExecutionUnits
+  :: Array (Redeemer /\ Maybe TransactionInput)
+  -> Ogmios.TxEvaluationResult
+  -> Array (Redeemer /\ Maybe TransactionInput)
+setRdmrsExecutionUnits rs (Ogmios.TxEvaluationResult xxs) =
+  case Array.uncons (Map.toUnfoldable xxs) of
+    Nothing -> rs
+    Just { head: ptr /\ exUnits, tail: xs } ->
+      let
+        xsWrapped = Ogmios.TxEvaluationResult (Map.fromFoldable xs)
+        ixMaybe = flip Array.findIndex rs $ \(Redeemer rdmr /\ _) ->
+          rdmr.tag == ptr.redeemerTag
+            && rdmr.index == Natural.toBigInt ptr.redeemerIndex
+      in
+        ixMaybe # maybe (setRdmrsExecutionUnits rs xsWrapped) \ix ->
+          flip setRdmrsExecutionUnits xsWrapped $
+            rs # Lens.ix ix %~ \(Redeemer rec /\ txOutRef) ->
+              let
+                mem = Natural.toBigInt exUnits.memory
+                steps = Natural.toBigInt exUnits.steps
+              in
+                Redeemer rec { exUnits = { mem, steps } } /\ txOutRef
+

--- a/src/BalanceTx/Helpers.purs
+++ b/src/BalanceTx/Helpers.purs
@@ -1,0 +1,40 @@
+module BalanceTx.Helpers
+  ( _body'
+  , _redeemersTxIns
+  , _transaction'
+  , _unbalancedTx
+  ) where
+
+import Prelude
+
+import Cardano.Types.Transaction (Redeemer, Transaction, TxBody, _body)
+import Data.Lens (Lens', lens')
+import Data.Lens.Getter ((^.))
+import Data.Lens.Setter ((.~), (%~))
+import Data.Maybe (Maybe)
+import Data.Tuple.Nested (type (/\), (/\))
+import Types.ScriptLookups (UnattachedUnbalancedTx(UnattachedUnbalancedTx))
+import Types.Transaction (TransactionInput)
+import Types.UnbalancedTransaction (UnbalancedTx, _transaction)
+
+_unbalancedTx :: Lens' UnattachedUnbalancedTx UnbalancedTx
+_unbalancedTx = lens' \(UnattachedUnbalancedTx rec@{ unbalancedTx }) ->
+  unbalancedTx /\
+    \ubTx -> UnattachedUnbalancedTx rec { unbalancedTx = ubTx }
+
+_transaction' :: Lens' UnattachedUnbalancedTx Transaction
+_transaction' = lens' \unattachedTx ->
+  unattachedTx ^. _unbalancedTx <<< _transaction /\
+    \tx -> unattachedTx # _unbalancedTx %~ (_transaction .~ tx)
+
+_body' :: Lens' UnattachedUnbalancedTx TxBody
+_body' = lens' \unattachedTx ->
+  unattachedTx ^. _transaction' <<< _body /\
+    \txBody -> unattachedTx # _transaction' %~ (_body .~ txBody)
+
+_redeemersTxIns
+  :: Lens' UnattachedUnbalancedTx (Array (Redeemer /\ Maybe TransactionInput))
+_redeemersTxIns = lens' \(UnattachedUnbalancedTx rec@{ redeemersTxIns }) ->
+  redeemersTxIns /\
+    \rdmrs -> UnattachedUnbalancedTx rec { redeemersTxIns = rdmrs }
+

--- a/src/BalanceTx/Types.purs
+++ b/src/BalanceTx/Types.purs
@@ -1,0 +1,35 @@
+module BalanceTx.Types
+  ( BalanceTxM
+  , FinalizedTransaction(FinalizedTransaction)
+  , PrebalancedTransaction(PrebalancedTransaction)
+  ) where
+
+import Prelude
+
+import BalanceTx.Error (BalanceTxError)
+import Cardano.Types.Transaction (Transaction)
+import Control.Monad.Except.Trans (ExceptT)
+import Data.Generic.Rep (class Generic)
+import Data.Newtype (class Newtype)
+import Data.Show.Generic (genericShow)
+import QueryM (QueryMExtended)
+import Types.ScriptLookups (UnattachedUnbalancedTx)
+
+type BalanceTxM (a :: Type) = ExceptT BalanceTxError (QueryMExtended ()) a
+
+newtype FinalizedTransaction = FinalizedTransaction Transaction
+
+derive instance Generic FinalizedTransaction _
+derive instance Newtype FinalizedTransaction _
+derive newtype instance Eq FinalizedTransaction
+
+instance Show FinalizedTransaction where
+  show = genericShow
+
+newtype PrebalancedTransaction = PrebalancedTransaction UnattachedUnbalancedTx
+
+derive instance Generic PrebalancedTransaction _
+derive instance Newtype PrebalancedTransaction _
+
+instance Show PrebalancedTransaction where
+  show = genericShow

--- a/src/Cardano/Types/Value.purs
+++ b/src/Cardano/Types/Value.purs
@@ -533,14 +533,15 @@ isAdaOnly v =
         tn == adaToken
     _ -> false
 
-minus :: Value -> Value -> Maybe Value
-minus x y = do
+minus :: Value -> Value -> Value
+minus lhs rhs =
   let
     negativeValues :: List (CurrencySymbol /\ TokenName /\ BigInt)
-    negativeValues = unsafeFlattenValue y <#>
+    negativeValues = unsafeFlattenValue rhs <#>
       (\(c /\ t /\ a) -> c /\ t /\ negate a)
-  y' <- traverse unflattenValue negativeValues
-  pure $ x <> fold y'
+  in
+    unsafePartial $
+      lhs <> fold (fromJust $ traverse unflattenValue negativeValues)
 
 -- From https://github.com/mlabs-haskell/bot-plutus-interface/blob/master/src/BotPlutusInterface/PreBalance.hs
 -- "isValueNat" uses unsafeFlattenValue which guards against zeros, so non-strict

--- a/src/Serialization/MinFee.purs
+++ b/src/Serialization/MinFee.purs
@@ -8,12 +8,10 @@ import Cardano.Types.Transaction as T
 import Cardano.Types.Value (Coin)
 import Control.Monad.Error.Class (class MonadThrow, liftMaybe)
 import Data.Array as Array
-import Data.BigInt as BigInt
 import Data.Lens ((.~))
 import Data.Maybe (Maybe(Just), fromMaybe)
 import Data.Newtype (unwrap, wrap)
 import Data.Tuple.Nested ((/\))
-import Data.UInt as UInt
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Exception (Error, error)
 import FfiHelpers (MaybeFfiHelper, maybeFfiHelper)
@@ -31,9 +29,7 @@ calculateMinFeeCsl
   -> T.Transaction
   -> m Coin
 calculateMinFeeCsl (ProtocolParameters pparams) txNoSigs = do
-  let
-    tx = addFakeSignatures txNoSigs
-    txFeePerByte = BigInt.fromInt $ UInt.toInt pparams.txFeePerByte
+  let tx = addFakeSignatures txNoSigs
   cslTx <- liftEffect $ Serialization.convertTransaction tx
   minFee <- liftMaybe (error "Unable to calculate min_fee") $
     BigNum.toBigInt =<< _minFee maybeFfiHelper cslTx
@@ -44,7 +40,7 @@ calculateMinFeeCsl (ProtocolParameters pparams) txNoSigs = do
   minScriptFee <-
     liftMaybe (error "Unable to calculate min_script_fee") $
       BigNum.toBigInt (_minScriptFee exUnitPricesCsl cslTx)
-  pure $ wrap $ minFee + minScriptFee + BigInt.fromInt 3 * txFeePerByte
+  pure $ wrap $ minFee + minScriptFee
 
 addFakeSignatures :: T.Transaction -> T.Transaction
 addFakeSignatures tx =


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/892, Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/570 (we have a similar problem with CSL fee calculation) 

TODO: description

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] The integration and unit tests have been run (`npm run test`) locally
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
