### PR TITLE
Fix `signData` resp handling & Add `SignData` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Added missing `stakePoolTargetNum` ("`nOpt`") protocol parameter (see [CIP-9](https://cips.cardano.org/cips/cip9/)) ([#571](https://github.com/Plutonomicon/cardano-transaction-lib/issues/571))
+- CIP-30 `signData` response handling ([#1289](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1289))
 
 ## [3.0.0] - 2022-11-21
 

--- a/examples/ByUrl.purs
+++ b/examples/ByUrl.purs
@@ -29,6 +29,7 @@ import Ctl.Examples.PlutusV2.OneShotMinting as OneShotMintingV2
 import Ctl.Examples.PlutusV2.ReferenceInputs as ReferenceInputsV2
 import Ctl.Examples.PlutusV2.ReferenceInputsAndScripts as ReferenceInputsAndScriptsV2
 import Ctl.Examples.SendsToken as SendsToken
+import Ctl.Examples.SignData as SignData
 import Ctl.Examples.SignMultiple as SignMultiple
 import Ctl.Examples.TxChaining as TxChaining
 import Ctl.Examples.Utxos as Utxos
@@ -76,6 +77,7 @@ examples = Map.fromFoldable
   , "Pkh2Pkh" /\ Pkh2Pkh.contract
   , "TxChaining" /\ TxChaining.contract
   , "SendsToken" /\ SendsToken.contract
+  , "SignData" /\ SignData.contract
   , "SignMultiple" /\ SignMultiple.contract
   , "MintsMultipleTokens" /\ MintsMultipleTokens.contract
   , "OneShotMinting" /\ OneShotMinting.contract

--- a/examples/SignData.purs
+++ b/examples/SignData.purs
@@ -1,0 +1,45 @@
+module Ctl.Examples.SignData (main, example, contract) where
+
+import Contract.Prelude
+
+import Contract.Config (ConfigParams, testnetNamiConfig)
+import Contract.Log (logInfo')
+import Contract.Monad (Contract, launchAff_, liftedM, runContract)
+import Contract.Prim.ByteArray (RawBytes, rawBytesFromAscii)
+import Contract.Wallet (getChangeAddress, getRewardAddresses, signData)
+import Ctl.Internal.Serialization.Address (Address)
+import Data.Array (head) as Array
+import Data.Maybe (fromJust)
+import Partial.Unsafe (unsafePartial)
+import Test.Ctl.Wallet.Cip30.SignData (checkCip30SignDataResponse)
+
+main :: Effect Unit
+main = example testnetNamiConfig
+
+example :: ConfigParams () -> Effect Unit
+example = launchAff_ <<< flip runContract contract
+
+contract :: Contract () Unit
+contract = do
+  logInfo' "Running Examples.SignData"
+
+  changeAddress <- liftedM "Could not get change address" getChangeAddress
+  logInfo' $ "change address: " <> show changeAddress
+  testSignDataWithAddress "changeAddress" changeAddress
+
+  rewardAddress <-
+    liftedM "Could not get reward address" $ Array.head <$> getRewardAddresses
+  logInfo' $ "reward address: " <> show rewardAddress
+  testSignDataWithAddress "rewardAddress" rewardAddress
+  where
+  payload :: RawBytes
+  payload = unsafePartial fromJust $ rawBytesFromAscii "Hello world!"
+
+  testSignDataWithAddress :: String -> Address -> Contract () Unit
+  testSignDataWithAddress addressLabel address = do
+    dataSignature <-
+      signData address payload
+        # liftedM "Could not get data signature"
+    logInfo' $ "signData " <> addressLabel <> ": " <> show dataSignature
+    void $ liftAff $ checkCip30SignDataResponse address dataSignature
+

--- a/scripts/examples-imports-check.sh
+++ b/scripts/examples-imports-check.sh
@@ -6,7 +6,7 @@ examples_imports_check() {
   local ix=1;
 
   set -o noglob
-  local excluded_paths=("KeyWallet/Internal/*" "ByUrl.purs")
+  local excluded_paths=("KeyWallet/Internal/*" "ByUrl.purs" "SignData.purs")
   local excluded_paths_=${excluded_paths[@]/#/! -path $examples_path/}
 
   for example_purs in $(find $examples_path -type f -name *.purs ${excluded_paths_[@]}); do

--- a/src/Internal/Wallet/Cip30.purs
+++ b/src/Internal/Wallet/Cip30.purs
@@ -41,13 +41,10 @@ import Ctl.Internal.Types.ByteArray (byteArrayToHex)
 import Ctl.Internal.Types.CborBytes
   ( CborBytes
   , cborBytesToHex
+  , hexToCborBytes
   , rawBytesAsCborBytes
   )
-import Ctl.Internal.Types.RawBytes
-  ( RawBytes
-  , hexToRawBytes
-  , rawBytesToHex
-  )
+import Ctl.Internal.Types.RawBytes (RawBytes, hexToRawBytes, rawBytesToHex)
 import Data.Maybe (Maybe(Just, Nothing), isNothing, maybe)
 import Data.Newtype (unwrap)
 import Data.Traversable (for, traverse)
@@ -203,8 +200,8 @@ signData conn address dat = do
     (rawBytesToHex dat)
     conn
   pure $ do
-    let key = signedData.key
-    let signature = rawBytesAsCborBytes signedData.signature
+    key <- hexToCborBytes signedData.key
+    signature <- hexToCborBytes signedData.signature
     pure { key: key, signature: signature }
   where
   fromBase :: Maybe CborBytes
@@ -288,4 +285,4 @@ foreign import _signData
   :: String -- Address
   -> String -- Hex-encoded data
   -> Cip30Connection
-  -> Effect (Promise { key :: CborBytes, signature :: RawBytes })
+  -> Effect (Promise { key :: String, signature :: String })

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -73,7 +73,7 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
       (unwrap networkId)
 
   dataSignature <- liftEffect $ signData privatePaymentKey address payload
-  { coseKey, coseSign1 } <- checkCip30SignDataResponse address dataSignature
+  { coseKey } <- checkCip30SignDataResponse address dataSignature
 
   assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
     (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -1,7 +1,13 @@
-module Test.Ctl.Wallet.Cip30.SignData (suite) where
+module Test.Ctl.Wallet.Cip30.SignData
+  ( suite
+  , COSEKey
+  , COSESign1
+  , checkCip30SignDataResponse
+  ) where
 
 import Prelude
 
+import Ctl.Internal.Deserialization.FromBytes (fromBytes)
 import Ctl.Internal.Deserialization.Keys (privateKeyFromBytes)
 import Ctl.Internal.FfiHelpers (MaybeFfiHelper, maybeFfiHelper)
 import Ctl.Internal.Serialization.Address
@@ -19,6 +25,7 @@ import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.ByteArray (byteArrayFromIntArrayUnsafe)
 import Ctl.Internal.Types.CborBytes (CborBytes)
 import Ctl.Internal.Types.RawBytes (RawBytes)
+import Ctl.Internal.Wallet.Cip30 (DataSignature)
 import Ctl.Internal.Wallet.Cip30.SignData (signData)
 import Ctl.Internal.Wallet.Key
   ( PrivatePaymentKey
@@ -33,7 +40,7 @@ import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Mote (group, test)
 import Partial.Unsafe (unsafePartial)
-import Test.Ctl.Utils (assertTrue)
+import Test.Ctl.Utils (assertTrue, errMaybe)
 import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Gen, chooseInt, randomSample, vectorOf)
 
@@ -54,21 +61,22 @@ type TestInput =
   , networkId :: ArbitraryNetworkId
   }
 
+type DeserializedDataSignature =
+  { coseKey :: COSEKey
+  , coseSign1 :: COSESign1
+  }
+
 testCip30SignData :: TestInput -> Aff Unit
 testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
   address <-
     privateKeysToAddress (unwrap privateKey) (unwrap <$> privateStakeKey)
       (unwrap networkId)
 
-  { key, signature } <- liftEffect $ signData privatePaymentKey address payload
+  dataSignature <- liftEffect $ signData privatePaymentKey address payload
+  { coseKey, coseSign1 } <- checkCip30SignDataResponse address dataSignature
 
-  coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
-  coseKey <- liftEffect $ fromBytesCoseKey key
-
-  checkCoseSign1ProtectedHeaders coseSign1 address
-  checkCoseKeyHeaders coseKey
-  checkKidHeaders coseSign1 coseKey
-  liftEffect $ checkVerification coseSign1
+  assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
+    (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))
   where
   privatePaymentKey :: PrivateKey
   privatePaymentKey = unwrap $ unwrap $ privateKey
@@ -76,6 +84,18 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
   publicPaymentKey :: PublicKey
   publicPaymentKey = publicKeyFromPrivateKey privatePaymentKey
 
+checkCip30SignDataResponse
+  :: Address -> DataSignature -> Aff DeserializedDataSignature
+checkCip30SignDataResponse address { key, signature } = do
+  coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
+  coseKey <- liftEffect $ fromBytesCoseKey key
+
+  checkCoseSign1ProtectedHeaders coseSign1 address
+  checkCoseKeyHeaders coseKey
+  checkKidHeaders coseSign1 coseKey
+  liftEffect $ checkVerification coseSign1 coseKey
+  pure { coseKey, coseSign1 }
+  where
   checkCoseSign1ProtectedHeaders :: COSESign1 -> Address -> Aff Unit
   checkCoseSign1ProtectedHeaders coseSign1 address = do
     assertTrue "COSE_Sign1's alg (1) header must be set to EdDSA (-8)"
@@ -97,9 +117,6 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
     assertTrue "COSE_Key's crv (-1) header must be set to Ed25519 (6)"
       (getCoseKeyHeaderCrv coseKey == Just (6))
 
-    assertTrue "COSE_Key's x (-2) header must be set to public key bytes"
-      (getCoseKeyHeaderX coseKey == Just (bytesFromPublicKey publicPaymentKey))
-
   checkKidHeaders :: COSESign1 -> COSEKey -> Aff Unit
   checkKidHeaders coseSign1 coseKey =
     assertTrue
@@ -107,11 +124,14 @@ testCip30SignData { privateKey, privateStakeKey, payload, networkId } = do
       \be set to the same value"
       (getCoseSign1ProtectedHeaderKid coseSign1 == getCoseKeyHeaderKid coseKey)
 
-  checkVerification :: COSESign1 -> Effect Unit
-  checkVerification coseSign1 = do
+  checkVerification :: COSESign1 -> COSEKey -> Effect Unit
+  checkVerification coseSign1 coseKey = do
+    publicKey <-
+      errMaybe "COSE_Key's x (-2) header must be set to public key bytes"
+        (getCoseKeyHeaderX coseKey >>= (fromBytes <<< unwrap))
     sigStructBytes <- getSignedData coseSign1
     assertTrue "Signature verification failed"
-      =<< verifySignature coseSign1 publicPaymentKey sigStructBytes
+      =<< verifySignature coseSign1 publicKey sigStructBytes
 
 --------------------------------------------------------------------------------
 -- Arbitrary

--- a/test/Wallet/Cip30/SignData.purs
+++ b/test/Wallet/Cip30/SignData.purs
@@ -90,14 +90,14 @@ checkCip30SignDataResponse address { key, signature } = do
   coseSign1 <- liftEffect $ fromBytesCoseSign1 signature
   coseKey <- liftEffect $ fromBytesCoseKey key
 
-  checkCoseSign1ProtectedHeaders coseSign1 address
+  checkCoseSign1ProtectedHeaders coseSign1
   checkCoseKeyHeaders coseKey
   checkKidHeaders coseSign1 coseKey
   liftEffect $ checkVerification coseSign1 coseKey
   pure { coseKey, coseSign1 }
   where
-  checkCoseSign1ProtectedHeaders :: COSESign1 -> Address -> Aff Unit
-  checkCoseSign1ProtectedHeaders coseSign1 address = do
+  checkCoseSign1ProtectedHeaders :: COSESign1 -> Aff Unit
+  checkCoseSign1ProtectedHeaders coseSign1 = do
     assertTrue "COSE_Sign1's alg (1) header must be set to EdDSA (-8)"
       (getCoseSign1ProtectedHeaderAlg coseSign1 == Just (-8))
 


### PR DESCRIPTION
Re-play of https://github.com/Plutonomicon/cardano-transaction-lib/pull/1287 without NuFi-related changes
Closes https://github.com/Plutonomicon/cardano-transaction-lib/issues/1286

### This PR:
1. provides `SignData` example, which enables testing of `signData` with browser wallets, using checks developed for our  `KeyWallet` implementation
2. fixes handling of `signData` response **[critical bug fix]**

### Testing progress 
(List of browser wallets generating valid data signatures according to [CIP-30](https://cips.cardano.org/cips/cip30/#apisigndataaddraddresspayloadbytespromisedatasignature)):
- [x] NuFi
- [x] Nami
- [x] Gero 
1 test failed (not critical, can be skipped): 
`COSE_Sign1` and `COSE_Key` `kid` headers, if present, must be set to the same value.
- [x] Flint
- [x] Lode
- [x] Eternl

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included