### PR TITLE
Use valid firstBlock config for preprod

### DIFF
--- a/nix/runtime.nix
+++ b/nix/runtime.nix
@@ -32,8 +32,8 @@ rec {
       controlApiToken = "";
       blockFetcher = {
         firstBlock = {
-          slot = 61625527;
-          id = "3afd8895c7b270f8250b744ec8d2b3c53ee2859c9d5711d906c47fe51b800988";
+          slot = 5854109;
+          id = "85366c607a9777b887733de621aa2008aec9db4f3e6a114fb90ec2909bc06f14";
         };
         autoStart = true;
         startFromLast = false;


### PR DESCRIPTION
To drop the postgresql state, this should be executed in `psql`:

```
$ psql --host localhost --port 5432 -U ctxlib -d ctxlib
password: ctxlib

# update last_block set slot=5702409, hash='f737e8f756b2ece3e361cf252d122cff54562897532d83ba75ab679a7fd859d1'; 
```