### PR TITLE
Expose the compiled project from `purescriptProject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Flint wallet support ([#556](https://github.com/Plutonomicon/cardano-transaction-lib/issues/556))
 - Support for `NativeScript`s in constraints interface: `mustPayToNativeScript` and `mustSpendNativeScriptOutput` functions ([#869](https://github.com/Plutonomicon/cardano-transaction-lib/pull/869))
 - `Plutus.Types.AssocMap.AssocMap` now has `TraversableWithIndex`,  `FoldableWithIndex`,  `FunctorWithIndex` instances ([#943](https://github.com/Plutonomicon/cardano-transaction-lib/pull/943))
-- The return value of `purescriptProject` now includes the project with its compiled `output` (under the `compiled`) attribute ([#956](https://github.com/Plutonomicon/cardano-transaction-lib/pull/956))
+- The return value of `purescriptProject` now includes the project with its compiled `output` and its generated `node_modules` (under the `compiled` and `nodeModules` attributes, respectively) ([#956](https://github.com/Plutonomicon/cardano-transaction-lib/pull/956))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `Contract.Hashing.transactionHash` to calculate the hash of the transaction ([#870](https://github.com/Plutonomicon/cardano-transaction-lib/pull/870))
 - Flint wallet support ([#556](https://github.com/Plutonomicon/cardano-transaction-lib/issues/556))
 - Support for `NativeScript`s in constraints interface: `mustPayToNativeScript` and `mustSpendNativeScriptOutput` functions ([#869](https://github.com/Plutonomicon/cardano-transaction-lib/pull/869))
-- `Plutus.Types.AssocMap.AssocMap` now has `TraversableWithIndex`,  `FoldableWithIndex`,  `FunctorWithIndex` instances
+- `Plutus.Types.AssocMap.AssocMap` now has `TraversableWithIndex`,  `FoldableWithIndex`,  `FunctorWithIndex` instances ([#943](https://github.com/Plutonomicon/cardano-transaction-lib/pull/943))
+- The return value of `purescriptProject` now includes the project with its compiled `output` (under the `compiled`) attribute ([#956](https://github.com/Plutonomicon/cardano-transaction-lib/pull/956))
 
 ### Changed
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -445,4 +445,5 @@ in
     purs nodejs mkNodeModules;
   devShell = shellFor shell;
   compiled = project;
+  nodeModules = projectNodeModules;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -444,4 +444,5 @@ in
     buildPursDocs buildSearchablePursDocs launchSearchablePursDocs
     purs nodejs mkNodeModules;
   devShell = shellFor shell;
+  compiled = project;
 }


### PR DESCRIPTION
It would be nice if our users could access the project including the compiled `output` (to simplify creating custom derivations, etc...), so I've added a `compiled` attribute to what `purescriptProject` returns. I've also added the generated `node_modules` to the return value as well

Not sure if `compiled` is the best name. I'm open to other suggestions. I didn't want to call it `project` (its internal name) because I think most people currently do `project = pkgs.purescriptProject { ... }` and `project.project` looks odd