### PR TITLE
add TestPlanM to API, remove interpretWithTimeout

### DIFF
--- a/src/Contract/Test/Mote.purs
+++ b/src/Contract/Test/Mote.purs
@@ -1,0 +1,9 @@
+module Contract.Test.Mote
+  ( module X
+  ) where
+
+import Ctl.Internal.Test.TestPlanM
+  ( TestPlanM
+  , interpret
+  , interpretWithConfig
+  ) as X

--- a/src/Contract/Test/Mote/ConsoleReporter.purs
+++ b/src/Contract/Test/Mote/ConsoleReporter.purs
@@ -1,0 +1,5 @@
+-- | A custom reporter that will print the entire stack trace of errors from
+-- | failed tests. Should be used with `Test.Spec.Runner.runSpec'`.
+module Contract.Test.Mote.ConsoleReporter (module X) where
+
+import Ctl.Internal.Test.ConsoleReporter (consoleReporter) as X

--- a/src/Internal/Test/TestPlanM.purs
+++ b/src/Internal/Test/TestPlanM.purs
@@ -1,7 +1,6 @@
 module Ctl.Internal.Test.TestPlanM
   ( TestPlanM
   , interpret
-  , interpretWithTimeout
   , interpretWithConfig
   ) where
 
@@ -11,7 +10,6 @@ import Ctl.Internal.Test.ConsoleReporter (consoleReporter)
 import Data.Foldable (sequence_)
 import Data.Maybe (Maybe(Just), maybe)
 import Data.Newtype (wrap)
-import Data.Time.Duration (Milliseconds)
 import Effect.Aff (Aff, bracket)
 import Mote (MoteT, Plan, foldPlan, planT)
 import Mote.Entry (Bracket, unBracket)
@@ -30,11 +28,6 @@ type AffSpec a = SpecT Aff Unit Aff a
 -- | in Test.Spec which prohibit effects.
 interpret :: TestPlanM (Aff Unit) Unit -> Aff Unit
 interpret = interpretWithConfig defaultConfig { timeout = Just (wrap 50000.0) }
-
-interpretWithTimeout
-  :: Maybe Milliseconds -> TestPlanM (Aff Unit) Unit -> Aff Unit
-interpretWithTimeout timeout spif = do
-  interpretWithConfig (defaultConfig { timeout = timeout }) spif
 
 interpretWithConfig
   :: SpecRunner.Config -> TestPlanM (Aff Unit) Unit -> Aff Unit
@@ -60,4 +53,3 @@ planToSpec =
   runBracket :: Aff Unit -> Maybe (Bracket Aff) -> Aff Unit
   runBracket action = maybe action
     $ unBracket \before after -> bracket before after (const action)
-


### PR DESCRIPTION
Closes # .

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
