### PR TITLE
Fix OutputDatum decoding instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - CIP-25 strings are now being split into chunks whose sizes are less than or equal to 64 to adhere to the CIP-25 standard ([#1343](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1343))
 - Critical upstream fix in [`purescript-bignumber`](https://github.com/mlabs-haskell/purescript-bignumber/pull/2)
-- `OutputDatum` aeson encoding now roundtrips
+- `OutputDatum` aeson encoding now roundtrips ([#1388](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1388))
 
 ### Runtime Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - CIP-25 strings are now being split into chunks whose sizes are less than or equal to 64 to adhere to the CIP-25 standard ([#1343](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1343))
 - Critical upstream fix in [`purescript-bignumber`](https://github.com/mlabs-haskell/purescript-bignumber/pull/2)
+- `OutputDatum` aeson encoding now roundtrips
 
 ### Runtime Dependencies
 

--- a/src/Internal/Types/OutputDatum.purs
+++ b/src/Internal/Types/OutputDatum.purs
@@ -77,7 +77,7 @@ instance DecodeAeson OutputDatum where
           pure $ OutputDatumHash dataHash
         "OutputDatum" -> do
           datum <- obj .: "contents"
-          pure $ OutputDatumHash datum
+          pure $ OutputDatum datum
         tagValue -> do
           Left $ UnexpectedValue $ toStringifiedNumbersJson $ fromString
             tagValue


### PR DESCRIPTION
Closes # .

Fix typo causing `OutputDatum` not being able to be decoded

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
