### PR TITLE
add FromBytes for Vkeywitness and Vkeywitnesses

### DIFF
--- a/src/Internal/Deserialization/FromBytes.purs
+++ b/src/Internal/Deserialization/FromBytes.purs
@@ -38,6 +38,8 @@ import Ctl.Internal.Serialization.Types
   , TransactionUnspentOutput
   , TransactionWitnessSet
   , Value
+  , Vkeywitness
+  , Vkeywitnesses
   )
 import Ctl.Internal.Types.ByteArray (ByteArray)
 import Ctl.Internal.Types.CborBytes (CborBytes)
@@ -132,6 +134,12 @@ instance FromBytes Value where
 
 instance FromBytes VRFKeyHash where
   fromBytes' = fromBytesImpl "VRFKeyHash"
+
+instance FromBytes Vkeywitness where
+  fromBytes' = fromBytesImpl "Vkeywitness"
+
+instance FromBytes Vkeywitnesses where
+  fromBytes' = fromBytesImpl "Vkeywitnesses"
 
 -- for backward compatibility until `Maybe` is abandoned. Then to be renamed.
 fromBytes :: forall (a :: Type). FromBytes a => CborBytes -> Maybe a

--- a/src/Internal/Serialization/ToBytes.purs
+++ b/src/Internal/Serialization/ToBytes.purs
@@ -29,6 +29,8 @@ import Ctl.Internal.Serialization.Types
   , TransactionUnspentOutput
   , TransactionWitnessSet
   , Value
+  , Vkeywitness
+  , Vkeywitnesses
   )
 import Ctl.Internal.Types.ByteArray (ByteArray)
 import Ctl.Internal.Types.CborBytes (CborBytes(CborBytes))
@@ -59,6 +61,8 @@ type SerializableData = Address
   |+| TransactionWitnessSet
   |+| Value
   |+| VRFKeyHash
+  |+| Vkeywitness
+  |+| Vkeywitnesses
 
 -- Add more as needed
 

--- a/test/Deserialization.purs
+++ b/test/Deserialization.purs
@@ -2,7 +2,7 @@ module Test.Ctl.Deserialization (suite) where
 
 import Prelude
 
-import Contract.Address (ByteArray)
+import Contract.Prim.ByteArray (ByteArray)
 import Contract.TextEnvelope
   ( TextEnvelope(TextEnvelope)
   , TextEnvelopeType(Other)
@@ -12,11 +12,12 @@ import Control.Monad.Error.Class (class MonadThrow, liftMaybe)
 import Ctl.Examples.OtherTypeTextEnvelope (otherTypeTextEnvelope)
 import Ctl.Internal.Cardano.Types.NativeScript (NativeScript(ScriptAny)) as T
 import Ctl.Internal.Cardano.Types.Transaction (Transaction, TransactionOutput) as T
+import Ctl.Internal.Cardano.Types.Transaction (Vkeywitness)
 import Ctl.Internal.Cardano.Types.TransactionUnspentOutput
   ( TransactionUnspentOutput(TransactionUnspentOutput)
   ) as T
 import Ctl.Internal.Deserialization.BigInt as DB
-import Ctl.Internal.Deserialization.FromBytes (fromBytes)
+import Ctl.Internal.Deserialization.FromBytes (fromBytes, fromBytesEffect)
 import Ctl.Internal.Deserialization.NativeScript as NSD
 import Ctl.Internal.Deserialization.PlutusData as DPD
 import Ctl.Internal.Deserialization.Transaction (convertTransaction) as TD
@@ -30,8 +31,11 @@ import Ctl.Internal.Serialization (convertTxInput, convertTxOutput) as Serializa
 import Ctl.Internal.Serialization.BigInt as SB
 import Ctl.Internal.Serialization.NativeScript (convertNativeScript) as NSS
 import Ctl.Internal.Serialization.PlutusData as SPD
+import Ctl.Internal.Serialization.ToBytes (toBytes)
 import Ctl.Internal.Serialization.ToBytes (toBytes) as Serialization
 import Ctl.Internal.Serialization.Types (TransactionUnspentOutput)
+import Ctl.Internal.Serialization.Types (Vkeywitness) as Serialization
+import Ctl.Internal.Serialization.WitnessSet (convertVkeywitness) as Serialization
 import Ctl.Internal.Serialization.WitnessSet as SW
 import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.BigNum (fromBigInt, toBigInt) as BigNum
@@ -39,8 +43,10 @@ import Ctl.Internal.Types.Transaction (TransactionInput) as T
 import Data.Array as Array
 import Data.BigInt as BigInt
 import Data.Either (hush)
+import Data.Foldable (fold)
 import Data.Maybe (isJust, isNothing)
 import Data.Newtype (unwrap, wrap)
+import Data.Traversable (traverse)
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Class (class MonadEffect, liftEffect)
@@ -203,6 +209,21 @@ suite = do
           liftEffect $ testNativeScript longNativeScript
     group "WitnessSet - deserialization is inverse to serialization" do
       let
+        vkeyWitnessesRoundtrip
+          :: ∀ (m :: Type -> Type)
+           . MonadEffect m
+          => MonadThrow Error m
+          => Array Vkeywitness
+          -> m Unit
+        vkeyWitnessesRoundtrip vks = do
+          cslVks <- traverse (liftEffect <<< Serialization.convertVkeywitness)
+            vks
+          let cslVksBytes = toBytes <$> cslVks
+          (_ :: Array Serialization.Vkeywitness) <- traverse
+            (liftEffect <<< fromBytesEffect)
+            cslVksBytes
+          pure unit
+
         witnessSetRoundTrip
           :: ∀ (m :: Type -> Type)
            . MonadEffect m
@@ -214,6 +235,8 @@ suite = do
             fromBytes (wrap fixture) >>= convertWitnessSet
           ws1 <- liftEffect $ SW.convertWitnessSet ws0
           ws2 <- errMaybe "Failed deserialization" $ convertWitnessSet ws1
+          let vkeys = fold (unwrap ws2).vkeys
+          vkeyWitnessesRoundtrip vkeys
           ws0 `shouldEqual` ws2 -- value representation
           let wsBytes = unwrap $ Serialization.toBytes ws1
           wsBytes `shouldEqual` fixture -- byte representation


### PR DESCRIPTION
This PR adds two instances for `FromBytes`: `Vkeywitness` and `Vkeywitnesses`. These instances can be made because CSL exports `.from_bytes` for these types.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
