### PR TITLE
Move distribution tests to after the contract tests, to avoid the cluster failure during contract tests.

### DIFF
--- a/test/Plutip.purs
+++ b/test/Plutip.purs
@@ -35,9 +35,9 @@ main = launchAff_ do
     defaultConfig { timeout = Just $ Milliseconds 70_000.0, exit = true }
     $ group "Plutip" do
         Logging.suite
-        UtxoDistribution.suite
         testStartPlutipCluster
         testPlutipContracts config Contract.suite
+        UtxoDistribution.suite
 
 testStartPlutipCluster :: TestPlanM (Aff Unit) Unit
 testStartPlutipCluster = group "Server" do

--- a/test/Plutip/UtxoDistribution.purs
+++ b/test/Plutip/UtxoDistribution.purs
@@ -75,7 +75,7 @@ import Type.Prelude (Proxy(Proxy))
 suite :: TestPlanM (Aff Unit) Unit
 suite = group "UtxoDistribution" do
   test
-    "runPlutipContract: stake key transfers with distribution: [[1000000000,1000000000]]"
+    "stake key transfers with distribution: [[1000000000,1000000000]]"
     do
       let
         distribution :: Array InitialUTxOs
@@ -83,7 +83,7 @@ suite = group "UtxoDistribution" do
       runPlutipContract config distribution $ checkUtxoDistribution distribution
 
   test
-    "runPlutipContract: stake key transfers with distribution: stake + [[1000000000,1000000000]]"
+    "stake key transfers with distribution: stake + [[1000000000,1000000000]]"
     do
       let
         distribution :: Array InitialUTxOsWithStakeKey
@@ -92,7 +92,7 @@ suite = group "UtxoDistribution" do
       runPlutipContract config distribution $ checkUtxoDistribution distribution
 
   test
-    "runPlutipContract: stake key transfers with distribution: ([[1000000000,1000000000]], stake + [[1000000000,1000000000]])"
+    "stake key transfers with distribution: ([[1000000000,1000000000]], stake + [[1000000000,1000000000]])"
     do
       let
         distribution1 :: Array InitialUTxOs


### PR DESCRIPTION
https://github.com/Plutonomicon/cardano-transaction-lib/issues/1232 has hit https://github.com/Plutonomicon/cardano-transaction-lib/pull/1055 twice in the contract tests, which is annoying because all of the tests fail. From my experience, the failures occur after several plutip clusters have been set up, so this change should hopefully avoid this (still not great that we have these failures)

Closes # .

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
