### PR TITLE
Plutip-server fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9979,17 +9979,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1660730745,
-        "narHash": "sha256-N1HOR3rqsXMIG7k12BsIyVZReJM9jHUW+gfvYBq/p84=",
+        "lastModified": 1669560943,
+        "narHash": "sha256-IecfHmnpqE1YhOS8MTobEG417FuO+HBmPmPReD6BfQM=",
         "owner": "mlabs-haskell",
         "repo": "plutip",
-        "rev": "8364c43ac6bc9ea140412af9a23c691adf67a18b",
+        "rev": "1c9dd05697d7cf55de8ca26f0756a75ed821bdfb",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
         "repo": "plutip",
-        "rev": "8364c43ac6bc9ea140412af9a23c691adf67a18b",
+        "rev": "1c9dd05697d7cf55de8ca26f0756a75ed821bdfb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
     ogmios.url = "github:mlabs-haskell/ogmios/3b229c1795efa30243485730b78ea053992fdc7a";
 
-    plutip.url = "github:mlabs-haskell/plutip/8364c43ac6bc9ea140412af9a23c691adf67a18b";
+    plutip.url = "github:mlabs-haskell/plutip/1c9dd05697d7cf55de8ca26f0756a75ed821bdfb";
     plutip.inputs.bot-plutus-interface.follows = "bot-plutus-interface";
     plutip.inputs.haskell-nix.follows = "bot-plutus-interface/haskell-nix";
     plutip.inputs.iohk-nix.follows = "bot-plutus-interface/iohk-nix";


### PR DESCRIPTION
Bump plutip to this [pr](https://github.com/mlabs-haskell/plutip/pull/154) that builds on top of the previously used commit.
Hopefully this fixes `ClientHttpError` from #1174.

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
