### PR TITLE
Fix available UTxO set selection in cip30 mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - `ConnectToNuFi` now reexported in `Contract.Wallet` ([#1435](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1435))
+- Fix a bug in UTxO selection in `Cip30Mock` (only affects Cip30Mock users) ([1437](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1437))
 
 ### Removed
 

--- a/examples/SignMultiple.purs
+++ b/examples/SignMultiple.purs
@@ -7,7 +7,7 @@ import Contract.Prelude
 
 import Contract.Address (ownPaymentPubKeysHashes, ownStakePubKeysHashes)
 import Contract.Config (ContractParams, testnetNamiConfig)
-import Contract.Log (logInfo')
+import Contract.Log (logInfo', logWarn')
 import Contract.Monad
   ( Contract
   , launchAff_
@@ -21,8 +21,10 @@ import Contract.Transaction
   ( BalancedSignedTransaction
   , TransactionHash
   , awaitTxConfirmed
+  , awaitTxConfirmedWithTimeout
   , signTransaction
   , submit
+  , submitTxFromConstraints
   , withBalancedTxs
   )
 import Contract.TxConstraints as Constraints
@@ -54,8 +56,9 @@ contract = do
     ownStakePubKeysHashes
 
   -- Early fail if not enough utxos present for 2 transactions
-  unlessM hasSufficientUtxos $ throwContractError
-    "Insufficient Utxos for 2 transactions"
+  unlessM hasSufficientUtxos do
+    logWarn' "Insufficient Utxos for 2 transactions"
+    createAdditionalUtxos
 
   let
     constraints :: Constraints.TxConstraints Void Void
@@ -107,6 +110,33 @@ contract = do
       <$> getWalletUtxos
 
     pure $ length walletValidUtxos >= 2 -- 2 transactions
+
+createAdditionalUtxos :: Contract Unit
+createAdditionalUtxos = do
+  logInfo' "Creating additional UTxOs for SignMultiple example"
+  pkh <- liftedM "Failed to get own PKH" $ head <$> ownPaymentPubKeysHashes
+  skh <- liftedM "Failed to get own SKH" $ join <<< head <$>
+    ownStakePubKeysHashes
+
+  let
+    constraints :: Constraints.TxConstraints Void Void
+    constraints =
+      Constraints.mustPayToPubKeyAddress pkh skh
+        ( Value.lovelaceValueOf
+            $ BigInt.fromInt 2_000_000
+        ) <>
+        Constraints.mustPayToPubKeyAddress pkh skh
+          ( Value.lovelaceValueOf
+              $ BigInt.fromInt 2_000_000
+          )
+
+    lookups :: Lookups.ScriptLookups Void
+    lookups = mempty
+
+  txId <- submitTxFromConstraints lookups constraints
+
+  awaitTxConfirmedWithTimeout (wrap 100.0) txId
+  logInfo' $ "Tx submitted successfully!"
 
 example :: ContractParams -> Effect Unit
 example cfg = launchAff_ do

--- a/src/Internal/Wallet/Cip30Mock.purs
+++ b/src/Internal/Wallet/Cip30Mock.purs
@@ -154,10 +154,11 @@ mkCip30Mock pKey mSKey = do
         utxos <- ownUtxos
         collateralUtxos <- getCollateralUtxos utxos
         let
-          -- filter UTxOs that will be used as collateral
+          -- filter out UTxOs that will be used as collateral
           nonCollateralUtxos =
             Map.filter
-              (flip Array.elem (collateralUtxos <#> unwrap >>> _.output))
+              (\utxo ->
+                not $ Array.elem utxo (collateralUtxos <#> unwrap >>> _.output))
               utxos
         -- Convert to CSL representation and serialize
         cslUtxos <- traverse (liftEffect <<< convertTransactionUnspentOutput)

--- a/src/Internal/Wallet/Cip30Mock.purs
+++ b/src/Internal/Wallet/Cip30Mock.purs
@@ -154,12 +154,10 @@ mkCip30Mock pKey mSKey = do
         utxos <- ownUtxos
         collateralUtxos <- getCollateralUtxos utxos
         let
+          collateralOutputs = collateralUtxos <#> unwrap >>> _.output
           -- filter out UTxOs that will be used as collateral
           nonCollateralUtxos =
-            Map.filter
-              (\utxo ->
-                not $ Array.elem utxo (collateralUtxos <#> unwrap >>> _.output))
-              utxos
+            Map.filter (not <<< flip Array.elem collateralOutputs) utxos
         -- Convert to CSL representation and serialize
         cslUtxos <- traverse (liftEffect <<< convertTransactionUnspentOutput)
           $ Map.toUnfoldable nonCollateralUtxos <#> \(input /\ output) ->


### PR DESCRIPTION
Boolean inversion bug: we want to filter out collateral UTxOs, not leave only them.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
