### PR TITLE
Add `submitTxFromConstraints` instead of `Helpers.buildBalanceSignAndSubmitTx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+* Add `submitTxConstraintsWith` and `submitTxConstraintsWithReturningFee` in `Contract.Transaction`. `submitTxConstraintsWith` build a transaction that satisfies the constraints, then submit it to the network. It is analog for same function in Plutus and replaces `Helpers.buildBalanceSignAndSubmitTx`.
+
 ### Changed
 
 - Running plutip servers attaches on SIGINT handlers and therefore node will not exit by default. ([#1231](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1231)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-* Add `submitTxConstraintsWith` and `submitTxConstraintsWithReturningFee` in `Contract.Transaction`. `submitTxConstraintsWith` build a transaction that satisfies the constraints, then submit it to the network. It is analog for same function in Plutus and replaces `Helpers.buildBalanceSignAndSubmitTx`.
+* Add `submitTxFromConstraints` and `submitTxFromConstraintsReturningFee` in `Contract.Transaction`. `submitTxFromConstraints` build a transaction that satisfies the constraints, then submit it to the network. It is analog for `submitTxConstraintsWith` function in Plutus and replaces `Helpers.buildBalanceSignAndSubmitTx`.
 
 ### Changed
 

--- a/doc/plutus-comparison.md
+++ b/doc/plutus-comparison.md
@@ -64,6 +64,12 @@ Finally, CTL's `Contract` is not parameterized by an error type as in Plutus. `C
 
 ## API differences
 
+### Transaction manipulation API
+
+| Plutus                      | CTL                           |
+| --------------------------- | ----------------------------- |
+| `submitTxConstraintsWith`   | `submitTxFromConstraints`     |
+
 ### Constraints and lookups
 
 CTL has adapted Plutus' Alonzo-era constraints/lookups interface fairly closely and it functions largely the same. One key difference is that CTL does not, and cannot, have the notion of a "current" script. All scripts must be explicitly provided to CTL (serialized as CBOR, see below). This has led us to depart from Plutus' naming conventions for certain constraints/lookups:

--- a/doc/side-by-side-ctl-plutus-comparison.md
+++ b/doc/side-by-side-ctl-plutus-comparison.md
@@ -96,76 +96,6 @@ the [Plutus pioneer program](https://plutus-pioneer-program.readthedocs.io/en/la
 Both of them use the same on-chain contract that allows an arbitrary
 datum and arbitrary redeemer.
 
-### Signature and submit
-
-We are going to need the auxiliary PureScript function that isn't part
-of CTL:
-
-```PureScript
-module ExampleModule where
-
-import Contract.Prelude
-import Contract.Log (logInfo')
-import Contract.Monad (Contract, liftedE)
-import Contract.ScriptLookups (ScriptLookups, mkUnbalancedTx)
-import Contract.PlutusData (PlutusData)
-import Contract.Transaction
-  ( balanceTx
-  , TransactionHash
-  , signTransaction
-  , submit
-  )
-import Contract.TxConstraints (TxConstraints)
-
-buildBalanceSignAndSubmitTx
-  :: ScriptLookups PlutusData
-  -> TxConstraints Unit Unit
-  -> Contract () TransactionHash
-buildBalanceSignAndSubmitTx lookups constraints = do
-  ubTx <- liftedE $ mkUnbalancedTx lookups constraints
-  bsTx <- signTransaction =<< liftedE (balanceTx ubTx)
-  txId <- submit bsTx
-  logInfo' $ "Tx ID: " <> show txId
-  pure txId
-```
-
-
-This function takes our lookups and constraints, then it:
-
-- Constructs an unbalanced transaction.
-- Attempts to balance the transaction.
-- Request the user to sign this transaction.
-- Submits the transaction.
-- Returns the Id for the submitted transaction.
-
-Note that some errors could happen in this process and
-the use of the functions `liftedE` and `liftedM` to
-propagate those errors and internalize them in the `Contract` monad.
-Also, as when we work with Haskell `IO` values, some other
-errors could happen performing the operations inside
-and `Aff` effect (some server could be unreachable,
-the user could fail provide the signature, etc).
-
-This is a separate function as is almost boilerplate once we
-have set our environment.
-
-We can see this function as a more explicit version of the
-process made by Plutus with the `submitTx` function:
-
-```Haskell
--- | Build a transaction that satisfies the constraints, then submit it to
--- | the network. The constraints do not refer to any
--- | typed script inputs or outputs.
-submitTx
-  :: forall w s e. AsContractError e
-    => TxConstraints Void Void -> Contract w s e CardanoTx
-```
-
-A major difference in both functions is the fact that we
-are also signing the transaction as part of the balance of
-the transaction.
-
-
 ### MustPayTo functions
 
 
@@ -247,7 +177,7 @@ give vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 ```
 
 
@@ -328,7 +258,7 @@ grab vhash validator txId = do
         constraints =
           Constraints.mustSpendScriptOutput txInput unitRedeemer
       in
-        void $ buildBalanceSignAndSubmitTx lookups constraints
+        void $ submitTxConstraintsWith lookups constraints
     _ ->
       logInfo' $ "The id "
         <> show txId

--- a/doc/side-by-side-ctl-plutus-comparison.md
+++ b/doc/side-by-side-ctl-plutus-comparison.md
@@ -177,7 +177,7 @@ give vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 ```
 
 
@@ -200,7 +200,7 @@ grab = do
       tx :: TxConstraints Void Void
       tx =
         mconcat [mustSpendScriptOutput oref $ Redeemer $ I 17 | oref <- orefs]
-   ledgerTx <- submitTxConstraintsWith @Void lookups tx
+   ledgerTx <- submitTxFromConstraints @Void lookups tx
    void $ awaitTxConfirmed $ txId ledgerTx
    logInfo @String $ "collected gifts"
 ```
@@ -258,7 +258,7 @@ grab vhash validator txId = do
         constraints =
           Constraints.mustSpendScriptOutput txInput unitRedeemer
       in
-        void $ submitTxConstraintsWith lookups constraints
+        void $ submitTxFromConstraints lookups constraints
     _ ->
       logInfo' $ "The id "
         <> show txId

--- a/examples/AlwaysMints.purs
+++ b/examples/AlwaysMints.purs
@@ -20,13 +20,12 @@ import Contract.TextEnvelope
   ( decodeTextEnvelope
   , plutusScriptV1FromEnvelope
   )
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   ) as Helpers
 import Data.BigInt as BigInt
@@ -49,7 +48,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmed txId
   logInfo' "Tx submitted successfully!"

--- a/examples/AlwaysMints.purs
+++ b/examples/AlwaysMints.purs
@@ -20,7 +20,7 @@ import Contract.TextEnvelope
   ( decodeTextEnvelope
   , plutusScriptV1FromEnvelope
   )
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
@@ -48,7 +48,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmed txId
   logInfo' "Tx submitted successfully!"

--- a/examples/AlwaysSucceeds.purs
+++ b/examples/AlwaysSucceeds.purs
@@ -27,13 +27,13 @@ import Contract.Transaction
   , _input
   , awaitTxConfirmed
   , lookupTxHash
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Data.Array (head)
 import Data.BigInt as BigInt
 import Data.Lens (view)
@@ -81,7 +81,7 @@ payToAlwaysSucceeds vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 spendFromAlwaysSucceeds
   :: ValidatorHash
@@ -113,7 +113,7 @@ spendFromAlwaysSucceeds vhash validator txId = do
     constraints :: TxConstraints Unit Unit
     constraints =
       Constraints.mustSpendScriptOutput txInput unitRedeemer
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 

--- a/examples/AlwaysSucceeds.purs
+++ b/examples/AlwaysSucceeds.purs
@@ -27,7 +27,7 @@ import Contract.Transaction
   , _input
   , awaitTxConfirmed
   , lookupTxHash
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
@@ -81,7 +81,7 @@ payToAlwaysSucceeds vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 spendFromAlwaysSucceeds
   :: ValidatorHash
@@ -113,7 +113,7 @@ spendFromAlwaysSucceeds vhash validator txId = do
     constraints :: TxConstraints Unit Unit
     constraints =
       Constraints.mustSpendScriptOutput txInput unitRedeemer
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 

--- a/examples/Helpers.purs
+++ b/examples/Helpers.purs
@@ -1,7 +1,5 @@
 module Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , buildBalanceSignAndSubmitTx'
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   , mustPayToPubKeyStakeAddress
   , submitAndLog
@@ -12,10 +10,9 @@ import Contract.Prelude
 import Contract.Address (PaymentPubKeyHash, StakePubKeyHash)
 import Contract.Log (logInfo')
 import Contract.Monad (Contract, liftContractM, liftedE)
-import Contract.PlutusData (class IsData)
 import Contract.Prim.ByteArray (byteArrayFromAscii)
 import Contract.ScriptLookups (ScriptLookups, mkUnbalancedTx) as Lookups
-import Contract.Scripts (class ValidatorTypes, MintingPolicy)
+import Contract.Scripts (MintingPolicy)
 import Contract.Transaction
   ( BalancedSignedTransaction
   , TransactionHash
@@ -31,35 +28,6 @@ import Contract.Value (CurrencySymbol, TokenName, Value)
 import Contract.Value (mkTokenName, scriptCurrencySymbol) as Value
 import Data.BigInt (BigInt)
 import Effect.Exception (throw)
-
-buildBalanceSignAndSubmitTx'
-  :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
-       (redeemer :: Type)
-   . ValidatorTypes validator datum redeemer
-  => IsData datum
-  => IsData redeemer
-  => Lookups.ScriptLookups validator
-  -> Constraints.TxConstraints redeemer datum
-  -> Contract r { txHash :: TransactionHash, txFinalFee :: BigInt }
-buildBalanceSignAndSubmitTx' lookups constraints = do
-  unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-  balancedTx <- liftedE $ balanceTx unbalancedTx
-  balancedSignedTx <- signTransaction balancedTx
-  txHash <- submit balancedSignedTx
-  logInfo' $ "Tx ID: " <> show txHash
-  pure { txHash, txFinalFee: getTxFinalFee balancedSignedTx }
-
-buildBalanceSignAndSubmitTx
-  :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
-       (redeemer :: Type)
-   . ValidatorTypes validator datum redeemer
-  => IsData datum
-  => IsData redeemer
-  => Lookups.ScriptLookups validator
-  -> Constraints.TxConstraints redeemer datum
-  -> Contract r TransactionHash
-buildBalanceSignAndSubmitTx lookups constraints =
-  _.txHash <$> buildBalanceSignAndSubmitTx' lookups constraints
 
 mkCurrencySymbol
   :: forall (r :: Row Type)

--- a/examples/IncludeDatum.purs
+++ b/examples/IncludeDatum.purs
@@ -25,7 +25,7 @@ import Contract.Transaction
   , _input
   , awaitTxConfirmed
   , lookupTxHash
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
@@ -69,7 +69,7 @@ payToIncludeDatum vhash =
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
   in
-    submitTxConstraintsWith lookups constraints
+    submitTxFromConstraints lookups constraints
 
 spendFromIncludeDatum
   :: ValidatorHash
@@ -90,7 +90,7 @@ spendFromIncludeDatum vhash validator txId = do
     constraints =
       Constraints.mustSpendScriptOutput txInput unitRedeemer
         <> Constraints.mustIncludeDatum datum
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 

--- a/examples/IncludeDatum.purs
+++ b/examples/IncludeDatum.purs
@@ -25,13 +25,13 @@ import Contract.Transaction
   , _input
   , awaitTxConfirmed
   , lookupTxHash
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Data.Array (head)
 import Data.BigInt as BigInt
 import Data.Lens (view)
@@ -69,7 +69,7 @@ payToIncludeDatum vhash =
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
   in
-    Helpers.buildBalanceSignAndSubmitTx lookups constraints
+    submitTxConstraintsWith lookups constraints
 
 spendFromIncludeDatum
   :: ValidatorHash
@@ -90,7 +90,7 @@ spendFromIncludeDatum vhash validator txId = do
     constraints =
       Constraints.mustSpendScriptOutput txInput unitRedeemer
         <> Constraints.mustIncludeDatum datum
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 

--- a/examples/KeyWallet/MintsAndSendsToken.purs
+++ b/examples/KeyWallet/MintsAndSendsToken.purs
@@ -8,7 +8,7 @@ import Contract.Prelude
 
 import Contract.Log (logInfo')
 import Contract.ScriptLookups as Lookups
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Ctl.Examples.AlwaysMints (alwaysMintsPolicy)
@@ -36,6 +36,6 @@ main = runKeyWalletContract_ \pkh lovelace unlock -> do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed txId
   liftEffect unlock

--- a/examples/KeyWallet/MintsAndSendsToken.purs
+++ b/examples/KeyWallet/MintsAndSendsToken.purs
@@ -8,13 +8,12 @@ import Contract.Prelude
 
 import Contract.Log (logInfo')
 import Contract.ScriptLookups as Lookups
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Ctl.Examples.AlwaysMints (alwaysMintsPolicy)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   ) as Helpers
 import Ctl.Examples.KeyWallet.Internal.Pkh2PkhContract (runKeyWalletContract_)
@@ -37,6 +36,6 @@ main = runKeyWalletContract_ \pkh lovelace unlock -> do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed txId
   liftEffect unlock

--- a/examples/KeyWallet/Pkh2Pkh.purs
+++ b/examples/KeyWallet/Pkh2Pkh.purs
@@ -8,7 +8,7 @@ import Contract.Prelude
 
 import Contract.Log (logInfo')
 import Contract.ScriptLookups as Lookups
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Value (lovelaceValueOf) as Value
 import Ctl.Examples.KeyWallet.Internal.Pkh2PkhContract (runKeyWalletContract_)
@@ -25,7 +25,7 @@ main = runKeyWalletContract_ \pkh lovelace unlock -> do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmed txId
   liftEffect unlock

--- a/examples/KeyWallet/Pkh2Pkh.purs
+++ b/examples/KeyWallet/Pkh2Pkh.purs
@@ -8,10 +8,9 @@ import Contract.Prelude
 
 import Contract.Log (logInfo')
 import Contract.ScriptLookups as Lookups
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Value (lovelaceValueOf) as Value
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Ctl.Examples.KeyWallet.Internal.Pkh2PkhContract (runKeyWalletContract_)
 
 main :: Effect Unit
@@ -26,7 +25,7 @@ main = runKeyWalletContract_ \pkh lovelace unlock -> do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmed txId
   liftEffect unlock

--- a/examples/Lose7Ada.purs
+++ b/examples/Lose7Ada.purs
@@ -28,7 +28,7 @@ import Contract.Transaction
   ( TransactionHash
   , TransactionInput(TransactionInput)
   , awaitTxConfirmed
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
@@ -70,7 +70,7 @@ payToAlwaysFails vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 spendFromAlwaysFails
   :: ValidatorHash
@@ -100,7 +100,7 @@ spendFromAlwaysFails vhash validator txId = do
       Constraints.mustSpendScriptOutput txInput unitRedeemer
         <> Constraints.mustNotBeValid
 
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   logInfo' $ "Tx ID: " <> show spendTxId
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."

--- a/examples/Lose7Ada.purs
+++ b/examples/Lose7Ada.purs
@@ -28,13 +28,13 @@ import Contract.Transaction
   ( TransactionHash
   , TransactionInput(TransactionInput)
   , awaitTxConfirmed
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (getWalletBalance, utxosAt)
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Data.BigInt as BigInt
 import Data.Foldable (fold)
 import Data.Functor ((<$>))
@@ -70,7 +70,7 @@ payToAlwaysFails vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 spendFromAlwaysFails
   :: ValidatorHash
@@ -100,7 +100,7 @@ spendFromAlwaysFails vhash validator txId = do
       Constraints.mustSpendScriptOutput txInput unitRedeemer
         <> Constraints.mustNotBeValid
 
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   logInfo' $ "Tx ID: " <> show spendTxId
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."

--- a/examples/MintsMultipleTokens.purs
+++ b/examples/MintsMultipleTokens.purs
@@ -22,13 +22,12 @@ import Contract.TextEnvelope
   ( decodeTextEnvelope
   , plutusScriptV1FromEnvelope
   )
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   ) as Helpers
 import Data.BigInt (fromInt) as BigInt
@@ -66,7 +65,7 @@ contract = do
         <> Lookups.mintingPolicy mp2
         <> Lookups.mintingPolicy mp3
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmed txId
   logInfo' $ "Tx submitted successfully!"

--- a/examples/MintsMultipleTokens.purs
+++ b/examples/MintsMultipleTokens.purs
@@ -22,7 +22,7 @@ import Contract.TextEnvelope
   ( decodeTextEnvelope
   , plutusScriptV1FromEnvelope
   )
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
@@ -65,7 +65,7 @@ contract = do
         <> Lookups.mintingPolicy mp2
         <> Lookups.mintingPolicy mp3
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmed txId
   logInfo' $ "Tx submitted successfully!"

--- a/examples/MultipleRedeemers.purs
+++ b/examples/MultipleRedeemers.purs
@@ -21,14 +21,13 @@ import Contract.Scripts
   , validatorHash
   )
 import Contract.TextEnvelope (decodeTextEnvelope, plutusScriptV1FromEnvelope)
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   )
 import Ctl.Examples.MintsMultipleTokens
@@ -64,7 +63,7 @@ contract = do
   let
     constraints =
       (mconcat $ fst <$> lcs) :: Constraints.TxConstraints Void Void
-  txHash <- buildBalanceSignAndSubmitTx
+  txHash <- submitTxConstraintsWith
     (Lookups.mintingPolicy mintingPolicy <> lookups)
     constraints
   void $ awaitTxConfirmed txHash
@@ -91,7 +90,7 @@ contractWithMintRedeemers = do
           (Redeemer $ Integer $ BigInt.fromInt 3)
           (Value.singleton cs tokenName one)
       )
-  txHash <- buildBalanceSignAndSubmitTx
+  txHash <- submitTxConstraintsWith
     ( Lookups.mintingPolicy mintingPolicy <> Lookups.mintingPolicy mp <>
         unlockingLookups
     )

--- a/examples/MultipleRedeemers.purs
+++ b/examples/MultipleRedeemers.purs
@@ -21,7 +21,7 @@ import Contract.Scripts
   , validatorHash
   )
 import Contract.TextEnvelope (decodeTextEnvelope, plutusScriptV1FromEnvelope)
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value as Value
@@ -63,7 +63,7 @@ contract = do
   let
     constraints =
       (mconcat $ fst <$> lcs) :: Constraints.TxConstraints Void Void
-  txHash <- submitTxConstraintsWith
+  txHash <- submitTxFromConstraints
     (Lookups.mintingPolicy mintingPolicy <> lookups)
     constraints
   void $ awaitTxConfirmed txHash
@@ -90,7 +90,7 @@ contractWithMintRedeemers = do
           (Redeemer $ Integer $ BigInt.fromInt 3)
           (Value.singleton cs tokenName one)
       )
-  txHash <- submitTxConstraintsWith
+  txHash <- submitTxFromConstraints
     ( Lookups.mintingPolicy mintingPolicy <> Lookups.mintingPolicy mp <>
         unlockingLookups
     )

--- a/examples/NativeScriptMints.purs
+++ b/examples/NativeScriptMints.purs
@@ -17,13 +17,12 @@ import Contract.Scripts
   ( MintingPolicy(NativeMintingPolicy)
   , NativeScript(ScriptPubkey)
   )
-import Contract.Transaction (awaitTxConfirmed)
+import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
 import Contract.TxConstraints as Constraints
 import Contract.Value (CurrencySymbol, TokenName)
 import Contract.Value as Value
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   , mustPayToPubKeyStakeAddress
   ) as Helpers
@@ -53,7 +52,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmed txId
   logInfo' "Minted successfully"
@@ -74,7 +73,7 @@ toSelfContract cs tn amount = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmed txId
   logInfo' $ "Moved " <> show (BigInt.fromInt 50) <> " to self successfully"

--- a/examples/NativeScriptMints.purs
+++ b/examples/NativeScriptMints.purs
@@ -17,7 +17,7 @@ import Contract.Scripts
   ( MintingPolicy(NativeMintingPolicy)
   , NativeScript(ScriptPubkey)
   )
-import Contract.Transaction (awaitTxConfirmed, submitTxConstraintsWith)
+import Contract.Transaction (awaitTxConfirmed, submitTxFromConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Value (CurrencySymbol, TokenName)
 import Contract.Value as Value
@@ -52,7 +52,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmed txId
   logInfo' "Minted successfully"
@@ -73,7 +73,7 @@ toSelfContract cs tn amount = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmed txId
   logInfo' $ "Moved " <> show (BigInt.fromInt 50) <> " to self successfully"

--- a/examples/OneShotMinting.purs
+++ b/examples/OneShotMinting.purs
@@ -37,7 +37,7 @@ import Contract.TextEnvelope (decodeTextEnvelope, plutusScriptV1FromEnvelope)
 import Contract.Transaction
   ( TransactionInput
   , awaitTxConfirmed
-  , submitTxConstraintsWithReturningFee
+  , submitTxFromConstraintsReturningFee
   )
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
@@ -111,7 +111,7 @@ mkContractWithAssertions exampleName mkMintingPolicy = do
   let assertions = mkAssertions ownAddress (cs /\ tn /\ one)
   void $ TestUtils.withAssertions assertions do
     { txHash, txFinalFee } <-
-      submitTxConstraintsWithReturningFee lookups constraints
+      submitTxFromConstraintsReturningFee lookups constraints
     logInfo' $ "Tx ID: " <> show txHash
     awaitTxConfirmed txHash
     logInfo' "Tx submitted successfully!"

--- a/examples/OneShotMinting.purs
+++ b/examples/OneShotMinting.purs
@@ -34,15 +34,18 @@ import Contract.Scripts
 import Contract.Test.Utils (ContractWrapAssertion, Labeled, label)
 import Contract.Test.Utils as TestUtils
 import Contract.TextEnvelope (decodeTextEnvelope, plutusScriptV1FromEnvelope)
-import Contract.Transaction (TransactionInput, awaitTxConfirmed)
+import Contract.Transaction
+  ( TransactionInput
+  , awaitTxConfirmed
+  , submitTxConstraintsWithReturningFee
+  )
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value (CurrencySymbol, TokenName)
 import Contract.Value (singleton) as Value
 import Control.Monad.Error.Class (liftMaybe)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx'
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   ) as Helpers
 import Data.Array (head)
@@ -108,8 +111,8 @@ mkContractWithAssertions exampleName mkMintingPolicy = do
   let assertions = mkAssertions ownAddress (cs /\ tn /\ one)
   void $ TestUtils.withAssertions assertions do
     { txHash, txFinalFee } <-
-      Helpers.buildBalanceSignAndSubmitTx' lookups constraints
-
+      submitTxConstraintsWithReturningFee lookups constraints
+    logInfo' $ "Tx ID: " <> show txHash
     awaitTxConfirmed txHash
     logInfo' "Tx submitted successfully!"
     pure { txFinalFee }

--- a/examples/Pkh2Pkh.purs
+++ b/examples/Pkh2Pkh.purs
@@ -12,7 +12,7 @@ import Contract.Monad (Contract, launchAff_, liftedM, runContract)
 import Contract.ScriptLookups as Lookups
 import Contract.Transaction
   ( awaitTxConfirmedWithTimeout
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
@@ -38,7 +38,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- submitTxConstraintsWith lookups constraints
+  txId <- submitTxFromConstraints lookups constraints
 
   awaitTxConfirmedWithTimeout (wrap 100.0) txId
   logInfo' $ "Tx submitted successfully!"

--- a/examples/Pkh2Pkh.purs
+++ b/examples/Pkh2Pkh.purs
@@ -10,10 +10,12 @@ import Contract.Config (ConfigParams, testnetNamiConfig)
 import Contract.Log (logInfo')
 import Contract.Monad (Contract, launchAff_, liftedM, runContract)
 import Contract.ScriptLookups as Lookups
-import Contract.Transaction (awaitTxConfirmedWithTimeout)
+import Contract.Transaction
+  ( awaitTxConfirmedWithTimeout
+  , submitTxConstraintsWith
+  )
 import Contract.TxConstraints as Constraints
 import Contract.Value as Value
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Data.Array (head)
 import Data.BigInt as BigInt
 
@@ -36,7 +38,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  txId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txId <- submitTxConstraintsWith lookups constraints
 
   awaitTxConfirmedWithTimeout (wrap 100.0) txId
   logInfo' $ "Tx submitted successfully!"

--- a/examples/PlutusV2/InlineDatum.purs
+++ b/examples/PlutusV2/InlineDatum.purs
@@ -31,13 +31,13 @@ import Contract.Transaction
   , TransactionInput(TransactionInput)
   , TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   , awaitTxConfirmed
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value as Value
 import Control.Monad.Error.Class (liftMaybe)
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Data.BigInt as BigInt
 import Data.Map as Map
 import Effect.Exception (error)
@@ -77,7 +77,7 @@ payToCheckDatumIsInline vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 spendFromCheckDatumIsInline
   :: ValidatorHash
@@ -109,7 +109,7 @@ spendFromCheckDatumIsInline vhash validator txId = do
     constraints =
       Constraints.mustSpendScriptOutput txInput redeemer
 
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 
@@ -134,7 +134,7 @@ payToCheckDatumIsInlineWrong vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 readFromCheckDatumIsInline
   :: ValidatorHash

--- a/examples/PlutusV2/InlineDatum.purs
+++ b/examples/PlutusV2/InlineDatum.purs
@@ -31,7 +31,7 @@ import Contract.Transaction
   , TransactionInput(TransactionInput)
   , TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   , awaitTxConfirmed
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
@@ -77,7 +77,7 @@ payToCheckDatumIsInline vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 spendFromCheckDatumIsInline
   :: ValidatorHash
@@ -109,7 +109,7 @@ spendFromCheckDatumIsInline vhash validator txId = do
     constraints =
       Constraints.mustSpendScriptOutput txInput redeemer
 
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
 
@@ -134,7 +134,7 @@ payToCheckDatumIsInlineWrong vhash = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 readFromCheckDatumIsInline
   :: ValidatorHash

--- a/examples/PlutusV2/ReferenceInputsAndScripts.purs
+++ b/examples/PlutusV2/ReferenceInputsAndScripts.purs
@@ -42,7 +42,7 @@ import Contract.Transaction
   , TransactionOutputWithRefScript
   , awaitTxConfirmed
   , mkTxUnspentOut
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints
   ( DatumPresence(DatumWitness)
@@ -115,7 +115,7 @@ payToAlwaysSucceedsAndCreateScriptRefOutput vhash validatorRef mpRef = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 spendFromAlwaysSucceeds
   :: ValidatorHash
@@ -159,7 +159,7 @@ spendFromAlwaysSucceeds vhash txId validator mp tokenName = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = Lookups.unspentOutputs scriptAddressUtxos
 
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values and minted tokens."
   where
@@ -206,5 +206,5 @@ mintAlwaysMintsV2ToTheScript tokenName validator sum = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txHash <- submitTxConstraintsWith lookups constraints
+  txHash <- submitTxFromConstraints lookups constraints
   void $ awaitTxConfirmed txHash

--- a/examples/PlutusV2/ReferenceInputsAndScripts.purs
+++ b/examples/PlutusV2/ReferenceInputsAndScripts.purs
@@ -42,6 +42,7 @@ import Contract.Transaction
   , TransactionOutputWithRefScript
   , awaitTxConfirmed
   , mkTxUnspentOut
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints
   ( DatumPresence(DatumWitness)
@@ -52,7 +53,7 @@ import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value (TokenName, Value)
 import Contract.Value as Value
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx, mkTokenName) as Helpers
+import Ctl.Examples.Helpers (mkTokenName) as Helpers
 import Ctl.Examples.PlutusV2.Scripts.AlwaysMints
   ( alwaysMintsPolicyScriptV2
   , alwaysMintsPolicyV2
@@ -114,7 +115,7 @@ payToAlwaysSucceedsAndCreateScriptRefOutput vhash validatorRef mpRef = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 spendFromAlwaysSucceeds
   :: ValidatorHash
@@ -158,7 +159,7 @@ spendFromAlwaysSucceeds vhash txId validator mp tokenName = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = Lookups.unspentOutputs scriptAddressUtxos
 
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values and minted tokens."
   where
@@ -205,5 +206,5 @@ mintAlwaysMintsV2ToTheScript tokenName validator sum = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  txHash <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txHash <- submitTxConstraintsWith lookups constraints
   void $ awaitTxConfirmed txHash

--- a/examples/PlutusV2/ReferenceScripts.purs
+++ b/examples/PlutusV2/ReferenceScripts.purs
@@ -20,6 +20,7 @@ import Contract.Transaction
   , TransactionInput(TransactionInput)
   , awaitTxConfirmed
   , mkTxUnspentOut
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints
   ( DatumPresence(DatumWitness)
@@ -29,7 +30,6 @@ import Contract.TxConstraints
 import Contract.TxConstraints as Constraints
 import Contract.Utxos (utxosAt)
 import Contract.Value (lovelaceValueOf) as Value
-import Ctl.Examples.Helpers (buildBalanceSignAndSubmitTx) as Helpers
 import Ctl.Examples.PlutusV2.Scripts.AlwaysSucceeds (alwaysSucceedsScriptV2)
 import Data.Array (head)
 import Data.BigInt (fromInt) as BigInt
@@ -85,7 +85,7 @@ payWithScriptRefToAlwaysSucceeds vhash scriptRef = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 spendFromAlwaysSucceeds :: ValidatorHash -> TransactionHash -> Contract () Unit
 spendFromAlwaysSucceeds vhash txId = do
@@ -110,7 +110,7 @@ spendFromAlwaysSucceeds vhash txId = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  spendTxId <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  spendTxId <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
   where

--- a/examples/PlutusV2/ReferenceScripts.purs
+++ b/examples/PlutusV2/ReferenceScripts.purs
@@ -20,7 +20,7 @@ import Contract.Transaction
   , TransactionInput(TransactionInput)
   , awaitTxConfirmed
   , mkTxUnspentOut
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints
   ( DatumPresence(DatumWitness)
@@ -85,7 +85,7 @@ payWithScriptRefToAlwaysSucceeds vhash scriptRef = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 spendFromAlwaysSucceeds :: ValidatorHash -> TransactionHash -> Contract () Unit
 spendFromAlwaysSucceeds vhash txId = do
@@ -110,7 +110,7 @@ spendFromAlwaysSucceeds vhash txId = do
     lookups :: Lookups.ScriptLookups PlutusData
     lookups = mempty
 
-  spendTxId <- submitTxConstraintsWith lookups constraints
+  spendTxId <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed spendTxId
   logInfo' "Successfully spent locked values."
   where

--- a/examples/SendsToken.purs
+++ b/examples/SendsToken.purs
@@ -15,7 +15,7 @@ import Contract.Scripts (MintingPolicy)
 import Contract.Transaction
   ( TransactionHash
   , awaitTxConfirmed
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints as Constraints
 import Contract.Value (Value)
@@ -55,7 +55,7 @@ mintToken = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 sendToken :: Contract () TransactionHash
 sendToken = do
@@ -69,7 +69,7 @@ sendToken = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  submitTxConstraintsWith lookups constraints
+  submitTxFromConstraints lookups constraints
 
 tokenValue :: Contract () (MintingPolicy /\ Value)
 tokenValue = do

--- a/examples/SendsToken.purs
+++ b/examples/SendsToken.purs
@@ -12,14 +12,17 @@ import Contract.Log (logInfo')
 import Contract.Monad (Contract, launchAff_, liftedM, runContract)
 import Contract.ScriptLookups as Lookups
 import Contract.Scripts (MintingPolicy)
-import Contract.Transaction (TransactionHash, awaitTxConfirmed)
+import Contract.Transaction
+  ( TransactionHash
+  , awaitTxConfirmed
+  , submitTxConstraintsWith
+  )
 import Contract.TxConstraints as Constraints
 import Contract.Value (Value)
 import Contract.Value as Value
 import Ctl.Examples.AlwaysMints (alwaysMintsPolicy)
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   , mustPayToPubKeyStakeAddress
   ) as Helpers
@@ -52,7 +55,7 @@ mintToken = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 sendToken :: Contract () TransactionHash
 sendToken = do
@@ -66,7 +69,7 @@ sendToken = do
     lookups :: Lookups.ScriptLookups Void
     lookups = mempty
 
-  Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  submitTxConstraintsWith lookups constraints
 
 tokenValue :: Contract () (MintingPolicy /\ Value)
 tokenValue = do

--- a/examples/Utxos.purs
+++ b/examples/Utxos.purs
@@ -24,6 +24,7 @@ import Contract.Scripts (MintingPolicy(PlutusMintingPolicy))
 import Contract.Transaction
   ( ScriptRef(NativeScriptRef, PlutusScriptRef)
   , awaitTxConfirmed
+  , submitTxConstraintsWith
   )
 import Contract.TxConstraints (DatumPresence(DatumInline, DatumWitness))
 import Contract.TxConstraints as Constraints
@@ -31,8 +32,7 @@ import Contract.Utxos (utxosAt)
 import Contract.Value (Value)
 import Contract.Value (lovelaceValueOf, singleton) as Value
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   ) as Helpers
 import Ctl.Examples.PlutusV2.OneShotMinting (oneShotMintingPolicyScriptV2)
@@ -96,7 +96,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp0 <> Lookups.unspentOutputs utxos
 
-  txHash <- Helpers.buildBalanceSignAndSubmitTx lookups constraints
+  txHash <- submitTxConstraintsWith lookups constraints
   awaitTxConfirmed txHash
   logInfo' "Tx submitted successfully!"
 

--- a/examples/Utxos.purs
+++ b/examples/Utxos.purs
@@ -24,7 +24,7 @@ import Contract.Scripts (MintingPolicy(PlutusMintingPolicy))
 import Contract.Transaction
   ( ScriptRef(NativeScriptRef, PlutusScriptRef)
   , awaitTxConfirmed
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   )
 import Contract.TxConstraints (DatumPresence(DatumInline, DatumWitness))
 import Contract.TxConstraints as Constraints
@@ -96,7 +96,7 @@ contract = do
     lookups :: Lookups.ScriptLookups Void
     lookups = Lookups.mintingPolicy mp0 <> Lookups.unspentOutputs utxos
 
-  txHash <- submitTxConstraintsWith lookups constraints
+  txHash <- submitTxFromConstraints lookups constraints
   awaitTxConfirmed txHash
   logInfo' "Tx submitted successfully!"
 

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -33,6 +33,8 @@ module Contract.Transaction
   , signTransaction
   , submit
   , submitE
+  , submitTxConstraintsWith
+  , submitTxConstraintsWithReturningFee
   , withBalancedTx
   , withBalancedTxWithConstraints
   , withBalancedTxs
@@ -51,6 +53,10 @@ import Contract.Monad
   , runContractInEnv
   , wrapContract
   )
+import Contract.PlutusData (class IsData)
+import Contract.ScriptLookups (mkUnbalancedTx)
+import Contract.Scripts (class ValidatorTypes)
+import Contract.TxConstraints (TxConstraints)
 import Control.Monad.Error.Class (catchError, throwError)
 import Control.Monad.Reader (ReaderT, asks, runReaderT)
 import Control.Monad.Reader.Class (ask)
@@ -227,7 +233,7 @@ import Ctl.Internal.Types.ScriptLookups
       , CannotConvertPaymentPubKeyHash
       , CannotSatisfyAny
       )
-  , mkUnbalancedTx
+  , ScriptLookups
   ) as ScriptLookups
 import Ctl.Internal.Types.ScriptLookups (UnattachedUnbalancedTx)
 import Ctl.Internal.Types.Scripts
@@ -599,3 +605,31 @@ createAdditionalUtxos tx = do
 
   pure $ plutusOutputs #
     foldl (\utxo txOut -> Map.insert (txIn $ length utxo) txOut utxo) Map.empty
+
+submitTxConstraintsWithReturningFee
+  :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
+       (redeemer :: Type)
+   . ValidatorTypes validator datum redeemer
+  => IsData datum
+  => IsData redeemer
+  => ScriptLookups.ScriptLookups validator
+  -> TxConstraints redeemer datum
+  -> Contract r { txHash :: TransactionHash, txFinalFee :: BigInt }
+submitTxConstraintsWithReturningFee lookups constraints = do
+  unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
+  balancedTx <- liftedE $ balanceTx unbalancedTx
+  balancedSignedTx <- signTransaction balancedTx
+  txHash <- submit balancedSignedTx
+  pure { txHash, txFinalFee: getTxFinalFee balancedSignedTx }
+
+submitTxConstraintsWith
+  :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
+       (redeemer :: Type)
+   . ValidatorTypes validator datum redeemer
+  => IsData datum
+  => IsData redeemer
+  => ScriptLookups.ScriptLookups validator
+  -> TxConstraints redeemer datum
+  -> Contract r TransactionHash
+submitTxConstraintsWith lookups constraints =
+  _.txHash <$> submitTxConstraintsWithReturningFee lookups constraints

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -33,8 +33,8 @@ module Contract.Transaction
   , signTransaction
   , submit
   , submitE
-  , submitTxConstraintsWith
-  , submitTxConstraintsWithReturningFee
+  , submitTxFromConstraints
+  , submitTxFromConstraintsReturningFee
   , withBalancedTx
   , withBalancedTxWithConstraints
   , withBalancedTxs
@@ -606,7 +606,7 @@ createAdditionalUtxos tx = do
   pure $ plutusOutputs #
     foldl (\utxo txOut -> Map.insert (txIn $ length utxo) txOut utxo) Map.empty
 
-submitTxConstraintsWithReturningFee
+submitTxFromConstraintsReturningFee
   :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
        (redeemer :: Type)
    . ValidatorTypes validator datum redeemer
@@ -615,14 +615,14 @@ submitTxConstraintsWithReturningFee
   => ScriptLookups.ScriptLookups validator
   -> TxConstraints redeemer datum
   -> Contract r { txHash :: TransactionHash, txFinalFee :: BigInt }
-submitTxConstraintsWithReturningFee lookups constraints = do
+submitTxFromConstraintsReturningFee lookups constraints = do
   unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
   balancedTx <- liftedE $ balanceTx unbalancedTx
   balancedSignedTx <- signTransaction balancedTx
   txHash <- submit balancedSignedTx
   pure { txHash, txFinalFee: getTxFinalFee balancedSignedTx }
 
-submitTxConstraintsWith
+submitTxFromConstraints
   :: forall (r :: Row Type) (validator :: Type) (datum :: Type)
        (redeemer :: Type)
    . ValidatorTypes validator datum redeemer
@@ -631,5 +631,5 @@ submitTxConstraintsWith
   => ScriptLookups.ScriptLookups validator
   -> TxConstraints redeemer datum
   -> Contract r TransactionHash
-submitTxConstraintsWith lookups constraints =
-  _.txHash <$> submitTxConstraintsWithReturningFee lookups constraints
+submitTxFromConstraints lookups constraints =
+  _.txHash <$> submitTxFromConstraintsReturningFee lookups constraints

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -58,6 +58,7 @@ import Contract.Transaction
   , createAdditionalUtxos
   , signTransaction
   , submit
+  , submitTxConstraintsWith
   , withBalancedTx
   , withBalancedTxs
   )
@@ -77,8 +78,7 @@ import Ctl.Examples.BalanceTxConstraints as BalanceTxConstraintsExample
 import Ctl.Examples.Cip30 as Cip30
 import Ctl.Examples.ContractTestUtils as ContractTestUtils
 import Ctl.Examples.Helpers
-  ( buildBalanceSignAndSubmitTx
-  , mkCurrencySymbol
+  ( mkCurrencySymbol
   , mkTokenName
   , mustPayToPubKeyStakeAddress
   )
@@ -527,7 +527,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- buildBalanceSignAndSubmitTx lookups constraints
+          txHash <- submitTxConstraintsWith lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending same amount
@@ -542,7 +542,7 @@ suite = do
               $ BigInt.fromInt 100
             lookups' = lookups <> Lookups.ownPaymentPubKeyHash pkh
 
-          txHash' <- buildBalanceSignAndSubmitTx lookups' constraints'
+          txHash' <- submitTxConstraintsWith lookups' constraints'
           void $ awaitTxConfirmed txHash'
 
     test "mustProduceAtLeast fail" do
@@ -569,7 +569,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- buildBalanceSignAndSubmitTx lookups constraints
+          txHash <- submitTxConstraintsWith lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending more than minted amount
@@ -612,7 +612,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- buildBalanceSignAndSubmitTx lookups constraints
+          txHash <- submitTxConstraintsWith lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending same amount
@@ -627,7 +627,7 @@ suite = do
               $ BigInt.fromInt 100
             lookups' = lookups <> Lookups.ownPaymentPubKeyHash pkh
 
-          txHash' <- buildBalanceSignAndSubmitTx lookups' constraints'
+          txHash' <- submitTxConstraintsWith lookups' constraints'
           void $ awaitTxConfirmed txHash'
 
     test "mustSpendAtLeast fail" do
@@ -654,7 +654,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- buildBalanceSignAndSubmitTx lookups constraints
+          txHash <- submitTxConstraintsWith lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending more than minted amount
@@ -742,7 +742,7 @@ suite = do
 
             lookups :: Lookups.ScriptLookups PlutusData
             lookups = mempty
-          buildBalanceSignAndSubmitTx lookups constraints
+          submitTxConstraintsWith lookups constraints
 
       withWallets distribution \alice -> do
         withKeyWallet alice do

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -58,7 +58,7 @@ import Contract.Transaction
   , createAdditionalUtxos
   , signTransaction
   , submit
-  , submitTxConstraintsWith
+  , submitTxFromConstraints
   , withBalancedTx
   , withBalancedTxs
   )
@@ -527,7 +527,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- submitTxConstraintsWith lookups constraints
+          txHash <- submitTxFromConstraints lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending same amount
@@ -542,7 +542,7 @@ suite = do
               $ BigInt.fromInt 100
             lookups' = lookups <> Lookups.ownPaymentPubKeyHash pkh
 
-          txHash' <- submitTxConstraintsWith lookups' constraints'
+          txHash' <- submitTxFromConstraints lookups' constraints'
           void $ awaitTxConfirmed txHash'
 
     test "mustProduceAtLeast fail" do
@@ -569,7 +569,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- submitTxConstraintsWith lookups constraints
+          txHash <- submitTxFromConstraints lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending more than minted amount
@@ -612,7 +612,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- submitTxConstraintsWith lookups constraints
+          txHash <- submitTxFromConstraints lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending same amount
@@ -627,7 +627,7 @@ suite = do
               $ BigInt.fromInt 100
             lookups' = lookups <> Lookups.ownPaymentPubKeyHash pkh
 
-          txHash' <- submitTxConstraintsWith lookups' constraints'
+          txHash' <- submitTxFromConstraints lookups' constraints'
           void $ awaitTxConfirmed txHash'
 
     test "mustSpendAtLeast fail" do
@@ -654,7 +654,7 @@ suite = do
             lookups :: Lookups.ScriptLookups Void
             lookups = Lookups.mintingPolicy mp
 
-          txHash <- submitTxConstraintsWith lookups constraints
+          txHash <- submitTxFromConstraints lookups constraints
           awaitTxConfirmed txHash
 
           -- Spending more than minted amount
@@ -742,7 +742,7 @@ suite = do
 
             lookups :: Lookups.ScriptLookups PlutusData
             lookups = mempty
-          submitTxConstraintsWith lookups constraints
+          submitTxFromConstraints lookups constraints
 
       withWallets distribution \alice -> do
         withKeyWallet alice do


### PR DESCRIPTION
Closes #821.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
