### PR TITLE
with extraBrowserArgs in runBrowser

### DIFF
--- a/src/Internal/Test/E2E/Runner.purs
+++ b/src/Internal/Test/E2E/Runner.purs
@@ -344,7 +344,6 @@ runBrowser tmpDir chromeUserDataDir browser extensions extraBrowserArgs = do
 
     extensionsList :: String
     extensionsList = intercalate "," $ map extPath $ Map.values extensions
-  -- how can I use extraBrowserArgs here?
   void $ spawnAndCollectOutput browser
     ( [ "--load-extension=" <> extensionsList
       , "--user-data-dir=" <> chromeUserDataDir

--- a/src/Internal/Test/E2E/Runner.purs
+++ b/src/Internal/Test/E2E/Runner.purs
@@ -155,8 +155,11 @@ runE2ECommand = case _ of
     runE2ETests testOptions' runtime
   RunBrowser browserOptions -> do
     runtime <- readBrowserRuntime Nothing browserOptions
+    extraBrowserArgs <- liftEffect $ readExtraArgs
+      browserOptions.extraBrowserArgs
     runBrowser runtime.tmpDir runtime.chromeUserDataDir runtime.browser
       runtime.wallets
+      extraBrowserArgs
   PackSettings opts -> do
     rt <- readSettingsRuntime opts
     packSettings rt.settingsArchive rt.chromeUserDataDir
@@ -333,17 +336,20 @@ runBrowser
   -> ChromeUserDataDir
   -> Browser
   -> Extensions
+  -> Array BrowserArg
   -> Aff Unit
-runBrowser tmpDir chromeUserDataDir browser extensions = do
+runBrowser tmpDir chromeUserDataDir browser extensions extraBrowserArgs = do
   let
     extPath ext = tmpDir <</>> unExtensionId ext.extensionId
 
     extensionsList :: String
     extensionsList = intercalate "," $ map extPath $ Map.values extensions
+  -- how can I use extraBrowserArgs here?
   void $ spawnAndCollectOutput browser
-    [ "--load-extension=" <> extensionsList
-    , "--user-data-dir=" <> chromeUserDataDir
-    ]
+    ( [ "--load-extension=" <> extensionsList
+      , "--user-data-dir=" <> chromeUserDataDir
+      ] <> extraBrowserArgs
+    )
     defaultSpawnOptions
     defaultErrorReader
 


### PR DESCRIPTION
Closes #1295.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
