### PR TITLE
Fix `signData` resp handling & Add `SignData` example 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 
 ### Added
+- NuFi wallet support ([#1265](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1265))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Support is planned for the following light wallets:
 - [x] [Flint](https://flint-wallet.com/)
 - [x] [Lode](https://lodewallet.io/)
 - [x] [Eternl (formerly CCvault)](https://eternl.io/)
+- [x] [NuFi](https://nu.fi/)
 - [ ] [Lace](https://www.lace.io/)
 - [ ] [Typhon](https://typhonwallet.io/)
 - [ ] [Yoroi](https://yoroi-wallet.com/)

--- a/examples/ByUrl.purs
+++ b/examples/ByUrl.purs
@@ -8,11 +8,13 @@ import Contract.Config
   , mainnetGeroConfig
   , mainnetLodeConfig
   , mainnetNamiConfig
+  , mainnetNufiConfig
   , testnetEternlConfig
   , testnetFlintConfig
   , testnetGeroConfig
   , testnetLodeConfig
   , testnetNamiConfig
+  , testnetNufiConfig
   )
 import Contract.Monad (Contract)
 import Contract.Test.E2E (E2EConfigName, E2ETestName, addLinks, route)
@@ -34,7 +36,7 @@ import Ctl.Examples.TxChaining as TxChaining
 import Ctl.Examples.Utxos as Utxos
 import Ctl.Examples.Wallet as Wallet
 import Ctl.Internal.Wallet.Cip30Mock
-  ( WalletMock(MockNami, MockGero, MockFlint, MockLode)
+  ( WalletMock(MockNami, MockGero, MockFlint, MockLode, MockNufi)
   )
 import Data.Map (Map)
 import Data.Map as Map
@@ -54,6 +56,7 @@ wallets = Map.fromFoldable
   , "flint" /\ testnetFlintConfig /\ Nothing
   , "eternl" /\ testnetEternlConfig /\ Nothing
   , "lode" /\ testnetLodeConfig /\ Nothing
+  , "nufi" /\ testnetNufiConfig /\ Nothing
   , "nami-mock" /\ testnetNamiConfig /\ Just MockNami
   , "gero-mock" /\ testnetGeroConfig /\ Just MockGero
   , "flint-mock" /\ testnetFlintConfig /\ Just MockFlint
@@ -63,6 +66,7 @@ wallets = Map.fromFoldable
   , "plutip-gero-mock" /\ mainnetGeroConfig /\ Just MockGero
   , "plutip-flint-mock" /\ mainnetFlintConfig /\ Just MockFlint
   , "plutip-lode-mock" /\ mainnetLodeConfig /\ Just MockLode
+  , "plutip-nufi-mock" /\ mainnetNufiConfig /\ Just MockNufi
   ]
 
 examples :: Map E2ETestName (Contract () Unit)

--- a/examples/ByUrl.purs
+++ b/examples/ByUrl.purs
@@ -31,6 +31,7 @@ import Ctl.Examples.PlutusV2.OneShotMinting as OneShotMintingV2
 import Ctl.Examples.PlutusV2.ReferenceInputs as ReferenceInputsV2
 import Ctl.Examples.PlutusV2.ReferenceInputsAndScripts as ReferenceInputsAndScriptsV2
 import Ctl.Examples.SendsToken as SendsToken
+import Ctl.Examples.SignData as SignData
 import Ctl.Examples.SignMultiple as SignMultiple
 import Ctl.Examples.TxChaining as TxChaining
 import Ctl.Examples.Utxos as Utxos
@@ -80,6 +81,7 @@ examples = Map.fromFoldable
   , "Pkh2Pkh" /\ Pkh2Pkh.contract
   , "TxChaining" /\ TxChaining.contract
   , "SendsToken" /\ SendsToken.contract
+  , "SignData" /\ SignData.contract
   , "SignMultiple" /\ SignMultiple.contract
   , "MintsMultipleTokens" /\ MintsMultipleTokens.contract
   , "OneShotMinting" /\ OneShotMinting.contract

--- a/examples/SignData.purs
+++ b/examples/SignData.purs
@@ -1,0 +1,45 @@
+module Ctl.Examples.SignData (main, example, contract) where
+
+import Contract.Prelude
+
+import Contract.Config (ConfigParams, testnetNamiConfig)
+import Contract.Log (logInfo')
+import Contract.Monad (Contract, launchAff_, liftedM, runContract)
+import Contract.Prim.ByteArray (RawBytes, rawBytesFromAscii)
+import Contract.Wallet (getChangeAddress, getRewardAddresses, signData)
+import Ctl.Internal.Serialization.Address (Address)
+import Data.Array (head) as Array
+import Data.Maybe (fromJust)
+import Partial.Unsafe (unsafePartial)
+import Test.Ctl.Wallet.Cip30.SignData (checkCip30SignDataResponse)
+
+main :: Effect Unit
+main = example testnetNamiConfig
+
+example :: ConfigParams () -> Effect Unit
+example = launchAff_ <<< flip runContract contract
+
+contract :: Contract () Unit
+contract = do
+  logInfo' "Running Examples.SignData"
+
+  changeAddress <- liftedM "Could not get change address" getChangeAddress
+  logInfo' $ "change address: " <> show changeAddress
+  testSignDataWithAddress "changeAddress" changeAddress
+
+  rewardAddress <-
+    liftedM "Could not get reward address" $ Array.head <$> getRewardAddresses
+  logInfo' $ "reward address: " <> show rewardAddress
+  testSignDataWithAddress "rewardAddress" rewardAddress
+  where
+  payload :: RawBytes
+  payload = unsafePartial fromJust $ rawBytesFromAscii "Hello world!"
+
+  testSignDataWithAddress :: String -> Address -> Contract () Unit
+  testSignDataWithAddress addressLabel address = do
+    dataSignature <-
+      signData address payload
+        # liftedM "Could not get data signature"
+    logInfo' $ "signData " <> addressLabel <> ": " <> show dataSignature
+    void $ liftAff $ checkCip30SignDataResponse address dataSignature
+

--- a/scripts/examples-imports-check.sh
+++ b/scripts/examples-imports-check.sh
@@ -6,7 +6,7 @@ examples_imports_check() {
   local ix=1;
 
   set -o noglob
-  local excluded_paths=("KeyWallet/Internal/*" "ByUrl.purs")
+  local excluded_paths=("KeyWallet/Internal/*" "ByUrl.purs" "SignData.purs")
   local excluded_paths_=${excluded_paths[@]/#/! -path $examples_path/}
 
   for example_purs in $(find $examples_path -type f -name *.purs ${excluded_paths_[@]}); do

--- a/src/Contract/Config.purs
+++ b/src/Contract/Config.purs
@@ -6,12 +6,14 @@ module Contract.Config
   , testnetFlintConfig
   , testnetEternlConfig
   , testnetLodeConfig
+  , testnetNufiConfig
   , mainnetConfig
   , mainnetNamiConfig
   , mainnetGeroConfig
   , mainnetFlintConfig
   , mainnetEternlConfig
   , mainnetLodeConfig
+  , mainnetNufiConfig
   , module Contract.Address
   , module Contract.Monad
   , module Data.Log.Level
@@ -50,6 +52,7 @@ import Ctl.Internal.Wallet.Spec
       , ConnectToFlint
       , ConnectToEternl
       , ConnectToLode
+      , ConnectToNufi
       )
   )
 import Data.Log.Level (LogLevel(Trace, Debug, Info, Warn, Error))
@@ -86,6 +89,9 @@ testnetEternlConfig = testnetConfig { walletSpec = Just ConnectToEternl }
 testnetLodeConfig :: ConfigParams ()
 testnetLodeConfig = testnetConfig { walletSpec = Just ConnectToLode }
 
+testnetNufiConfig :: ConfigParams ()
+testnetNufiConfig = testnetConfig { walletSpec = Just ConnectToNufi }
+
 mainnetConfig :: ConfigParams ()
 mainnetConfig = testnetConfig { networkId = MainnetId }
 
@@ -103,3 +109,6 @@ mainnetEternlConfig = mainnetConfig { walletSpec = Just ConnectToEternl }
 
 mainnetLodeConfig :: ConfigParams ()
 mainnetLodeConfig = mainnetConfig { walletSpec = Just ConnectToLode }
+
+mainnetNufiConfig :: ConfigParams ()
+mainnetNufiConfig = mainnetConfig { walletSpec = Just ConnectToNufi }

--- a/src/Internal/QueryM.purs
+++ b/src/Internal/QueryM.purs
@@ -213,13 +213,14 @@ import Ctl.Internal.Wallet
   ( Cip30Connection
   , Cip30Wallet
   , KeyWallet
-  , Wallet(KeyWallet, Lode, Flint, Gero, Nami, Eternl)
+  , Wallet(KeyWallet, Lode, Flint, Gero, Nami, Eternl, Nufi)
   , WalletExtension
       ( LodeWallet
       , EternlWallet
       , FlintWallet
       , GeroWallet
       , NamiWallet
+      , NufiWallet
       )
   , mkKeyWallet
   , mkWalletAff
@@ -240,6 +241,7 @@ import Ctl.Internal.Wallet.Spec
       , ConnectToFlint
       , ConnectToEternl
       , ConnectToLode
+      , ConnectToNufi
       )
   )
 import Data.Array (catMaybes)
@@ -536,6 +538,7 @@ mkWalletBySpec = case _ of
   ConnectToFlint -> mkWalletAff FlintWallet
   ConnectToEternl -> mkWalletAff EternlWallet
   ConnectToLode -> mkWalletAff LodeWallet
+  ConnectToNufi -> mkWalletAff NufiWallet
 
 runQueryM :: forall (a :: Type). QueryConfig -> QueryM a -> Aff a
 runQueryM config action = do
@@ -713,6 +716,7 @@ actionBasedOnWallet walletAction keyWalletAction =
     Gero wallet -> callCip30Wallet wallet walletAction
     Flint wallet -> callCip30Wallet wallet walletAction
     Lode wallet -> callCip30Wallet wallet walletAction
+    Nufi wallet -> callCip30Wallet wallet walletAction
     KeyWallet kw -> pure <$> keyWalletAction kw
 
 signData :: Address -> RawBytes -> QueryM (Maybe DataSignature)

--- a/src/Internal/QueryM/Sign.purs
+++ b/src/Internal/QueryM/Sign.purs
@@ -16,7 +16,9 @@ import Ctl.Internal.QueryM
   )
 import Ctl.Internal.QueryM.Utxos (getUtxo, getWalletUtxos)
 import Ctl.Internal.Types.Transaction (TransactionInput)
-import Ctl.Internal.Wallet (Wallet(KeyWallet, Lode, Eternl, Flint, Gero, Nami))
+import Ctl.Internal.Wallet
+  ( Wallet(KeyWallet, Lode, Eternl, Flint, Gero, Nami, Nufi)
+  )
 import Data.Array (elem, fromFoldable)
 import Data.Lens ((<>~))
 import Data.Lens.Getter ((^.))
@@ -49,6 +51,7 @@ signTransaction tx = do
       walletWaitForInputs txInputs
       liftAff $ callCip30Wallet eternl \nw -> flip nw.signTx tx
     Lode lode -> liftAff $ callCip30Wallet lode \nw -> flip nw.signTx tx
+    Nufi nufi -> liftAff $ callCip30Wallet nufi \w -> flip w.signTx tx
     KeyWallet kw -> liftAff do
       witnessSet <- (unwrap kw).signTx tx
       pure $ Just (tx # _witnessSet <>~ witnessSet)

--- a/src/Internal/QueryM/Utxos.purs
+++ b/src/Internal/QueryM/Utxos.purs
@@ -28,7 +28,9 @@ import Ctl.Internal.QueryM.Kupo (getUtxoByOref, utxosAt) as Kupo
 import Ctl.Internal.Serialization.Address (Address)
 import Ctl.Internal.Types.Transaction (TransactionInput)
 import Ctl.Internal.Types.UsedTxOuts (UsedTxOuts, isTxOutRefUsed)
-import Ctl.Internal.Wallet (Wallet(Gero, Nami, Flint, Lode, Eternl, KeyWallet))
+import Ctl.Internal.Wallet
+  ( Wallet(Gero, Nami, Flint, Lode, Eternl, Nufi, KeyWallet)
+  )
 import Data.Array (head)
 import Data.Array as Array
 import Data.Either (hush)
@@ -70,6 +72,7 @@ mkUtxoQuery allUtxosAt =
     Flint _ -> cip30UtxosAt
     Eternl _ -> cip30UtxosAt
     Lode _ -> cip30UtxosAt
+    Nufi _ -> cip30UtxosAt
     KeyWallet _ -> allUtxosAt
 
   cip30UtxosAt :: QueryM (Maybe UtxoMap)
@@ -109,6 +112,7 @@ getWalletBalance = do
     Eternl wallet -> liftAff $ wallet.getBalance wallet.connection
     Flint wallet -> liftAff $ wallet.getBalance wallet.connection
     Lode wallet -> liftAff $ wallet.getBalance wallet.connection
+    Nufi wallet -> liftAff $ wallet.getBalance wallet.connection
     KeyWallet _ -> do
       -- Implement via `utxosAt`
       addresses <- getWalletAddresses
@@ -127,6 +131,7 @@ getWalletUtxos = do
     Eternl wallet -> liftAff $ wallet.getUtxos wallet.connection <#> map
       toUtxoMap
     Lode wallet -> liftAff $ wallet.getUtxos wallet.connection <#> map toUtxoMap
+    Nufi wallet -> liftAff $ wallet.getUtxos wallet.connection <#> map toUtxoMap
     KeyWallet _ -> do
       mbAddress <- getWalletAddresses <#> head
       map join $ for mbAddress utxosAt
@@ -144,6 +149,7 @@ getWalletCollateral = do
       Flint wallet -> liftAff $ callCip30Wallet wallet _.getCollateral
       Lode wallet -> liftAff $ callCip30Wallet wallet _.getCollateral
       Eternl wallet -> liftAff $ callCip30Wallet wallet _.getCollateral
+      Nufi wallet -> liftAff $ callCip30Wallet wallet _.getCollateral
       KeyWallet kw -> do
         networkId <- getNetworkId
         addr <- liftAff $ (unwrap kw).address networkId

--- a/src/Internal/Wallet.purs
+++ b/src/Internal/Wallet.purs
@@ -1,13 +1,14 @@
 module Ctl.Internal.Wallet
   ( module KeyWallet
   , module Cip30Wallet
-  , Wallet(Gero, Nami, Flint, Lode, Eternl, KeyWallet)
+  , Wallet(Gero, Nami, Flint, Lode, Eternl, Nufi, KeyWallet)
   , WalletExtension
       ( NamiWallet
       , LodeWallet
       , GeroWallet
       , FlintWallet
       , EternlWallet
+      , NufiWallet
       )
   , isEternlAvailable
   , isGeroAvailable
@@ -74,6 +75,7 @@ data Wallet
   | Flint Cip30Wallet
   | Eternl Cip30Wallet
   | Lode Cip30Wallet
+  | Nufi Cip30Wallet
   | KeyWallet KeyWallet
 
 data WalletExtension
@@ -82,6 +84,7 @@ data WalletExtension
   | FlintWallet
   | EternlWallet
   | LodeWallet
+  | NufiWallet
 
 mkKeyWallet :: PrivatePaymentKey -> Maybe PrivateStakeKey -> Wallet
 mkKeyWallet payKey mbStakeKey = KeyWallet $ privateKeysToKeyWallet payKey
@@ -104,6 +107,7 @@ mkWalletAff walletExtension =
     FlintWallet -> Flint <$> mkCip30WalletAff "Flint"
       (_enableWallet walletName)
     LodeWallet -> _mkLodeWalletAff
+    NufiWallet -> Nufi <$> mkCip30WalletAff "NuFi" (_enableWallet walletName)
   where
   walletName = walletExtensionToName walletExtension
 
@@ -215,6 +219,7 @@ cip30Wallet = case _ of
   Flint c30 -> Just c30
   Eternl c30 -> Just c30
   Lode c30 -> Just c30
+  Nufi c30 -> Just c30
   KeyWallet _ -> Nothing
 
 walletExtensionToName :: WalletExtension -> String
@@ -224,6 +229,7 @@ walletExtensionToName = case _ of
   FlintWallet -> "flint"
   EternlWallet -> "eternl"
   LodeWallet -> "LodeWallet"
+  NufiWallet -> "nufi"
 
 walletToWalletExtension :: Wallet -> Maybe WalletExtension
 walletToWalletExtension = case _ of
@@ -232,6 +238,7 @@ walletToWalletExtension = case _ of
   Flint _ -> Just FlintWallet
   Eternl _ -> Just EternlWallet
   Lode _ -> Just LodeWallet
+  Nufi _ -> Just NufiWallet
   KeyWallet _ -> Nothing
 
 isEnabled :: WalletExtension -> Aff Boolean

--- a/src/Internal/Wallet/Cip30.purs
+++ b/src/Internal/Wallet/Cip30.purs
@@ -41,13 +41,10 @@ import Ctl.Internal.Types.ByteArray (byteArrayToHex)
 import Ctl.Internal.Types.CborBytes
   ( CborBytes
   , cborBytesToHex
+  , hexToCborBytes
   , rawBytesAsCborBytes
   )
-import Ctl.Internal.Types.RawBytes
-  ( RawBytes
-  , hexToRawBytes
-  , rawBytesToHex
-  )
+import Ctl.Internal.Types.RawBytes (RawBytes, hexToRawBytes, rawBytesToHex)
 import Data.Maybe (Maybe(Just, Nothing), isNothing, maybe)
 import Data.Newtype (unwrap)
 import Data.Traversable (for, traverse)
@@ -203,8 +200,8 @@ signData conn address dat = do
     (rawBytesToHex dat)
     conn
   pure $ do
-    let key = signedData.key
-    let signature = rawBytesAsCborBytes signedData.signature
+    key <- hexToCborBytes signedData.key
+    signature <- hexToCborBytes signedData.signature
     pure { key: key, signature: signature }
   where
   fromBase :: Maybe CborBytes
@@ -288,4 +285,4 @@ foreign import _signData
   :: String -- Address
   -> String -- Hex-encoded data
   -> Cip30Connection
-  -> Effect (Promise { key :: CborBytes, signature :: RawBytes })
+  -> Effect (Promise { key :: String, signature :: String })

--- a/src/Internal/Wallet/Cip30Mock.purs
+++ b/src/Internal/Wallet/Cip30Mock.purs
@@ -25,7 +25,7 @@ import Ctl.Internal.Types.ByteArray (byteArrayToHex, hexToByteArray)
 import Ctl.Internal.Types.CborBytes (cborBytesFromByteArray)
 import Ctl.Internal.Wallet
   ( Wallet
-  , WalletExtension(LodeWallet, NamiWallet, GeroWallet, FlintWallet)
+  , WalletExtension(LodeWallet, NamiWallet, GeroWallet, FlintWallet, NufiWallet)
   , mkWalletAff
   )
 import Ctl.Internal.Wallet.Cip30 (DataSignature)
@@ -58,7 +58,7 @@ import Effect.Unsafe (unsafePerformEffect)
 import Type.Proxy (Proxy(Proxy))
 import Untagged.Union (asOneOf)
 
-data WalletMock = MockFlint | MockGero | MockNami | MockLode
+data WalletMock = MockFlint | MockGero | MockNami | MockLode | MockNufi
 
 -- | Construct a CIP-30 wallet mock that exposes `KeyWallet` functionality
 -- | behind a CIP-30 interface and uses Ogmios to submit Txs.
@@ -100,6 +100,7 @@ withCip30Mock (KeyWallet keyWallet) mock contract = do
     MockGero -> mkWalletAff GeroWallet
     MockNami -> mkWalletAff NamiWallet
     MockLode -> mkWalletAff LodeWallet
+    MockNufi -> mkWalletAff NufiWallet
 
   mockString :: String
   mockString = case mock of
@@ -107,6 +108,7 @@ withCip30Mock (KeyWallet keyWallet) mock contract = do
     MockGero -> "gerowallet"
     MockNami -> "nami"
     MockLode -> "LodeWallet"
+    MockNufi -> "nufi"
 
 type Cip30Mock =
   { getNetworkId :: Effect (Promise Int)

--- a/src/Internal/Wallet/Spec.purs
+++ b/src/Internal/Wallet/Spec.purs
@@ -6,6 +6,7 @@ module Ctl.Internal.Wallet.Spec
       , ConnectToFlint
       , ConnectToEternl
       , ConnectToLode
+      , ConnectToNufi
       )
   , PrivateStakeKeySource(PrivateStakeKeyFile, PrivateStakeKeyValue)
   , PrivatePaymentKeySource(PrivatePaymentKeyFile, PrivatePaymentKeyValue)
@@ -31,3 +32,4 @@ data WalletSpec
   | ConnectToFlint
   | ConnectToEternl
   | ConnectToLode
+  | ConnectToNufi

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -116,10 +116,10 @@ import Ctl.Internal.Scripts (nativeScriptHashEnterpriseAddress)
 import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.Interval (getSlotLength)
 import Ctl.Internal.Wallet
-  ( WalletExtension(NamiWallet, GeroWallet, FlintWallet)
+  ( WalletExtension(NamiWallet, GeroWallet, FlintWallet, NufiWallet)
   )
 import Ctl.Internal.Wallet.Cip30Mock
-  ( WalletMock(MockNami, MockGero, MockFlint)
+  ( WalletMock(MockNami, MockGero, MockFlint, MockNufi)
   , withCip30Mock
   )
 import Data.Array (head, (!!))
@@ -1463,6 +1463,8 @@ suite = do
           try (liftEffect $ isWalletAvailable FlintWallet) >>= flip
             shouldSatisfy
             isLeft
+          try (liftEffect $ isWalletAvailable NufiWallet) >>= flip shouldSatisfy
+            isLeft
 
           withCip30Mock alice MockNami do
             (liftEffect $ isWalletAvailable NamiWallet) >>= shouldEqual true
@@ -1473,10 +1475,16 @@ suite = do
             (liftEffect $ isWalletAvailable GeroWallet) >>= shouldEqual true
           try (liftEffect $ isWalletAvailable GeroWallet) >>= flip shouldSatisfy
             isLeft
+
           withCip30Mock alice MockFlint do
             (liftEffect $ isWalletAvailable FlintWallet) >>= shouldEqual true
           try (liftEffect $ isWalletAvailable FlintWallet) >>= flip
             shouldSatisfy
+            isLeft
+
+          withCip30Mock alice MockNufi do
+            (liftEffect $ isWalletAvailable NufiWallet) >>= shouldEqual true
+          try (liftEffect $ isWalletAvailable NufiWallet) >>= flip shouldSatisfy
             isLeft
 
       test "Collateral selection" do

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -73,7 +73,7 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
       (unwrap networkId)
 
   dataSignature <- liftEffect $ signData privatePaymentKey address payload
-  { coseKey, coseSign1 } <- checkCip30SignDataResponse address dataSignature
+  { coseKey } <- checkCip30SignDataResponse address dataSignature
 
   assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
     (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -1,7 +1,13 @@
-module Test.Ctl.Wallet.Cip30.SignData (suite) where
+module Test.Ctl.Wallet.Cip30.SignData
+  ( suite
+  , COSEKey
+  , COSESign1
+  , checkCip30SignDataResponse
+  ) where
 
 import Prelude
 
+import Ctl.Internal.Deserialization.FromBytes (fromBytes)
 import Ctl.Internal.Deserialization.Keys (privateKeyFromBytes)
 import Ctl.Internal.FfiHelpers (MaybeFfiHelper, maybeFfiHelper)
 import Ctl.Internal.Serialization.Address
@@ -19,6 +25,7 @@ import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.ByteArray (byteArrayFromIntArrayUnsafe)
 import Ctl.Internal.Types.CborBytes (CborBytes)
 import Ctl.Internal.Types.RawBytes (RawBytes)
+import Ctl.Internal.Wallet.Cip30 (DataSignature)
 import Ctl.Internal.Wallet.Cip30.SignData (signData)
 import Ctl.Internal.Wallet.Key
   ( PrivatePaymentKey
@@ -33,7 +40,7 @@ import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Mote (group, test)
 import Partial.Unsafe (unsafePartial)
-import Test.Ctl.Utils (assertTrue)
+import Test.Ctl.Utils (assertTrue, errMaybe)
 import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Gen, chooseInt, randomSample, vectorOf)
 
@@ -54,21 +61,22 @@ type TestInput =
   , networkId :: ArbitraryNetworkId
   }
 
+type DeserializedDataSignature =
+  { coseKey :: COSEKey
+  , coseSign1 :: COSESign1
+  }
+
 testCip30SignData :: TestInput -> Aff Unit
 testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
   address <-
     privateKeysToAddress (unwrap privateKey) (unwrap <$> privateStakeKey)
       (unwrap networkId)
 
-  { key, signature } <- liftEffect $ signData privatePaymentKey address payload
+  dataSignature <- liftEffect $ signData privatePaymentKey address payload
+  { coseKey, coseSign1 } <- checkCip30SignDataResponse address dataSignature
 
-  coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
-  coseKey <- liftEffect $ fromBytesCoseKey key
-
-  checkCoseSign1ProtectedHeaders coseSign1 address
-  checkCoseKeyHeaders coseKey
-  checkKidHeaders coseSign1 coseKey
-  liftEffect $ checkVerification coseSign1
+  assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
+    (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))
   where
   privatePaymentKey :: PrivateKey
   privatePaymentKey = unwrap $ unwrap $ privateKey
@@ -76,6 +84,18 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
   publicPaymentKey :: PublicKey
   publicPaymentKey = publicKeyFromPrivateKey privatePaymentKey
 
+checkCip30SignDataResponse
+  :: Address -> DataSignature -> Aff DeserializedDataSignature
+checkCip30SignDataResponse address { key, signature } = do
+  coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
+  coseKey <- liftEffect $ fromBytesCoseKey key
+
+  checkCoseSign1ProtectedHeaders coseSign1 address
+  checkCoseKeyHeaders coseKey
+  checkKidHeaders coseSign1 coseKey
+  liftEffect $ checkVerification coseSign1 coseKey
+  pure { coseKey, coseSign1 }
+  where
   checkCoseSign1ProtectedHeaders :: COSESign1 -> Address -> Aff Unit
   checkCoseSign1ProtectedHeaders coseSign1 address = do
     assertTrue "COSE_Sign1's alg (1) header must be set to EdDSA (-8)"
@@ -97,9 +117,6 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
     assertTrue "COSE_Key's crv (-1) header must be set to Ed25519 (6)"
       (getCoseKeyHeaderCrv coseKey == Just (6))
 
-    assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
-      (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))
-
   checkKidHeaders :: COSESign1 -> COSEKey -> Aff Unit
   checkKidHeaders coseSign1 coseKey =
     assertTrue
@@ -107,11 +124,14 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
       \be set to the same value"
       (getCoseSign1ProtectedHeaderKid coseSign1 == getCoseKeyHeaderKid coseKey)
 
-  checkVerification :: COSESign1 -> Effect Unit
-  checkVerification coseSign1 = do
+  checkVerification :: COSESign1 -> COSEKey -> Effect Unit
+  checkVerification coseSign1 coseKey = do
+    publicKey <-
+      errMaybe "COSE_Key's x (-2) header must be set to public key bytes"
+        (getCoseKeyHeaderX coseKey >>= (fromBytes <<< unwrap))
     sigStructBytes <- getSignedData coseSign1
     assertTrue "Signature verification failed"
-      =<< verifySignature coseSign1 publicPaymentKey sigStructBytes
+      =<< verifySignature coseSign1 publicKey sigStructBytes
 
 --------------------------------------------------------------------------------
 -- Arbitrary

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -90,14 +90,14 @@ checkCip30SignDataResponse address { key, signature } = do
   coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
   coseKey <- liftEffect $ fromBytesCoseKey key
 
-  checkCoseSign1ProtectedHeaders coseSign1 address
+  checkCoseSign1ProtectedHeaders coseSign1
   checkCoseKeyHeaders coseKey
   checkKidHeaders coseSign1 coseKey
   liftEffect $ checkVerification coseSign1 coseKey
   pure { coseKey, coseSign1 }
   where
-  checkCoseSign1ProtectedHeaders :: COSESign1 -> Address -> Aff Unit
-  checkCoseSign1ProtectedHeaders coseSign1 address = do
+  checkCoseSign1ProtectedHeaders :: COSESign1 -> Aff Unit
+  checkCoseSign1ProtectedHeaders coseSign1 = do
     assertTrue "COSE_Sign1's alg (1) header must be set to EdDSA (-8)"
       (getCoseSign1ProtectedHeaderAlg coseSign1 == Just (-8))
 


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/1286

### This PR:
1. provides `SignData` example, which enables testing of `signData` with browser wallets, using checks developed for our  `KeyWallet` implementation
2. fixes response handling of `signData` response [critical bug fix]

### Testing progress 
(List of browser wallets generating valid data signatures according to [CIP-30](https://cips.cardano.org/cips/cip30/#apisigndataaddraddresspayloadbytespromisedatasignature)):
- [x] NuFi
- [ ] Nami
- [ ] Gero
- [ ] Flint
- [ ] Lode
- [ ] Eternl

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
