### PR TITLE
Disallow selecting inputs with inline datums/script refs when plutusv1 scripts are used during balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `blake2b224Hash` and `blake2b224HashHex` functions for computing blake2b-224 hashes of arbitrary byte arrays ([#1323](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1323))
 
 ### Changed
+- `Balancer` no longer selects UTxOs which use PlutusV2 features when the transaction contains PlutusV1 scripts ([#1349](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1349))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `blake2b224Hash` and `blake2b224HashHex` functions for computing blake2b-224 hashes of arbitrary byte arrays ([#1323](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1323))
 
 ### Changed
-- `Balancer` no longer selects UTxOs which use PlutusV2 features when the transaction contains PlutusV1 scripts ([#1349](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1349))
+- Balancer no longer selects UTxOs which use PlutusV2 features when the transaction contains PlutusV1 scripts ([#1349](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1349))
 
 ### Removed
 

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -60,13 +60,33 @@ import Contract.TxConstraints (TxConstraints)
 import Control.Monad.Error.Class (catchError, throwError)
 import Control.Monad.Reader (ReaderT, asks, runReaderT)
 import Control.Monad.Reader.Class (ask)
-import Ctl.Internal.BalanceTx (BalanceTxError) as BalanceTxError
 import Ctl.Internal.BalanceTx (FinalizedTransaction)
 import Ctl.Internal.BalanceTx
   ( FinalizedTransaction(FinalizedTransaction)
   ) as FinalizedTransaction
 import Ctl.Internal.BalanceTx (balanceTxWithConstraints) as BalanceTx
 import Ctl.Internal.BalanceTx.Constraints (BalanceTxConstraintsBuilder)
+import Ctl.Internal.BalanceTx.Error
+  ( Actual(Actual)
+  , BalanceTxError
+      ( BalanceInsufficientError
+      , CouldNotConvertScriptOutputToTxInput
+      , CouldNotGetChangeAddress
+      , CouldNotGetCollateral
+      , CouldNotGetUtxos
+      , CollateralReturnError
+      , CollateralReturnMinAdaValueCalcError
+      , ExUnitsEvaluationFailed
+      , InsufficientTxInputs
+      , InsufficientUtxoBalanceToCoverAsset
+      , ReindexRedeemersError
+      , UtxoLookupFailedFor
+      , UtxoMinAdaValueCalculationFailed
+      )
+  , Expected(Expected)
+  , ImpossibleError(Impossible)
+  , InvalidInContext(InvalidInContext)
+  ) as BalanceTxError
 import Ctl.Internal.Cardano.Types.NativeScript
   ( NativeScript
       ( ScriptPubkey

--- a/src/Internal/BalanceTx/BalanceTx.purs
+++ b/src/Internal/BalanceTx/BalanceTx.purs
@@ -291,7 +291,7 @@ runBalancer p = do
   -- We check if the transaction uses a plutusv1 script, so that we can filter
   -- out utxos which use plutusv2 features if so.
   txHasPlutusV1 :: Boolean
-  txHasPlutusV1 = do
+  txHasPlutusV1 =
     case p.unbalancedTx ^. _transaction' ^. _witnessSet ^. _plutusScripts of
       Just scripts -> flip Array.any scripts case _ of
         PlutusScript (_ /\ PlutusV1) -> true

--- a/src/Internal/BalanceTx/BalanceTx.purs
+++ b/src/Internal/BalanceTx/BalanceTx.purs
@@ -350,8 +350,7 @@ runBalancer p = do
           true ->
             if (Set.isEmpty $ balancedTx ^. _body' <<< _inputs) then do
               selectionState <-
-                performMultiAssetSelection p.strategy
-                  leftoverUtxos
+                performMultiAssetSelection p.strategy leftoverUtxos
                   (lovelaceValueOf one)
               runNextBalancerStep $ s
                 { transaction =

--- a/src/Internal/BalanceTx/BalanceTx.purs
+++ b/src/Internal/BalanceTx/BalanceTx.purs
@@ -118,6 +118,7 @@ import Ctl.Internal.Cardano.Types.Value
 import Ctl.Internal.CoinSelection.UtxoIndex (UtxoIndex, buildUtxoIndex)
 import Ctl.Internal.Helpers ((??))
 import Ctl.Internal.Partition (equipartition, partition)
+import Ctl.Internal.Plutus.Conversion (toPlutusValue)
 import Ctl.Internal.QueryM (QueryM, getProtocolParameters)
 import Ctl.Internal.QueryM (getChangeAddress, getWalletAddresses) as QueryM
 import Ctl.Internal.QueryM.Utxos
@@ -283,7 +284,8 @@ runBalancer p = do
   addInvalidInContext invalidInContext m = catchError m $ throwError <<<
     case _ of
       BalanceInsufficientError e a (InvalidInContext v) ->
-        BalanceInsufficientError e a (InvalidInContext (v <> invalidInContext))
+        BalanceInsufficientError e a
+          (InvalidInContext (v <> toPlutusValue invalidInContext))
       e -> e
 
   -- We check if the transaction uses a plutusv1 script, so that we can filter

--- a/src/Internal/BalanceTx/CoinSelection.purs
+++ b/src/Internal/BalanceTx/CoinSelection.purs
@@ -30,6 +30,7 @@ import Ctl.Internal.BalanceTx.Error
       )
   , Expected(Expected)
   , ImpossibleError(Impossible)
+  , InvalidInContext(InvalidInContext)
   )
 import Ctl.Internal.Cardano.Types.Transaction (UtxoMap)
 import Ctl.Internal.Cardano.Types.Value (AssetClass(AssetClass), Coin, Value)
@@ -128,7 +129,10 @@ performMultiAssetSelection
   -> UtxoIndex
   -> Value
   -> m SelectionState
-performMultiAssetSelection strategy utxoIndex requiredValue =
+performMultiAssetSelection
+  strategy
+  utxoIndex
+  requiredValue =
   case requiredValue `Value.leq` availableValue of
     true ->
       runRoundRobinM (mkSelectionState utxoIndex) selectors
@@ -138,6 +142,7 @@ performMultiAssetSelection strategy utxoIndex requiredValue =
   balanceInsufficientError :: BalanceTxError
   balanceInsufficientError =
     BalanceInsufficientError (Expected requiredValue) (Actual availableValue)
+      (InvalidInContext mempty)
 
   availableValue :: Value
   availableValue = balance (utxoIndexUniverse utxoIndex)

--- a/src/Internal/BalanceTx/CoinSelection.purs
+++ b/src/Internal/BalanceTx/CoinSelection.purs
@@ -129,10 +129,7 @@ performMultiAssetSelection
   -> UtxoIndex
   -> Value
   -> m SelectionState
-performMultiAssetSelection
-  strategy
-  utxoIndex
-  requiredValue =
+performMultiAssetSelection strategy utxoIndex requiredValue =
   case requiredValue `Value.leq` availableValue of
     true ->
       runRoundRobinM (mkSelectionState utxoIndex) selectors

--- a/src/Internal/BalanceTx/CoinSelection.purs
+++ b/src/Internal/BalanceTx/CoinSelection.purs
@@ -53,6 +53,7 @@ import Ctl.Internal.CoinSelection.UtxoIndex
   , utxoIndexPartition
   , utxoIndexUniverse
   )
+import Ctl.Internal.Plutus.Conversion (toPlutusValue)
 import Ctl.Internal.Types.ByteArray (byteArrayToHex)
 import Ctl.Internal.Types.TokenName (getTokenName) as TokenName
 import Ctl.Internal.Types.Transaction (TransactionInput)
@@ -138,8 +139,10 @@ performMultiAssetSelection strategy utxoIndex requiredValue =
   where
   balanceInsufficientError :: BalanceTxError
   balanceInsufficientError =
-    BalanceInsufficientError (Expected requiredValue) (Actual availableValue)
-      (InvalidInContext mempty)
+    BalanceInsufficientError
+      (Expected $ toPlutusValue requiredValue)
+      (Actual $ toPlutusValue availableValue)
+      (InvalidInContext $ toPlutusValue mempty)
 
   availableValue :: Value
   availableValue = balance (utxoIndexUniverse utxoIndex)

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -27,7 +27,7 @@ module Ctl.Internal.BalanceTx.Error
 import Prelude
 
 import Ctl.Internal.Cardano.Types.Transaction (Redeemer(Redeemer))
-import Ctl.Internal.Cardano.Types.Value (Value)
+import Ctl.Internal.Plutus.Types.Value (Value)
 import Ctl.Internal.QueryM.Ogmios
   ( RedeemerPointer
   , ScriptFailure

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -3,6 +3,7 @@
 -- | that may be returned from Ogmios when calculating ex units.
 module Ctl.Internal.BalanceTx.Error
   ( Actual(Actual)
+  , InvalidInContext(InvalidInContext)
   , BalanceTxError
       ( BalanceInsufficientError
       , CouldNotConvertScriptOutputToTxInput
@@ -68,7 +69,7 @@ import Data.Tuple.Nested (type (/\), (/\))
 
 -- | Errors conditions that may possibly arise during transaction balancing
 data BalanceTxError
-  = BalanceInsufficientError Expected Actual
+  = BalanceInsufficientError Expected Actual InvalidInContext
   | CouldNotConvertScriptOutputToTxInput
   | CouldNotGetChangeAddress
   | CouldNotGetCollateral
@@ -95,6 +96,14 @@ derive instance Generic Actual _
 derive instance Newtype Actual _
 
 instance Show Actual where
+  show = genericShow
+
+newtype InvalidInContext = InvalidInContext Value
+
+derive instance Generic InvalidInContext _
+derive instance Newtype InvalidInContext _
+
+instance Show InvalidInContext where
   show = genericShow
 
 newtype Expected = Expected Value

--- a/src/Internal/Test/E2E/Feedback/Node.purs
+++ b/src/Internal/Test/E2E/Feedback/Node.purs
@@ -96,7 +96,7 @@ subscribeToBrowserEvents page cont = do
   where
   -- How many times to try until we get any event?
   firstTimeConnectionAttempts :: Int
-  firstTimeConnectionAttempts = 10
+  firstTimeConnectionAttempts = 30
 
 getBrowserEvents
   :: Toppokki.Page -> Aff (Array BrowserEvent)

--- a/src/Internal/Types/ScriptLookups.purs
+++ b/src/Internal/Types/ScriptLookups.purs
@@ -583,8 +583,6 @@ type ConstraintsM (a :: Type) (b :: Type) =
 -- We could use `MonadError` to clean up the `ExceptT`s below although we can't
 -- use the type alias because they need to be fully applied so this is perhaps
 -- more readable.
--- Fix me: add execution units from Ogmios where this function should be
--- inside QueryM https://github.com/Plutonomicon/cardano-transaction-lib/issues/174
 -- | Resolve some `TxConstraints` by modifying the `UnbalancedTx` in the
 -- | `ConstraintProcessingState`
 processLookupsAndConstraints
@@ -1081,20 +1079,15 @@ processConstraint mpsMap osMap = do
       runExceptT $ _valueSpentBalancesOutputs <>= requireValue value
     MustSpendPubKeyOutput txo -> runExceptT do
       txOut <- ExceptT $ lookupTxOutRef txo Nothing
-      -- Recall an Ogmios datum is a `Maybe String` where `Nothing` implies a
-      -- wallet address and `Just` as script address.
       case txOut of
-        TransactionOutput { amount, datum: NoOutputDatum } -> do
+        TransactionOutput { amount } -> do
           -- POTENTIAL FIX ME: Plutus has Tx.TxIn and Tx.PubKeyTxIn -- TxIn
           -- keeps track TransactionInput and TxInType (the input type, whether
           -- consuming script, public key or simple script)
           _cpsToTxBody <<< _inputs %= Set.insert txo
           _valueSpentBalancesInputs <>= provideValue amount
-        _ -> throwError $ TxOutRefWrongType txo
     MustSpendScriptOutput txo red scriptRefUnspentOut -> runExceptT do
       txOut <- ExceptT $ lookupTxOutRef txo scriptRefUnspentOut
-      -- Recall an Ogmios datum is a `Maybe String` where `Nothing` implies a
-      -- wallet address and `Just` as script address.
       case txOut of
         TransactionOutput { datum: NoOutputDatum } ->
           throwError $ TxOutRefWrongType txo
@@ -1112,9 +1105,6 @@ processConstraint mpsMap osMap = do
                 ExceptT $ processScriptRefUnspentOut vHash scriptRefUnspentOut'
             -- Note: Plutus uses `TxIn` to attach a redeemer and datum.
             -- Use the datum hash inside the lookup
-            -- Note: if we get `Nothing`, we have to throw eventhough that's a
-            -- valid input, because our `txOut` above is a Script address via
-            -- `Just`.
             case datum' of
               OutputDatumHash dHash -> do
                 dat <- ExceptT do
@@ -1269,8 +1259,6 @@ processConstraint mpsMap osMap = do
                     , delegationCred: credentialToStakeCredential cred
                     }
             , amount
-            -- TODO: save correct and scriptRef, should be done in
-            -- Constraints API upgrade that follows Vasil
             , datum: datum'
             , scriptRef: scriptRef
             }

--- a/src/Internal/Types/ScriptLookups.purs
+++ b/src/Internal/Types/ScriptLookups.purs
@@ -1078,14 +1078,12 @@ processConstraint mpsMap osMap = do
       let value = fromPlutusValue plutusValue
       runExceptT $ _valueSpentBalancesOutputs <>= requireValue value
     MustSpendPubKeyOutput txo -> runExceptT do
-      txOut <- ExceptT $ lookupTxOutRef txo Nothing
-      case txOut of
-        TransactionOutput { amount } -> do
-          -- POTENTIAL FIX ME: Plutus has Tx.TxIn and Tx.PubKeyTxIn -- TxIn
-          -- keeps track TransactionInput and TxInType (the input type, whether
-          -- consuming script, public key or simple script)
-          _cpsToTxBody <<< _inputs %= Set.insert txo
-          _valueSpentBalancesInputs <>= provideValue amount
+      TransactionOutput { amount } <- ExceptT $ lookupTxOutRef txo Nothing
+      -- POTENTIAL FIX ME: Plutus has Tx.TxIn and Tx.PubKeyTxIn -- TxIn
+      -- keeps track TransactionInput and TxInType (the input type, whether
+      -- consuming script, public key or simple script)
+      _cpsToTxBody <<< _inputs %= Set.insert txo
+      _valueSpentBalancesInputs <>= provideValue amount
     MustSpendScriptOutput txo red scriptRefUnspentOut -> runExceptT do
       txOut <- ExceptT $ lookupTxOutRef txo scriptRefUnspentOut
       case txOut of

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -12,6 +12,7 @@ import Contract.Address
   , getWalletCollateral
   , ownPaymentPubKeysHashes
   , ownStakePubKeysHashes
+  , scriptHashAddress
   )
 import Contract.BalanceTxConstraints
   ( BalanceTxConstraintsBuilder
@@ -35,6 +36,7 @@ import Contract.PlutusData
   , getDatumByHash
   , getDatumsByHashes
   , getDatumsByHashesWithErrors
+  , unitRedeemer
   )
 import Contract.Prelude (liftM, mconcat)
 import Contract.Prim.ByteArray (byteArrayFromAscii, hexToByteArrayUnsafe)
@@ -57,8 +59,11 @@ import Contract.Time (getEraSummaries)
 import Contract.Transaction
   ( DataHash
   , NativeScript(ScriptPubkey, ScriptNOfK, ScriptAll)
+  , OutputDatum(OutputDatumHash, NoOutputDatum, OutputDatum)
   , ScriptRef(PlutusScriptRef, NativeScriptRef)
-  , TransactionHash
+  , TransactionHash(TransactionHash)
+  , TransactionInput(TransactionInput)
+  , TransactionOutput(TransactionOutput)
   , awaitTxConfirmed
   , balanceTx
   , balanceTxWithConstraints
@@ -71,8 +76,8 @@ import Contract.Transaction
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
-import Contract.Utxos (getWalletBalance, utxosAt)
-import Contract.Value (Coin(Coin), coinToValue)
+import Contract.Utxos (UtxoMap, getWalletBalance, utxosAt)
+import Contract.Value (Coin(Coin), Value, coinToValue)
 import Contract.Value as Value
 import Contract.Wallet (getWalletUtxos, isWalletAvailable, withKeyWallet)
 import Control.Monad.Error.Class (try)
@@ -111,12 +116,14 @@ import Ctl.Examples.Schnorr as Schnorr
 import Ctl.Examples.SendsToken (contract) as SendsToken
 import Ctl.Examples.TxChaining (contract) as TxChaining
 import Ctl.Internal.Plutus.Conversion.Address (toPlutusAddress)
+import Ctl.Internal.Plutus.Types.Address (Address, pubKeyHashAddress)
 import Ctl.Internal.Plutus.Types.Transaction
   ( TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   )
 import Ctl.Internal.Plutus.Types.TransactionUnspentOutput
   ( TransactionUnspentOutput(TransactionUnspentOutput)
   , _input
+  , _output
   , lookupTxHash
   )
 import Ctl.Internal.Plutus.Types.Value (lovelaceValueOf)
@@ -132,14 +139,16 @@ import Ctl.Internal.Wallet.Cip30Mock
   )
 import Data.Array (head, (!!))
 import Data.BigInt as BigInt
-import Data.Either (Either(Right), isLeft)
+import Data.Either (Either(Right), isLeft, isRight)
 import Data.Foldable (fold, foldM, length)
 import Data.Lens (view)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), isJust)
 import Data.Newtype (unwrap, wrap)
 import Data.Traversable (traverse, traverse_)
+import Data.Tuple (Tuple(Tuple))
 import Data.Tuple.Nested (type (/\), (/\))
+import Data.UInt (UInt)
 import Effect.Class (liftEffect)
 import Effect.Exception (error, throw)
 import Mote (group, skip, test)
@@ -918,6 +927,104 @@ suite = do
           ]
       withWallets distribution \alice -> do
         withKeyWallet alice SendsToken.contract
+
+    test "PlutusV1 forces balancer to select non-PlutusV2 inputs" do
+      let
+        distribution :: InitialUTxOs
+        distribution = [ BigInt.fromInt 5_000_000 ]
+
+      withWallets distribution \alice -> do
+        alicePkh <- withKeyWallet alice do
+          liftedM "Could not get own PKH" (head <$> ownPaymentPubKeysHashes)
+
+        validator <- AlwaysSucceeds.alwaysSucceedsScript
+
+        let
+          vhash = validatorHash validator
+          scriptAddress = scriptHashAddress vhash Nothing
+
+        let
+          datum42 = Datum $ Integer $ BigInt.fromInt 42
+
+        datum42Hash <- liftM (error "Failed to hash datum") $ datumHash datum42
+        datum42Lookup <- liftM (error "Could not make lookup") $ Lookups.datum
+          datum42
+
+        let
+          transactionId :: TransactionHash
+          transactionId = TransactionHash $ hexToByteArrayUnsafe
+            "a6b656487601c390a3bb61958c62369cb5d5a7597a68a9dccedb3dd68a60bfdd"
+
+          mkUtxo
+            :: UInt
+            -> Address
+            -> Value
+            -> OutputDatum
+            -> TransactionUnspentOutput
+          mkUtxo index address amount datum =
+            TransactionUnspentOutput
+              { input: TransactionInput
+                  { index
+                  , transactionId
+                  }
+              , output: TransactionOutputWithRefScript
+                  { scriptRef: Nothing
+                  , output: TransactionOutput
+                      { address
+                      , amount
+                      , datum
+                      , referenceScript: Nothing
+                      }
+                  }
+              }
+
+          aliceUtxo :: OutputDatum -> TransactionUnspentOutput
+          aliceUtxo = mkUtxo zero
+            (pubKeyHashAddress alicePkh Nothing)
+            (Value.lovelaceValueOf $ BigInt.fromInt 50_000_000)
+
+          alwaysSucceedsUtxo :: TransactionUnspentOutput
+          alwaysSucceedsUtxo = mkUtxo one
+            scriptAddress
+            (Value.lovelaceValueOf $ BigInt.fromInt 2_000_000)
+            (OutputDatumHash datum42Hash)
+
+          -- Balance a transaction which requires selecting a utxo with a
+          -- certain datum
+          balanceWithDatum datum = withKeyWallet alice do
+            let
+              additionalUtxos :: UtxoMap
+              additionalUtxos =
+                Map.fromFoldable $ (Tuple <$> view _input <*> view _output) <$>
+                  [ alwaysSucceedsUtxo, aliceUtxo datum ]
+
+              value :: Value.Value
+              value = Value.lovelaceValueOf $ BigInt.fromInt 50_000_000
+
+              constraints :: TxConstraints Unit Unit
+              constraints = fold
+                [ Constraints.mustSpendScriptOutput
+                    (view _input alwaysSucceedsUtxo)
+                    unitRedeemer
+                , Constraints.mustPayToPubKey alicePkh value
+                ]
+
+              lookups :: Lookups.ScriptLookups PlutusData
+              lookups =
+                Lookups.validator validator
+                  <> Lookups.unspentOutputs additionalUtxos
+                  <> datum42Lookup
+
+              balanceTxConstraints
+                :: BalanceTxConstraints.BalanceTxConstraintsBuilder
+              balanceTxConstraints =
+                BalanceTxConstraints.mustUseAdditionalUtxos additionalUtxos
+
+            unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            balanceTxWithConstraints unbalancedTx balanceTxConstraints
+
+        balanceWithDatum NoOutputDatum >>= flip shouldSatisfy isRight
+        balanceWithDatum (OutputDatum datum42) >>= flip shouldSatisfy isLeft
 
     test "InlineDatum" do
       let


### PR DESCRIPTION
Closes #1349.

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
