### PR TITLE
Switch CIP25 metadata keys to use strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Runtime Dependencies
 
-- [Ogmios](https://github.com/mlabs-haskell/ogmios) - v5.5.7 
+- [Ogmios](https://github.com/mlabs-haskell/ogmios) - v5.5.7
 - [Kupo](https://github.com/CardanoSolutions/kupo) - v2.2.0
 - [Cardano-Node](https://github.com/input-output-hk/cardano-node/) - v1.35.3
 - [Ogmios-Datum-Cache](https://github.com/mlabs-haskell/ogmios-datum-cache) - commit 862c6bfcb6110b8fe816e26b3bba105dfb492b24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Running plutip servers attaches on SIGINT handlers and therefore node will not exit by default. ([#1231](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1231)).
 - `TestPlanM`, `interpret` and `interpretWithConfig` are now public in `Contract.Test.Mote` and our custom `consoleReporter` in `Contract.Test.Mote.ConsoleReporter`. ([#1261](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1261)).
+- CIP-25 `policy_id` and `asset_name` metadata keys no longer include a `0x` prefix for compatibility with Blockfrost ([#1309](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1309 "CTL's CIP25 metadata encoding is considered invalid by Blockfrost #1309")).
 
 ### Removed
 

--- a/src/Internal/Metadata/Cip25/V2.purs
+++ b/src/Internal/Metadata/Cip25/V2.purs
@@ -143,7 +143,10 @@ instance DecodeAeson Cip25V2 where
       2 -> pure Cip25V2
       _ -> Left $ TypeMismatch "Cip25V2"
 
--- Why not an instance of ToMetadata?
+-- Note: this is not an instance of `ToMetadata` to prevent confusion
+-- between `Cip25Metadata` and `Cip25MetadataEntry` (the users do not
+-- need to deal with data-representations of a single entry, because
+-- the standard only specifies the encoding for Cip25Metadata).
 metadataEntryToMetadata :: Cip25MetadataEntry -> TransactionMetadatum
 metadataEntryToMetadata (Cip25MetadataEntry entry) = toMetadata $
   [ "name" /\ anyToMetadata entry.name

--- a/test/Fixtures.purs
+++ b/test/Fixtures.purs
@@ -14,6 +14,7 @@ module Test.Ctl.Fixtures
   , cip25MetadataFixture1
   , cip25MetadataFixture2
   , cip25MetadataFixture3
+  , cip25MetadataFixture4
   , cip25MetadataJsonFixture1
   , cip25MetadataJsonFixture2
   , cip25MetadataJsonFixture3
@@ -257,13 +258,18 @@ currencySymbol1 = unsafePartial $ fromJust $ mkCurrencySymbol $
   hexToByteArrayUnsafe
     "1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e"
 
+tokenNameFromString :: String -> TokenName
+tokenNameFromString s = unsafePartial $ fromJust $ mkTokenName $
+  hexToByteArrayUnsafe s
+
 tokenName1 :: TokenName
-tokenName1 = unsafePartial $ fromJust $ mkTokenName $
-  hexToByteArrayUnsafe "4974657374546f6b656e"
+tokenName1 = tokenNameFromString "4974657374546f6b656e"
 
 tokenName2 :: TokenName
-tokenName2 = unsafePartial $ fromJust $ mkTokenName $
-  hexToByteArrayUnsafe "54657374546f6b656e32"
+tokenName2 = tokenNameFromString "54657374546f6b656e32"
+
+tokenName4 :: TokenName
+tokenName4 = tokenNameFromString "abcdef"
 
 txOutputBinaryFixture1 :: String
 txOutputBinaryFixture1 =
@@ -1305,13 +1311,23 @@ plutusDataFixture8Bytes' = hexToByteArrayUnsafe
   \206f6620736b7920581cda13ed22b9294f1d86bbd530e99b1456884c7364bf16c90edc1ae41e\
   \182d"
 
+scriptHashFromString :: String -> ScriptHash
+scriptHashFromString s = unsafePartial $ fromJust $ scriptHashFromBytes $
+  hexToRawBytesUnsafe s
+
 scriptHash1 :: ScriptHash
-scriptHash1 = unsafePartial $ fromJust $ scriptHashFromBytes $
-  hexToRawBytesUnsafe
-    "5d677265fa5bb21ce6d8c7502aca70b9316d10e958611f3c6b758f65"
+scriptHash1 = scriptHashFromString
+  "5d677265fa5bb21ce6d8c7502aca70b9316d10e958611f3c6b758f65"
+
+scriptHash4 :: ScriptHash
+scriptHash4 = scriptHashFromString
+  "1e4409ba69fb38887c23d15a766476384085b66a755530934938abfe"
 
 policyId :: MintingPolicyHash
 policyId = MintingPolicyHash scriptHash1
+
+policyId4 :: MintingPolicyHash
+policyId4 = MintingPolicyHash scriptHash4
 
 cip25MetadataFilesFixture1 :: Array Cip25MetadataFile
 cip25MetadataFilesFixture1 = Cip25MetadataFile <$>
@@ -1379,34 +1395,47 @@ cip25MetadataFixture3 = Cip25Metadata
       }
   ]
 
+cip25MetadataFixture4 :: Cip25Metadata
+cip25MetadataFixture4 = Cip25Metadata
+  [ Cip25MetadataEntry
+      { policyId: policyId4
+      , assetName: Cip25TokenName tokenName4
+      , name: unsafeMkCip25String "Allium"
+      , image: "ipfs://k2cwuee3arxg398hwxx6c0iferxitu126xntuzg8t765oo020h5y6npn"
+      , mediaType: Nothing
+      , description: Just "From pixabay"
+      , files: []
+      }
+  ]
+
 unsafeMkCip25String :: String -> Cip25String
 unsafeMkCip25String str = unsafePartial $ fromJust $ mkCip25String str
 
+readJsonFixtureFile :: String -> Effect Aeson
+readJsonFixtureFile path =
+  readTextFile UTF8 path >>=
+    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+
 cip25MetadataJsonFixture1 :: Effect Aeson
 cip25MetadataJsonFixture1 =
-  readTextFile UTF8 "test/Fixtures/cip25MetadataJsonFixture1.json" >>=
-    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+  readJsonFixtureFile "test/Fixtures/cip25MetadataJsonFixture1.json"
 
 cip25MetadataJsonFixture2 :: Effect Aeson
 cip25MetadataJsonFixture2 =
-  readTextFile UTF8 "test/Fixtures/cip25MetadataJsonFixture2.json" >>=
-    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+  readJsonFixtureFile "test/Fixtures/cip25MetadataJsonFixture2.json"
 
 cip25MetadataJsonFixture3 :: Effect Aeson
 cip25MetadataJsonFixture3 =
-  readTextFile UTF8 "test/Fixtures/cip25MetadataJsonFixture3.json" >>=
-    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+  readJsonFixtureFile "test/Fixtures/cip25MetadataJsonFixture3.json"
 
 ogmiosEvaluateTxValidRespFixture :: Effect Aeson
 ogmiosEvaluateTxValidRespFixture =
-  readTextFile UTF8 "test/Fixtures/OgmiosEvaluateTxValidRespFixture.json" >>=
-    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+  readJsonFixtureFile "test/Fixtures/OgmiosEvaluateTxValidRespFixture.json"
 
 ogmiosEvaluateTxInvalidPointerFormatFixture :: Effect Aeson
 ogmiosEvaluateTxInvalidPointerFormatFixture =
-  readTextFile UTF8
-    "test/Fixtures/OgmiosEvaluateTxInvalidPointerFormatFixture.json" >>=
-    pure <<< fromRight aesonNull <<< parseJsonStringToAeson
+  readJsonFixtureFile
+    "test/Fixtures/OgmiosEvaluateTxInvalidPointerFormatFixture.json"
 
 redeemerFixture1 :: Redeemer
 redeemerFixture1 = Redeemer

--- a/test/Metadata/Cip25.purs
+++ b/test/Metadata/Cip25.purs
@@ -28,6 +28,7 @@ import Test.Ctl.Fixtures
   ( cip25MetadataFixture1
   , cip25MetadataFixture2
   , cip25MetadataFixture3
+  , cip25MetadataFixture4
   , cip25MetadataJsonFixture1
   , cip25MetadataJsonFixture2
   , unsafeMkCip25String
@@ -84,6 +85,9 @@ suite = do
     test "MetadataType instance #3" do
       fromGeneralTxMetadata (toGeneralTxMetadata cip25MetadataFixture3)
         `shouldEqual` Just cip25MetadataFixture3
+    test "MetadataType instance #4" do
+      fromGeneralTxMetadata (toGeneralTxMetadata cip25MetadataFixture4)
+        `shouldEqual` Just cip25MetadataFixture4
     test "FromData / ToData instances #1" do
       fromData (toData cip25MetadataFixture1) `shouldEqual`
         Just cip25MetadataFixture1
@@ -93,6 +97,9 @@ suite = do
     test "FromData / ToData instances #3" do
       fromData (toData cip25MetadataFixture3) `shouldEqual`
         Just cip25MetadataFixture3
+    test "FromData / ToData instances #4" do
+      fromData (toData cip25MetadataFixture4) `shouldEqual`
+        Just cip25MetadataFixture4
     test "DecodeJson instance #1" do
       jsonFixture <- liftEffect cip25MetadataJsonFixture1
       decodeAeson jsonFixture `shouldEqual`


### PR DESCRIPTION
Closes #1309.

This is confirmed to fix the issue of Blockfrost not accepting the CIP25 metadata through testing in Seabug using the [`seabug/main`](https://github.com/Plutonomicon/cardano-transaction-lib/tree/seabug/main) branch of CTL. [This](https://preview.cexplorer.io/tx/1e48e0891c3d597b5c8973f7a507bcb7d009a217fa6ed9675d5e13289d869845/metadata#data) is an example of the new CIP25 metadata encoding, and the corresponding response returned from Blockfrost from https://cardano-preview.blockfrost.io/api/v0/assets/1e4409ba69fb38887c23d15a766476384085b66a755530934938abfeabcdef:

```json
{
  "asset": "1e4409ba69fb38887c23d15a766476384085b66a755530934938abfeabcdef",
  "policy_id": "1e4409ba69fb38887c23d15a766476384085b66a755530934938abfe",
  "asset_name": "abcdef",
  "fingerprint": "asset1a63v0u52tvacvp60tyykn0chjfsgtqg3p8a9am",
  "quantity": "1",
  "initial_mint_tx_hash": "1e48e0891c3d597b5c8973f7a507bcb7d009a217fa6ed9675d5e13289d869845",
  "mint_or_burn_count": 1,
  "onchain_metadata": {
    "name": "Allium",
    "image": "ipfs://k2cwuee3arxg398hwxx6c0iferxitu126xntuzg8t765oo020h5y6npn",
    "description": "From pixabay"
  },
  "onchain_metadata_standard": "CIP25v2",
  "metadata": null
}
```

Note that the `seabug/main` branch is significantly behind `develop`, however the only difference between the changes on that branch and on this PR's branch is the import locations.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
