### PR TITLE
Fix `runPlutipTest` not adding custom `buildInputs` (was #954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
 - Bug in `TransactionMetadatum` deserialization ([#932](https://github.com/Plutonomicon/cardano-transaction-lib/issues/932))
 - Fix excessive logging after the end of `Contract` execution ([#893](https://github.com/Plutonomicon/cardano-transaction-lib/issues/893))
 - Add ability to suppress logs of successful `Contract` executions - with new `suppressLogs` config option the logs will be shown on error ([#768](https://github.com/Plutonomicon/cardano-transaction-lib/issues/768))
-- Fix `runPlutipTest` not passing custom `buildInputs`
+- Fix `runPlutipTest` not passing custom `buildInputs` ([#954](https://github.com/Plutonomicon/cardano-transaction-lib/pull/954))
 
 ## [2.0.0-alpha] - 2022-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
 - Bug in `TransactionMetadatum` deserialization ([#932](https://github.com/Plutonomicon/cardano-transaction-lib/issues/932))
 - Fix excessive logging after the end of `Contract` execution ([#893](https://github.com/Plutonomicon/cardano-transaction-lib/issues/893))
 - Add ability to suppress logs of successful `Contract` executions - with new `suppressLogs` config option the logs will be shown on error ([#768](https://github.com/Plutonomicon/cardano-transaction-lib/issues/768))
+- Fix `runPlutipTest` not passing custom `buildInputs`
 
 ## [2.0.0-alpha] - 2022-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- `Plutus.Types.AssocMap.AssocMap` now has `TraversableWithIndex`,  `FoldableWithIndex`,  `FunctorWithIndex` instances
 - Plutip integration to run `Contract`s in local, private testnets ([#470](https://github.com/Plutonomicon/cardano-transaction-lib/pull/470))
 - Ability to run `Contract`s in Plutip environment in parallel - `Contract.Test.Plutip.withPlutipContractEnv` ([#800](https://github.com/Plutonomicon/cardano-transaction-lib/issues/800))
 - `withKeyWallet` utility that allows to simulate multiple actors in Plutip environment ([#663](https://github.com/Plutonomicon/cardano-transaction-lib/issues/663))
@@ -62,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Hashing.transactionHash` to calculate the hash of the transaction ([#870](https://github.com/Plutonomicon/cardano-transaction-lib/pull/870))
 - Flint wallet support ([#556](https://github.com/Plutonomicon/cardano-transaction-lib/issues/556))
 - Support for `NativeScript`s in constraints interface: `mustPayToNativeScript` and `mustSpendNativeScriptOutput` functions ([#869](https://github.com/Plutonomicon/cardano-transaction-lib/pull/869))
+- `Plutus.Types.AssocMap.AssocMap` now has `TraversableWithIndex`,  `FoldableWithIndex`,  `FunctorWithIndex` instances
 
 ### Changed
 
@@ -88,7 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Removed
 
-- `Contract.Monad.traceTestnetContractConfig` - use `Contract.Config.testnetNamiConfig` instead.
+- `Contract.Monad.traceTestnetContractConfig` - use `Contract.Config.testnetNamiConfig` instead (or other variants of `testnet...Config` for other wallets).
 - `runContract_` - use `void <<< runContract`.
 
 ### Fixed
@@ -99,12 +99,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Bug when zero-valued non-Ada assets were added to the non-Ada change output ([#802](https://github.com/Plutonomicon/cardano-transaction-lib/pull/802))
 - Error recovery logic for `SubmitTx` if the WebSocket connection is dropped ([#870](https://github.com/Plutonomicon/cardano-transaction-lib/pull/870))
 - Properly implemented CIP-25 V2 metadata. Now there's no need to split arbitrary-length strings manually to fit them in 64 PlutusData bytes (CTL handles that). A new `Cip25String` type has been introduced (a smart constructor ensures that byte representation fits 64 bytes, as required by the spec). Additionally, a new `Metadata.Cip25.Common.Cip25TokenName` wrapper over `TokenName` is added to ensure proper encoding of `asset_name`s. There are still some minor differences from the spec:
-    - We do not split strings in pieces when encoding to JSON
-    - We require a `"version": 2` tag
-    - `policy_id` must be 28 bytes
-    - `asset_name` is up to 32 bytes
-
+  - We do not split strings in pieces when encoding to JSON
+  - We require a `"version": 2` tag
+  - `policy_id` must be 28 bytes
+  - `asset_name` is up to 32 bytes
 See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
+
 - `ogmios-datum-cache` now works on `x86_64-darwin`
 - `TypedValidator` interface ([#808](https://github.com/Plutonomicon/cardano-transaction-lib/issues/808))
 - `Contract.Address.getWalletCollateral` now works with `KeyWallet`.
@@ -115,11 +115,11 @@ See https://github.com/cardano-foundation/CIPs/issues/303 for motivation
 - Bug in `TransactionMetadatum` deserialization ([#932](https://github.com/Plutonomicon/cardano-transaction-lib/issues/932))
 - Fix excessive logging after the end of `Contract` execution ([#893](https://github.com/Plutonomicon/cardano-transaction-lib/issues/893))
 - Add ability to suppress logs of successful `Contract` executions - with new `suppressLogs` config option the logs will be shown on error ([#768](https://github.com/Plutonomicon/cardano-transaction-lib/issues/768))
-- Fix `runPlutipTest` not passing custom `buildInputs` ([#954](https://github.com/Plutonomicon/cardano-transaction-lib/pull/954))
+- Fix `runPlutipTest` not passing custom `buildInputs` ([#955](https://github.com/Plutonomicon/cardano-transaction-lib/pull/954))
 
 ## [2.0.0-alpha] - 2022-07-05
 
-This release adds support for running CTL contracts against Babbage-era nodes. **Note**: this release does not support Babbagge-era features and improvements, e.g. inline datums and reference inputs. Those feature will be implemented in v2.0.0 proper.
+This release adds support for running CTL contracts against Babbage-era nodes. **Note**: this release does not support Babbagge-era features and improvements, e.g. inline datums and reference inputs. Those feature will be implemented in `v2.0.0` proper.
 
 ### Added
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -260,7 +260,9 @@ let
           ogmios
           ogmios-datum-cache
           plutip-server
-        ] ++ pkgs.lib.lists.optional withCtlServer pkgs.ctl-server ++ args.buildInputs;
+        ]
+        ++ (pkgs.lib.lists.optional withCtlServer pkgs.ctl-server)
+        ++ args.buildInputs;
       }
     );
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -254,14 +254,14 @@ let
     , ...
     }@args:
     runPursTest (
-      {
+      args // {
         buildInputs = with pkgs; [
           postgresql
           ogmios
           ogmios-datum-cache
           plutip-server
-        ] ++ pkgs.lib.lists.optional withCtlServer pkgs.ctl-server;
-      } // args
+        ] ++ pkgs.lib.lists.optional withCtlServer pkgs.ctl-server ++ args.buildInputs;
+      }
     );
 
   # Bundles a Purescript project using Webpack, typically for the browser

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -262,7 +262,7 @@ let
           plutip-server
         ]
         ++ (pkgs.lib.lists.optional withCtlServer pkgs.ctl-server)
-        ++ args.buildInputs;
+        ++ (args.buildInputs or [ ]);
       }
     );
 


### PR DESCRIPTION
Changes from #954