### PR TITLE
Fix `fd` usage in Makefile to ignore inherited local system configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ SHELL := bash
 		query-testnet-tip clean check-explicit-exports
 .SHELLFLAGS := -eu -o pipefail -c
 
-ps-sources := $(shell fd -epurs -Etmp)
-nix-sources := $(shell fd -enix --exclude='spago*' -Etmp)
-js-sources := $(shell fd -ejs -Etmp)
+ps-sources := $(shell fd --no-ignore-parent -epurs)
+nix-sources := $(shell fd --no-ignore-parent -enix --exclude='spago*')
+js-sources := $(shell fd --no-ignore-parent -ejs)
 ps-entrypoint := Ctl.Examples.ByUrl # points to one of the example PureScript modules in examples/
 ps-bundle = spago bundle-module -m ${ps-entrypoint} --to output.js
 preview-node-ipc = $(shell docker volume inspect store_node-preview-ipc | jq -r '.[0].Mountpoint')


### PR DESCRIPTION
Also remove the `tmp` exclusion, because this is automatically
excluded as `tmp` is ignored in `.gitignore`

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included