### PR TITLE
Fix absence of getUtxos in CIP-30 mock

### DIFF
--- a/src/Wallet/Cip30.purs
+++ b/src/Wallet/Cip30.purs
@@ -34,6 +34,7 @@ import Types.CborBytes (rawBytesAsCborBytes)
 import Types.RawBytes (RawBytes, hexToRawBytes)
 import Untagged.Union (asOneOf)
 
+-- Please update Cip30Mock when you add or remove methods in this handle.
 type Cip30Wallet =
   { -- A reference to a connection with the wallet, i.e. `window.cardano.nami`
     connection :: Cip30Connection

--- a/src/Wallet/Cip30Mock.js
+++ b/src/Wallet/Cip30Mock.js
@@ -31,6 +31,7 @@ exports.injectCip30Mock = walletName => mock => () => {
           signTx: mock.signTx,
           getUsedAddresses: mock.getUsedAddresses,
           getBalance: mock.getBalance,
+          getUtxos: mock.getUtxos,
         })
       );
     },

--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -18,13 +18,7 @@ import Contract.Address
 import Contract.Chain (currentTime)
 import Contract.Hashing (nativeScriptHash)
 import Contract.Log (logInfo')
-import Contract.Monad
-  ( Contract
-  , liftContractM
-  , liftedE
-  , liftedM
-  , wrapContract
-  )
+import Contract.Monad (Contract, liftContractM, liftedE, liftedM, wrapContract)
 import Contract.PlutusData
   ( PlutusData(Integer)
   , Redeemer(Redeemer)
@@ -62,7 +56,8 @@ import Contract.Utxos (getWalletBalance, utxosAt)
 import Contract.Value (Coin(Coin), coinToValue)
 import Contract.Value as Value
 import Contract.Wallet
-  ( isFlintAvailable
+  ( getWalletUtxos
+  , isFlintAvailable
   , isGeroAvailable
   , isNamiAvailable
   , withKeyWallet
@@ -93,7 +88,6 @@ import Examples.Helpers
   , mkTokenName
   , mustPayToPubKeyStakeAddress
   )
-import Examples.PlutusV2.InlineDatum as InlineDatum
 import Examples.Lose7Ada as AlwaysFails
 import Examples.MintsMultipleTokens
   ( mintingPolicyRdmrInt1
@@ -101,6 +95,7 @@ import Examples.MintsMultipleTokens
   , mintingPolicyRdmrInt3
   )
 import Examples.PlutusV2.AlwaysSucceeds as AlwaysSucceedsV2
+import Examples.PlutusV2.InlineDatum as InlineDatum
 import Examples.PlutusV2.ReferenceInputs (contract) as ReferenceInputs
 import Examples.PlutusV2.ReferenceScripts (contract) as ReferenceScripts
 import Examples.SendsToken (contract) as SendsToken
@@ -880,6 +875,18 @@ suite = do
             Just _ -> do
               -- not a bug, but unexpected
               throw "More than one UTxO in collateral"
+
+    test "CIP-30 mock: get own UTxOs" do
+      let
+        distribution :: InitialUTxOs
+        distribution =
+          [ BigInt.fromInt 1_000_000_000
+          , BigInt.fromInt 2_000_000_000
+          ]
+      runPlutipContract config distribution \alice -> do
+        utxos <- withCip30Mock alice MockNami do
+          getWalletUtxos
+        utxos `shouldSatisfy` isJust
 
     test "CIP-30 mock: get own address" do
       let


### PR DESCRIPTION
### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
