### PR TITLE
Fix redeemer indexing problem in staking constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - CIP-25 strings are now being split into chunks whose sizes are less than or equal to 64 to adhere to the CIP-25 standard ([#1343](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1343))
 - Critical upstream fix in [`purescript-bignumber`](https://github.com/mlabs-haskell/purescript-bignumber/pull/2)
 - `OutputDatum` aeson encoding now roundtrips ([#1388](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1388))
+- Fix incorrect redeemer indexing for Plutus stake validator scripts ([#1417](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1417))
 
 ### Runtime Dependencies
 

--- a/src/Internal/Types/ScriptLookups.purs
+++ b/src/Internal/Types/ScriptLookups.purs
@@ -249,14 +249,14 @@ import Ctl.Internal.Types.UnbalancedTransaction
   , emptyUnbalancedTx
   )
 import Data.Array (cons, filter, mapWithIndex, partition, toUnfoldable, zip)
-import Data.Array (singleton, union, (:)) as Array
+import Data.Array (length, singleton, union, (:)) as Array
 import Data.Bifunctor (lmap)
 import Data.BigInt (BigInt, fromInt)
 import Data.Either (Either(Left, Right), either, isRight, note)
 import Data.Foldable (foldM)
 import Data.Generic.Rep (class Generic)
 import Data.Lattice (join)
-import Data.Lens (non, (%=), (%~), (.=), (.~), (<>=))
+import Data.Lens (non, view, (%=), (%~), (.=), (.~), (<>=))
 import Data.Lens.Getter (to, use)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
@@ -1299,19 +1299,19 @@ processConstraint mpsMap osMap = do
       if dh' == dh then addDatum dt
       else pure $ throwError $ DatumWrongHash dh dt
     MustRegisterStakePubKey skh -> runExceptT do
-      lift $ addCertificate
+      void $ lift $ addCertificate
         $ StakeRegistration
         $ keyHashCredential
         $ unwrap
         $ unwrap skh
     MustDeregisterStakePubKey pubKey -> runExceptT do
-      lift $ addCertificate
+      void $ lift $ addCertificate
         $ StakeDeregistration
         $ keyHashCredential
         $ unwrap
         $ unwrap pubKey
     MustRegisterStakeScript scriptHash -> runExceptT do
-      lift $ addCertificate
+      void $ lift $ addCertificate
         $ StakeRegistration
         $ scriptHashCredential
         $ unwrap scriptHash
@@ -1321,29 +1321,30 @@ processConstraint mpsMap osMap = do
           ( scriptHashCredential $ unwrap $ plutusScriptStakeValidatorHash
               plutusScript
           )
+      index <- lift $ addCertificate cert
+      let
         redeemer = T.Redeemer
           { tag: Cert
-          , index: zero -- hardcoded and tweaked after balancing.
+          , index: fromInt index
           , "data": unwrap redeemerData
           , exUnits: zero
           }
       ExceptT $ attachToCps attachPlutusScript (unwrap plutusScript)
       ExceptT $ attachToCps attachRedeemer redeemer
-      _redeemersTxIns <>= Array.singleton (redeemer /\ Nothing)
-      lift $ addCertificate cert
+      _redeemersTxIns <>= Array.singleton (redeemer /\ Nothing) -- TODO: is needed?
     MustDeregisterStakeNativeScript stakeValidator -> do
-      addCertificate $ StakeDeregistration
+      void $ addCertificate $ StakeDeregistration
         $ scriptHashCredential
         $ unwrap
         $ nativeScriptStakeValidatorHash
             stakeValidator
       attachToCps attachNativeScript (unwrap stakeValidator)
     MustRegisterPool poolParams -> runExceptT do
-      lift $ addCertificate $ PoolRegistration poolParams
+      void $ lift $ addCertificate $ PoolRegistration poolParams
     MustRetirePool poolKeyHash epoch -> runExceptT do
-      lift $ addCertificate $ PoolRetirement { poolKeyHash, epoch }
+      void $ lift $ addCertificate $ PoolRetirement { poolKeyHash, epoch }
     MustDelegateStakePubKey stakePubKeyHash poolKeyHash -> runExceptT do
-      lift $ addCertificate $
+      void $ lift $ addCertificate $
         StakeDelegation (keyHashCredential $ unwrap $ unwrap $ stakePubKeyHash)
           poolKeyHash
     MustDelegateStakePlutusScript stakeValidator redeemerData poolKeyHash ->
@@ -1354,18 +1355,19 @@ processConstraint mpsMap osMap = do
                 stakeValidator
             )
             poolKeyHash
+        ix <- lift $ addCertificate cert
+        let
           redeemer = T.Redeemer
             { tag: Cert
-            , index: zero -- hardcoded and tweaked after balancing.
+            , index: fromInt ix
             , "data": unwrap redeemerData
             , exUnits: zero
             }
         ExceptT $ attachToCps attachPlutusScript (unwrap stakeValidator)
         ExceptT $ attachToCps attachRedeemer redeemer
-        _redeemersTxIns <>= Array.singleton (redeemer /\ Nothing)
-        lift $ addCertificate cert
+        _redeemersTxIns <>= Array.singleton (redeemer /\ Nothing) -- TODO: is needed?
     MustDelegateStakeNativeScript stakeValidator poolKeyHash -> do
-      addCertificate $ StakeDelegation
+      void $ addCertificate $ StakeDelegation
         ( scriptHashCredential $ unwrap $ nativeScriptStakeValidatorHash
             stakeValidator
         )
@@ -1483,12 +1485,16 @@ addDatum dat = runExceptT do
   ExceptT $ attachToCps attachDatum dat
   _datums <>= Array.singleton dat
 
+-- | Returns an index pointing to the location of the newly inserted certificate
+-- | in the array of transaction certificates.
 addCertificate
   :: forall (a :: Type)
    . Certificate
-  -> ConstraintsM a Unit
-addCertificate cert =
+  -> ConstraintsM a Int
+addCertificate cert = do
+  ix <- gets (view (_cpsToTxBody <<< _certs <<< non [] <<< to Array.length))
   _cpsToTxBody <<< _certs <<< non [] %= Array.(:) cert
+  pure ix
 
 -- Helper to focus from `ConstraintProcessingState` down to `Transaction`.
 _cpsToTransaction


### PR DESCRIPTION
There is a problem with redeemers for stake validators: redeemers were not. in fact, reindexed in the balancer. The index in the redeemer with `Cert` type should point to the corresponding certificate in the array of certificates.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
