### PR TITLE
Remove short-circuiting added for wasm bindgen bug

### DIFF
--- a/src/Internal/Deserialization/Keys.js
+++ b/src/Internal/Deserialization/Keys.js
@@ -8,14 +8,8 @@ if (typeof BROWSER_RUNTIME != "undefined" && BROWSER_RUNTIME) {
 }
 
 exports._publicKeyFromBech32 = maybe => bech32 => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
-    if (/^ed25519_pk1[0-9a-z]+$/.test(bech32)) {
-      return maybe.just(lib.PublicKey.from_bech32(bech32));
-    } else {
-      throw new Error("Wrong prefix");
-    }
+    return maybe.just(lib.PublicKey.from_bech32(bech32));
   } catch (_) {
     return maybe.nothing;
   }

--- a/src/Internal/Serialization.js
+++ b/src/Internal/Serialization.js
@@ -131,24 +131,9 @@ exports.setTxBodyMint = setter("mint");
 
 exports.newMint = () => lib.Mint.new();
 
-const bigNumLimit = BigInt("18446744073709551616"); // 2 ^ 64
-
-const bigNumLimitNeg = BigInt("-18446744073709551616"); // 2 ^ 64
-
-const checkLimit = (num, lower_limit, upper_limit) => {
-  if (lower_limit < num && num < upper_limit) {
-    return num;
-  } else {
-    throw new Error("Overflow detected");
-  }
-};
-
 exports._bigIntToInt = maybe => bigInt => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
     const str = bigInt.to_str();
-    checkLimit(BigInt(str), bigNumLimitNeg, bigNumLimit);
     if (str[0] == "-") {
       return maybe.just(
         lib.Int.new_negative(lib.BigNum.from_str(str.slice(1)))

--- a/src/Internal/Serialization/BigInt.js
+++ b/src/Internal/Serialization/BigInt.js
@@ -8,10 +8,7 @@ if (typeof BROWSER_RUNTIME != "undefined" && BROWSER_RUNTIME) {
 }
 
 exports._BigInt_from_str = helper => str => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
-    BigInt(str);
     return helper.just(lib.BigInt.from_str(str));
   } catch (_) {
     return helper.nothing;

--- a/src/Internal/Serialization/PlutusData.js
+++ b/src/Internal/Serialization/PlutusData.js
@@ -19,10 +19,7 @@ exports._packPlutusList = containerHelper => elems =>
 exports._mkConstrPlutusData = n => list => lib.ConstrPlutusData.new(n, list);
 
 exports._bigIntFromString = maybe => str => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
-    BigInt(str);
     return maybe.just(lib.BigInt.from_str(str));
   } catch (_) {
     return maybe.nothing;

--- a/src/Internal/Types/BigNum.js
+++ b/src/Internal/Types/BigNum.js
@@ -30,9 +30,6 @@ exports.bnMul = maybe => lhs => rhs => {
 };
 
 exports._fromString = maybe => str => {
-  if (str[0] == "-") {
-    return maybe.nothing;
-  }
   try {
     return maybe.just(lib.BigNum.from_str(str));
   } catch (_) {

--- a/src/Internal/Types/BigNum.js
+++ b/src/Internal/Types/BigNum.js
@@ -13,39 +13,8 @@ exports.zero = lib.BigNum.zero();
 
 exports.one = lib.BigNum.one();
 
-const add = (a, b) => a + b;
-
-const mul = (a, b) => a * b;
-
-const bigNumLimit = BigInt("18446744073709551616"); // 2 ^ 64
-
-const checkLimitWithFunc = (a, b, limit, func) => {
-  const r = func(a, b);
-  if (r < limit) {
-    return r;
-  } else {
-    throw new Error("Overflow detected");
-  }
-};
-
-const checkLimit = (str, limit) => {
-  if (0 <= BigInt(str) && BigInt(str) < limit) {
-    return BigInt(str);
-  } else {
-    throw new Error("Overflow detected");
-  }
-};
-
 exports.bnAdd = maybe => lhs => rhs => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
-    checkLimitWithFunc(
-      BigInt(lhs.to_str()),
-      BigInt(rhs.to_str()),
-      bigNumLimit,
-      add
-    );
     return maybe.just(lhs.checked_add(rhs));
   } catch (_) {
     return maybe.nothing;
@@ -53,15 +22,7 @@ exports.bnAdd = maybe => lhs => rhs => {
 };
 
 exports.bnMul = maybe => lhs => rhs => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
   try {
-    checkLimitWithFunc(
-      BigInt(lhs.to_str()),
-      BigInt(rhs.to_str()),
-      bigNumLimit,
-      mul
-    );
     return maybe.just(lhs.checked_mul(rhs));
   } catch (_) {
     return maybe.nothing;
@@ -69,10 +30,10 @@ exports.bnMul = maybe => lhs => rhs => {
 };
 
 exports._fromString = maybe => str => {
-  // this is needed because try/catch overuse breaks runtime badly
-  // https://github.com/Plutonomicon/cardano-transaction-lib/issues/875
+  if (str[0] == "-") {
+    return maybe.nothing;
+  }
   try {
-    checkLimit(str, bigNumLimit);
     return maybe.just(lib.BigNum.from_str(str));
   } catch (_) {
     return maybe.nothing;


### PR DESCRIPTION
Closes #1181.

All tests are passing locally. I also ran the reproduction code provided in #875 and confirmed memory access issue no longer occurs.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included