### PR TITLE
allow keeping bundle-module output in nix bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+- `bundlePursProject` allows passing of `includeBundledModule` flag to export the bundled JS module `spago bundle-module` outputs
+
 - `Contract.Transaction` exports `mkPoolPubKeyHash` and `poolPubKeyHashToBech32` for bech32 roundtripping ([#1360](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1360))
 
 ### Changed

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -389,6 +389,8 @@ let
       # Generated `node_modules` in the Nix store. Can be passed to have better
       # control over individual project components
     , nodeModules ? projectNodeModules
+      # If the spago bundle-module output should be included in the derivation
+    , includeBundledModule ? false
     , ...
     }: pkgs.runCommand "${name}"
       {
@@ -412,6 +414,7 @@ let
         spago bundle-module --no-install --no-build -m "${main}" \
           --to ${bundledModuleName}
         mkdir ./dist
+        ${pkgs.lib.optionalString includeBundledModule "cp ${bundledModuleName} ./dist"}
         webpack --mode=production -c ${webpackConfig} -o ./dist \
           --entry ./${entrypoint}
         mkdir $out


### PR DESCRIPTION
This is a relatively tiny change that adds some flexibility to the bundling nix code. When creating a bundle, we currently force the use of webpack, which is totally fine, but we don't make it possible to export the `spago bundle-module` output. This small change adds a flag which allows it to be included in the `dist` folder.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
