### PR TITLE
Fix runPlutipTest not adding custom buildInputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
 - Bug in `TransactionMetadatum` deserialization ([#932](https://github.com/Plutonomicon/cardano-transaction-lib/issues/932))
 - Fix excessive logging after the end of `Contract` execution ([#893](https://github.com/Plutonomicon/cardano-transaction-lib/issues/893))
 - Add ability to suppress logs of successful `Contract` executions - with new `suppressLogs` config option the logs will be shown on error ([#768](https://github.com/Plutonomicon/cardano-transaction-lib/issues/768))
-- Fix `runPlutipTest` not passing custom `buildInputs`
+- Fix `runPlutipTest` not passing custom `buildInputs` ([#954](https://github.com/Plutonomicon/cardano-transaction-lib/pull/954))
 
 ## [2.0.0-alpha] - 2022-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
 - Bug in `TransactionMetadatum` deserialization ([#932](https://github.com/Plutonomicon/cardano-transaction-lib/issues/932))
 - Fix excessive logging after the end of `Contract` execution ([#893](https://github.com/Plutonomicon/cardano-transaction-lib/issues/893))
 - Add ability to suppress logs of successful `Contract` executions - with new `suppressLogs` config option the logs will be shown on error ([#768](https://github.com/Plutonomicon/cardano-transaction-lib/issues/768))
+- Fix `runPlutipTest` not passing custom `buildInputs`
 
 ## [2.0.0-alpha] - 2022-07-05
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -254,14 +254,14 @@ let
     , ...
     }@args:
     runPursTest (
-      {
+      args // {
         buildInputs = with pkgs; [
           postgresql
           ogmios
           ogmios-datum-cache
           plutip-server
-        ] ++ pkgs.lib.lists.optional withCtlServer pkgs.ctl-server;
-      } // args
+        ] ++ pkgs.lib.lists.optional withCtlServer pkgs.ctl-server ++ args.buildInputs;
+      }
     );
 
   # Bundles a Purescript project using Webpack, typically for the browser


### PR DESCRIPTION
Closes # .

`runPlutipTest` did not pass additional `buildInputs` to `runPursTest`

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](../doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
