### PR TITLE
Fix wrong constructor call in reconnecting-websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CIP-25 strings are now being split into chunks whose sizes are less than or equal to 64 to adhere to the CIP-25 standard ([#1343](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1343))
 - Critical upstream fix in [`purescript-bignumber`](https://github.com/mlabs-haskell/purescript-bignumber/pull/2)
 - `OutputDatum` aeson encoding now roundtrips ([#1388](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1388))
+- `reconnecting-websocket` calling correct constructor in node environment
 
 ### Runtime Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CIP-25 strings are now being split into chunks whose sizes are less than or equal to 64 to adhere to the CIP-25 standard ([#1343](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1343))
 - Critical upstream fix in [`purescript-bignumber`](https://github.com/mlabs-haskell/purescript-bignumber/pull/2)
 - `OutputDatum` aeson encoding now roundtrips ([#1388](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1388))
-- `reconnecting-websocket` calling correct constructor in node environment
+- `reconnecting-websocket` calling correct constructor in node environment ([#1399](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1399))
 
 ### Runtime Dependencies
 

--- a/src/Internal/JsWebSocket.js
+++ b/src/Internal/JsWebSocket.js
@@ -23,7 +23,7 @@ exports._mkWebSocket = logger => url => () => {
     if (typeof BROWSER_RUNTIME != "undefined" && BROWSER_RUNTIME) {
       ws = new ReconnectingWebSocket.default(url);
     } else {
-      ws = new ReconnectingWebSocket(url, [], {
+      ws = new ReconnectingWebSocket.default(url, [], {
         WebSocket: NoPerMessageDeflateWebSocket,
       });
     }


### PR DESCRIPTION
Closes # .

Fixes `reconnecting-websocket` constructor call in node environment

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
