### PR TITLE
Remove ctl-server port from test-nixos-configuration.nix

### DIFF
--- a/nix/test-nixos-configuration.nix
+++ b/nix/test-nixos-configuration.nix
@@ -6,8 +6,11 @@
     memorySize = 8192;
     diskSize = 100000;
     forwardPorts = [
+      # TODO What is this port for? SSH?
       { from = "host"; host.port = 2222; guest.port = 22; }
+      # Ogmios
       { from = "host"; host.port = 1337; guest.port = 1337; }
+      # Ogmios Datum Cache
       { from = "host"; host.port = 9999; guest.port = 9999; }
     ];
   };

--- a/nix/test-nixos-configuration.nix
+++ b/nix/test-nixos-configuration.nix
@@ -6,7 +6,7 @@
     memorySize = 8192;
     diskSize = 100000;
     forwardPorts = [
-      # TODO What is this port for? SSH?
+      # SSH
       { from = "host"; host.port = 2222; guest.port = 22; }
       # Ogmios
       { from = "host"; host.port = 1337; guest.port = 1337; }

--- a/nix/test-nixos-configuration.nix
+++ b/nix/test-nixos-configuration.nix
@@ -8,7 +8,6 @@
     forwardPorts = [
       { from = "host"; host.port = 2222; guest.port = 22; }
       { from = "host"; host.port = 1337; guest.port = 1337; }
-      { from = "host"; host.port = 8081; guest.port = 8081; }
       { from = "host"; host.port = 9999; guest.port = 9999; }
     ];
   };


### PR DESCRIPTION
Doesn't really matter, just noticed the port for ctl-server gets forwarded in the nixos config

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
