### PR TITLE
fix: defaultKupoServerConfig not compatible with runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+- Fix default config to use Kupo server parameters from nix runtime.
 - Added missing `stakePoolTargetNum` ("`nOpt`") protocol parameter (see [CIP-9](https://cips.cardano.org/cips/cip9/)) ([#571](https://github.com/Plutonomicon/cardano-transaction-lib/issues/571))
 - CIP-30 `signData` response handling ([#1289](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1289))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-- Fix default config to use Kupo server parameters from nix runtime.
+- Fix default config to use Kupo server parameters from nix runtime. ([#1294](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1294))
 - Added missing `stakePoolTargetNum` ("`nOpt`") protocol parameter (see [CIP-9](https://cips.cardano.org/cips/cip9/)) ([#571](https://github.com/Plutonomicon/cardano-transaction-lib/issues/571))
 - CIP-30 `signData` response handling ([#1289](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1289))
 

--- a/src/Internal/QueryM/ServerConfig.purs
+++ b/src/Internal/QueryM/ServerConfig.purs
@@ -54,10 +54,10 @@ defaultDatumCacheWsConfig =
 
 defaultKupoServerConfig :: ServerConfig
 defaultKupoServerConfig =
-  { port: UInt.fromInt 4008
+  { port: UInt.fromInt 1442
   , host: "localhost"
   , secure: false
-  , path: Just "kupo"
+  , path: Nothing
   }
 
 mkHttpUrl :: ServerConfig -> Url


### PR DESCRIPTION
Closes # .

Using `testnetConfig` did not work as expected due to wrong config on either purs or nix runtime, changed it in purs.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
