### PR TITLE
Fix CIP30 Mock throwing wrong error when no collateral can be picked

### DIFF
--- a/src/Internal/Wallet/Cip30Mock.purs
+++ b/src/Internal/Wallet/Cip30Mock.purs
@@ -37,7 +37,7 @@ import Ctl.Internal.Wallet.Key
   )
 import Data.Array as Array
 import Data.Either (hush)
-import Data.Foldable (foldMap)
+import Data.Foldable (foldMap, fold)
 import Data.Function.Uncurried (Fn2, mkFn2)
 import Data.Lens ((.~))
 import Data.Lens.Common (simple)
@@ -136,7 +136,7 @@ mkCip30Mock pKey mSKey = do
         (unwrap keyWallet).selectCollateral coinsPerUtxoUnit
           maxCollateralInputs
           utxos
-          >>= liftMaybe (error "No UTxOs at address")
+          <#> fold
 
   pure $
     { getNetworkId: fromAff $ pure $

--- a/src/Internal/Wallet/Cip30Mock.purs
+++ b/src/Internal/Wallet/Cip30Mock.purs
@@ -37,7 +37,7 @@ import Ctl.Internal.Wallet.Key
   )
 import Data.Array as Array
 import Data.Either (hush)
-import Data.Foldable (foldMap, fold)
+import Data.Foldable (fold, foldMap)
 import Data.Function.Uncurried (Fn2, mkFn2)
 import Data.Lens ((.~))
 import Data.Lens.Common (simple)

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -1561,18 +1561,18 @@ suite = do
           withCip30Mock alice MockNami do
             Cip30.contract
 
-      -- TODO
-      skip $ test "Failing getWalletBalance - investigate" do
+      test "getWalletBalance" do
         let
           distribution :: InitialUTxOs
           distribution =
-            [ BigInt.fromInt 2_000_000
+            [ BigInt.fromInt 5_000_000
             , BigInt.fromInt 2_000_000
+            , BigInt.fromInt 1_000_000
             ]
         withWallets distribution \alice -> do
           withCip30Mock alice MockNami do
             getWalletBalance >>= flip shouldSatisfy
-              (eq $ Just $ coinToValue $ Coin $ BigInt.fromInt 3_000_000)
+              (eq $ Just $ coinToValue $ Coin $ BigInt.fromInt 8_000_000)
 
 signMultipleContract :: forall (r :: Row Type). Contract r Unit
 signMultipleContract = do


### PR DESCRIPTION
Closes #1083.

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
