### PR TITLE
Add test duration to output

### DIFF
--- a/test/Reporter/Console.purs
+++ b/test/Reporter/Console.purs
@@ -6,12 +6,15 @@ import Prelude
 
 import Control.Monad.State (class MonadState, get, put)
 import Control.Monad.Writer (class MonadWriter)
-import Data.Foldable (for_, intercalate)
+import Data.Foldable (fold, for_, intercalate)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), isNothing)
+import Data.Newtype (un)
+import Data.Number.Format (fixed, toStringWith)
 import Data.Show.Generic (genericShow)
+import Data.Time.Duration (Seconds(Seconds), convertDuration)
 import Test.Spec.Console (tellLn)
 import Test.Spec.Reporter.Base
   ( RunningItem(RunningTest, RunningPending)
@@ -107,8 +110,15 @@ print path a = do
           $ intercalate " » " (parentSuiteName suite.path <> [ suite.name ])
         put s { lastPrintedSuitePath = Just suite.path }
   case a of
-    PrintTest name (Success _ _) -> do
-      tellLn $ "  " <> styled Style.green "✓︎ " <> styled Style.dim name
+    PrintTest name (Success _ timeElapsed) -> do
+      let
+        timeStr = styled Style.cyan $ fold
+          [ " ("
+          , toStringWith (fixed 2) $ un Seconds $ convertDuration timeElapsed
+          , "s)"
+          ]
+      tellLn $ "  " <> styled Style.green "✓︎ " <> styled Style.dim name <>
+        timeStr
     PrintTest name (Failure err) -> do
       tellLn $ "  " <> styled Style.red ("✗ " <> name <> ":")
       tellLn $ ""


### PR DESCRIPTION
I thought this might be useful to see what tests take the longest, and to observe changes in durations

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
