### PR TITLE
Include cluster startup failure detials into `startPlutipCluster` error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
-- `startPlutipCluster` error message now includes cluster startup failure details. ([#1406](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1406))
+- `startPlutipCluster` error message now includes cluster startup failure details. ([#1407](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1407))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
+- `startPlutipCluster` error message now includes cluster startup failure details. ([#1406](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1406))
+
 ### Removed
 
 ### Fixed

--- a/src/Internal/Plutip/Server.purs
+++ b/src/Internal/Plutip/Server.purs
@@ -492,8 +492,9 @@ startPlutipCluster cfg keysToGenerate = do
         $ (decodeAeson <=< parseJsonStringToAeson) body
   either (liftEffect <<< throw <<< show) pure res >>=
     case _ of
-      ClusterStartupFailure _ -> do
-        liftEffect $ throw "Failed to start up cluster"
+      ClusterStartupFailure reason -> do
+        liftEffect $ throw $
+          "Failed to start up cluster. Reason: " <> show reason
       ClusterStartupSuccess response@{ privateKeys } ->
         case Array.uncons privateKeys of
           Nothing ->


### PR DESCRIPTION
Closes #1405.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
