### PR TITLE
cleanup race condition with rmdir sync

### DIFF
--- a/src/Internal/Plutip/Spawn.purs
+++ b/src/Internal/Plutip/Spawn.purs
@@ -122,6 +122,6 @@ cleanupTmpDir :: ManagedProcess -> FilePath -> Effect Unit
 cleanupTmpDir (ManagedProcess _ child _) workingDir = do
   ChildProcess.onExit child \_ -> do
     _rmdirSync workingDir
-  -- TODO
-  -- cleanup directories in case of ctrl+c exit,
-  -- https://github.com/Plutonomicon/cardano-transaction-lib/issues/1176
+-- TODO
+-- cleanup directories in case of ctrl+c exit,
+-- https://github.com/Plutonomicon/cardano-transaction-lib/issues/1176

--- a/src/Internal/Plutip/Spawn.purs
+++ b/src/Internal/Plutip/Spawn.purs
@@ -33,7 +33,6 @@ import Node.ChildProcess
   , stdout
   )
 import Node.ChildProcess as ChildProcess
-import Node.Process as Process
 import Node.ReadLine (Interface, close, createInterface, setLineHandler) as RL
 
 -- | Carry along an `AVar` which resolves when the process closes.
@@ -119,14 +118,10 @@ waitForStop (ManagedProcess cmd _ closedAVar) = do
 
 foreign import _rmdirSync :: FilePath -> Effect Unit
 
-cleanupTmpDir :: ManagedProcess -> FilePath -> FilePath -> Effect Unit
-cleanupTmpDir (ManagedProcess _ child _) workingDir testClusterDir = do
+cleanupTmpDir :: ManagedProcess -> FilePath -> Effect Unit
+cleanupTmpDir (ManagedProcess _ child _) workingDir = do
   ChildProcess.onExit child \_ -> do
     _rmdirSync workingDir
   -- TODO
   -- cleanup directories in case of ctrl+c exit,
-  -- code below doesn't work as intended.
   -- https://github.com/Plutonomicon/cardano-transaction-lib/issues/1176
-  Process.onExit \_ -> do
-    _rmdirSync testClusterDir
-    _rmdirSync workingDir


### PR DESCRIPTION
Closes #1229.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
