### PR TITLE
Throw error when a transaction output can't be found in utxos in Examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Absence of `serializeData` in Plutip ([#1078](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1078))
 - Fix excessive reconnection attempts after `Contract` runtime finalization ([#965](https://github.com/Plutonomicon/cardano-transaction-lib/pull/965))
 - Fix wallet extension error terminating the whole test suite ([#1209](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1209))
-- Examples fails when they can't find the needed utxos([#1207](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1207)) 
+- Examples fails when they can't find the needed utxos([#1207](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1207))
 
 ## [2.0.0] - 2022-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Absence of `serializeData` in Plutip ([#1078](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1078))
 - Fix excessive reconnection attempts after `Contract` runtime finalization ([#965](https://github.com/Plutonomicon/cardano-transaction-lib/pull/965))
 - Fix wallet extension error terminating the whole test suite ([#1209](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1209))
+- Examples fails when they can't find the needed utxos([#1207](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1207)) 
 
 ## [2.0.0] - 2022-09-12
 

--- a/examples/AlwaysSucceeds.purs
+++ b/examples/AlwaysSucceeds.purs
@@ -13,7 +13,7 @@ module Ctl.Examples.AlwaysSucceeds
 
 import Contract.Prelude
 
-import Contract.Address (ownStakePubKeyHash, scriptHashAddress)
+import Contract.Address (ownStakePubKeysHashes, scriptHashAddress)
 import Contract.Config (ConfigParams, testnetNamiConfig)
 import Contract.Credential (Credential(PubKeyCredential))
 import Contract.Log (logInfo')
@@ -60,7 +60,7 @@ example cfg = launchAff_ do
 payToAlwaysSucceeds :: ValidatorHash -> Contract () TransactionHash
 payToAlwaysSucceeds vhash = do
   -- Send to own stake credential. This is used to test mustPayToScriptAddress.
-  mbStakeKeyHash <- ownStakePubKeyHash
+  mbStakeKeyHash <- join <<< head <$> ownStakePubKeysHashes
   let
     constraints :: TxConstraints Unit Unit
     constraints =
@@ -90,7 +90,7 @@ spendFromAlwaysSucceeds
   -> Contract () Unit
 spendFromAlwaysSucceeds vhash validator txId = do
   -- Use own stake credential if available
-  mbStakeKeyHash <- ownStakePubKeyHash
+  mbStakeKeyHash <- join <<< head <$> ownStakePubKeysHashes
   let
     scriptAddress =
       scriptHashAddress vhash (PubKeyCredential <<< unwrap <$> mbStakeKeyHash)
@@ -104,7 +104,7 @@ spendFromAlwaysSucceeds vhash validator txId = do
               <> show scriptAddress
           )
       )
-     (view _input <$> head (lookupTxHash txId utxos))
+      (view _input <$> head (lookupTxHash txId utxos))
   let
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = Lookups.validator validator

--- a/examples/IncludeDatum.purs
+++ b/examples/IncludeDatum.purs
@@ -15,14 +15,11 @@ import Contract.Prelude
 import Contract.Address (scriptHashAddress)
 import Contract.Config (ConfigParams, testnetNamiConfig)
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, launchAff_, runContract)
+import Contract.Monad (Contract, launchAff_, liftContractM, runContract)
 import Contract.PlutusData (Datum(Datum), PlutusData(Integer), unitRedeemer)
 import Contract.ScriptLookups as Lookups
 import Contract.Scripts (Validator(Validator), ValidatorHash, validatorHash)
-import Contract.TextEnvelope
-  ( decodeTextEnvelope
-  , plutusScriptV1FromEnvelope
-  )
+import Contract.TextEnvelope (decodeTextEnvelope, plutusScriptV1FromEnvelope)
 import Contract.Transaction
   ( TransactionHash
   , _input
@@ -82,23 +79,20 @@ spendFromIncludeDatum
 spendFromIncludeDatum vhash validator txId = do
   let scriptAddress = scriptHashAddress vhash Nothing
   utxos <- utxosAt scriptAddress
-  case view _input <$> head (lookupTxHash txId utxos) of
-    Just txInput ->
-      let
-        lookups :: Lookups.ScriptLookups PlutusData
-        lookups = Lookups.validator validator
-          <> Lookups.unspentOutputs utxos
+  txInput <- liftContractM "no locked output at address"
+    (view _input <$> head (lookupTxHash txId utxos))
+  let
+    lookups :: Lookups.ScriptLookups PlutusData
+    lookups = Lookups.validator validator
+      <> Lookups.unspentOutputs utxos
 
-        constraints :: TxConstraints Unit Unit
-        constraints =
-          Constraints.mustSpendScriptOutput txInput unitRedeemer
-            <> Constraints.mustIncludeDatum datum
-      in
-        do
-          spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
-          awaitTxConfirmed spendTxId
-          logInfo' "Successfully spent locked values."
-    _ -> logInfo' "no locked output at address"
+    constraints :: TxConstraints Unit Unit
+    constraints =
+      Constraints.mustSpendScriptOutput txInput unitRedeemer
+        <> Constraints.mustIncludeDatum datum
+  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  awaitTxConfirmed spendTxId
+  logInfo' "Successfully spent locked values."
 
 foreign import includeDatum :: String
 

--- a/examples/Lose7Ada.purs
+++ b/examples/Lose7Ada.purs
@@ -81,15 +81,15 @@ spendFromAlwaysFails vhash validator txId = do
   balanceBefore <- fold <$> getWalletBalance
   let scriptAddress = scriptHashAddress vhash Nothing
   utxos <- utxosAt scriptAddress
-  txInput <-  liftM
-      ( error
-          ( "The id "
-              <> show txId
-              <> " does not have output locked at: "
-              <> show scriptAddress
-          )
-      )
-      (fst <$> find hasTransactionId (Map.toUnfoldable utxos :: Array _))
+  txInput <- liftM
+    ( error
+        ( "The id "
+            <> show txId
+            <> " does not have output locked at: "
+            <> show scriptAddress
+        )
+    )
+    (fst <$> find hasTransactionId (Map.toUnfoldable utxos :: Array _))
   let
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = Lookups.validator validator

--- a/examples/PlutusV2/ReferenceScripts.purs
+++ b/examples/PlutusV2/ReferenceScripts.purs
@@ -6,7 +6,7 @@ module Ctl.Examples.PlutusV2.ReferenceScripts
 
 import Contract.Prelude
 
-import Contract.Address (ownStakePubKeyHash, scriptHashAddress)
+import Contract.Address (ownStakePubKeysHashes, scriptHashAddress)
 import Contract.Config (ConfigParams, testnetNamiConfig)
 import Contract.Credential (Credential(PubKeyCredential))
 import Contract.Log (logInfo')
@@ -31,6 +31,7 @@ import Contract.Utxos (utxosAt)
 import Contract.Value (lovelaceValueOf) as Value
 import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Ctl.Examples.PlutusV2.AlwaysSucceeds (alwaysSucceedsScriptV2)
+import Data.Array (head)
 import Data.BigInt (fromInt) as BigInt
 import Data.Map (toUnfoldable) as Map
 
@@ -63,7 +64,7 @@ payWithScriptRefToAlwaysSucceeds
 payWithScriptRefToAlwaysSucceeds vhash scriptRef = do
   -- Send to own stake credential. This is used to test
   -- `mustPayToScriptAddressWithScriptRef`
-  mbStakeKeyHash <- ownStakePubKeyHash
+  mbStakeKeyHash <- join <<< head <$> ownStakePubKeysHashes
   let
     constraints :: TxConstraints Unit Unit
     constraints =
@@ -90,7 +91,7 @@ spendFromAlwaysSucceeds :: ValidatorHash -> TransactionHash -> Contract () Unit
 spendFromAlwaysSucceeds vhash txId = do
   -- Send to own stake credential. This is used to test
   -- `mustPayToScriptAddressWithScriptRef`
-  mbStakeKeyHash <- ownStakePubKeyHash
+  mbStakeKeyHash <- join <<< head <$> ownStakePubKeysHashes
   let
     scriptAddress =
       scriptHashAddress vhash (PubKeyCredential <<< unwrap <$> mbStakeKeyHash)

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -60,13 +60,7 @@ import Contract.TxConstraints as Constraints
 import Contract.Utxos (getWalletBalance, utxosAt)
 import Contract.Value (Coin(Coin), coinToValue)
 import Contract.Value as Value
-import Contract.Wallet
-  ( getWalletUtxos
-  , isFlintAvailable
-  , isGeroAvailable
-  , isNamiAvailable
-  , withKeyWallet
-  )
+import Contract.Wallet (getWalletUtxos, isWalletAvailable, withKeyWallet)
 import Control.Monad.Error.Class (try)
 import Control.Monad.Reader (asks)
 import Control.Parallel (parallel, sequential)
@@ -112,6 +106,9 @@ import Ctl.Internal.Plutus.Types.Value (lovelaceValueOf)
 import Ctl.Internal.Scripts (nativeScriptHashEnterpriseAddress)
 import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.Interval (getSlotLength)
+import Ctl.Internal.Wallet
+  ( WalletExtension(NamiWallet, GeroWallet, FlintWallet)
+  )
 import Ctl.Internal.Wallet.Cip30Mock
   ( WalletMock(MockNami, MockGero, MockFlint)
   , withCip30Mock
@@ -1376,20 +1373,28 @@ suite = do
             , BigInt.fromInt 2_000_000_000
             ]
         withWallets distribution \alice -> do
-          try (liftEffect isNamiAvailable) >>= flip shouldSatisfy isLeft
-          try (liftEffect isGeroAvailable) >>= flip shouldSatisfy isLeft
-          try (liftEffect isFlintAvailable) >>= flip shouldSatisfy isLeft
+          try (liftEffect $ isWalletAvailable NamiWallet) >>= flip shouldSatisfy
+            isLeft
+          try (liftEffect $ isWalletAvailable GeroWallet) >>= flip shouldSatisfy
+            isLeft
+          try (liftEffect $ isWalletAvailable FlintWallet) >>= flip
+            shouldSatisfy
+            isLeft
 
           withCip30Mock alice MockNami do
-            liftEffect isNamiAvailable >>= shouldEqual true
-          try (liftEffect isNamiAvailable) >>= flip shouldSatisfy isLeft
+            (liftEffect $ isWalletAvailable NamiWallet) >>= shouldEqual true
+          try (liftEffect $ isWalletAvailable NamiWallet) >>= flip shouldSatisfy
+            isLeft
 
           withCip30Mock alice MockGero do
-            liftEffect isGeroAvailable >>= shouldEqual true
-          try (liftEffect isGeroAvailable) >>= flip shouldSatisfy isLeft
+            (liftEffect $ isWalletAvailable GeroWallet) >>= shouldEqual true
+          try (liftEffect $ isWalletAvailable GeroWallet) >>= flip shouldSatisfy
+            isLeft
           withCip30Mock alice MockFlint do
-            liftEffect isFlintAvailable >>= shouldEqual true
-          try (liftEffect isFlintAvailable) >>= flip shouldSatisfy isLeft
+            (liftEffect $ isWalletAvailable FlintWallet) >>= shouldEqual true
+          try (liftEffect $ isWalletAvailable FlintWallet) >>= flip
+            shouldSatisfy
+            isLeft
 
       test "Collateral selection" do
         let


### PR DESCRIPTION
Closes #1207  .

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
