### PR TITLE
Remove unwanted E2E test suite timeout

### DIFF
--- a/src/Internal/Test/E2E/Feedback/Node.purs
+++ b/src/Internal/Test/E2E/Feedback/Node.purs
@@ -17,9 +17,7 @@ import Ctl.Internal.Test.E2E.Feedback (BrowserEvent(Failure, Success))
 import Data.Array as Array
 import Data.Either (Either(Left), hush, note)
 import Data.Foldable (and)
-import Data.Maybe (Maybe(Just, Nothing), fromMaybe)
-import Data.Number (infinity)
-import Data.Time.Duration (Seconds(Seconds), convertDuration)
+import Data.Maybe (Maybe(Just, Nothing))
 import Data.Traversable (for, traverse_)
 import Effect (Effect)
 import Effect.Aff
@@ -43,11 +41,10 @@ import Toppokki as Toppokki
 
 -- | React to events raised by the browser
 subscribeToBrowserEvents
-  :: Maybe Seconds
-  -> Toppokki.Page
+  :: Toppokki.Page
   -> (BrowserEvent -> Effect Unit)
   -> Aff Unit
-subscribeToBrowserEvents timeout page cont = do
+subscribeToBrowserEvents page cont = do
   logs <- liftEffect $ Ref.new ""
   let
     addLogLine line = Ref.modify_ (flip append (line <> "\n")) logs
@@ -90,17 +87,12 @@ subscribeToBrowserEvents timeout page cont = do
           else process Nothing
         else pure unit
 
-    timeoutFiber <- Ref.new Nothing
     processFiber <- Ref.new Nothing
     launchAff_ do
-      liftEffect <<< flip Ref.write timeoutFiber <<< Just =<< forkAff do
-        delay $ convertDuration $ fromMaybe (Seconds infinity) timeout
-        liftEffect $ f $ Left $ error "Timeout reached"
       liftEffect <<< flip Ref.write processFiber <<< Just =<< forkAff do
         try (process (Just firstTimeConnectionAttempts)) >>= liftEffect <<< f
     pure $ Canceler \e -> do
-      liftEffect (Ref.read timeoutFiber) >>= traverse_ (killFiber e)
-      liftEffect (Ref.read timeoutFiber) >>= traverse_ (killFiber e)
+      liftEffect (Ref.read processFiber) >>= traverse_ (killFiber e)
   where
   -- How many times to try until we get any event?
   firstTimeConnectionAttempts :: Int

--- a/src/Internal/Test/E2E/Runner.purs
+++ b/src/Internal/Test/E2E/Runner.purs
@@ -280,7 +280,7 @@ testPlan opts@{ tests } rt@{ wallets } =
                 , confirmAccess: confirmAccess extensionId re
                 , sign: sign extensionId password re
                 }
-            subscribeToBrowserEvents (Just $ Seconds 10.0) page
+            subscribeToBrowserEvents page
               case _ of
                 ConfirmAccess -> launchAff_ someWallet.confirmAccess
                 Sign -> launchAff_ someWallet.sign
@@ -289,7 +289,7 @@ testPlan opts@{ tests } rt@{ wallets } =
   where
   subscribeToTestStatusUpdates :: Toppokki.Page -> Aff Unit
   subscribeToTestStatusUpdates page =
-    subscribeToBrowserEvents (Just $ Seconds 10.0) page
+    subscribeToBrowserEvents page
       case _ of
         Success -> pure unit
         Failure err -> throw err

--- a/src/Internal/Test/E2E/Runner.purs
+++ b/src/Internal/Test/E2E/Runner.purs
@@ -88,7 +88,7 @@ import Data.Posix.Signal (Signal(SIGINT))
 import Data.String (Pattern(Pattern))
 import Data.String (contains, null, split, toLower, toUpper, trim) as String
 import Data.String.Utils (startsWith) as String
-import Data.Time.Duration (Milliseconds(Milliseconds), Seconds(Seconds))
+import Data.Time.Duration (Milliseconds(Milliseconds))
 import Data.Traversable (for, for_)
 import Data.Tuple (Tuple(Tuple))
 import Data.UInt as UInt


### PR DESCRIPTION
This PR simplifies the test suite: we don't need a timeout, since we exit after 10 attempts to connect to the remote contract anyway.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
