### PR TITLE
Derive `Ring`-like numeric instances for `Coin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [Unreleased]
 
 ### Added
-
+- Added several `Ring`-like numeric instances for `Coin` ([#1485](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1485))
 - **[IMPORTANT]** New machinery to achieve better synchronization between wallets and query layer has been added. This affects all CTL-based apps when light wallet browser extensions are in use. See [here](./doc/query-layers.md) for more info ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))
 - **Local Blockfrost runtime** based on [run-your-own version of Blockfrost](https://github.com/blockfrost/blockfrost-backend-ryo/) - see [here](./doc/blockfrost.md#running-blockfrost-locally) for more info ([#1395](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1395))
 - **Lace wallet support** - ([#1477](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1477))

--- a/src/Internal/Cardano/Types/Value.purs
+++ b/src/Internal/Cardano/Types/Value.purs
@@ -131,7 +131,7 @@ import Test.QuickCheck.Gen (Gen, chooseInt, suchThat, vectorOf)
 -- to `split` and `negate` (it's just 6 functions) in total without the need of
 -- a somewhat meaningless typeclass.
 
--- We could write a Ring instance to get `negate` but I'm not sure this would
+-- We could write a Group instance to get `negate` but I'm not sure this would
 -- make much sense for Value. Plutus uses a custom AdditiveGroup.
 -- We could define a Data.Group although zero-valued tokens don't degenerate
 -- from our map currently - I don't think we'd want this behaviour.
@@ -160,6 +160,10 @@ derive newtype instance Ord Coin
 derive newtype instance DecodeAeson Coin
 derive newtype instance EncodeAeson Coin
 derive newtype instance Equipartition Coin
+derive newtype instance Semiring Coin
+derive newtype instance Ring Coin
+derive newtype instance CommutativeRing Coin
+derive newtype instance EuclideanRing Coin
 
 instance Arbitrary Coin where
   arbitrary = Coin <<< fromInt <$> suchThat arbitrary (_ >= zero)


### PR DESCRIPTION
Closes #1485.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
