### PR TITLE
Set project.name explicitly in buildCtlRuntime

### DIFF
--- a/nix/runtime.nix
+++ b/nix/runtime.nix
@@ -245,6 +245,7 @@ rec {
       } else { });
     in
     {
+      project.name = "ctl-runtime";
       docker-compose.raw = pkgs.lib.recursiveUpdate
         {
           volumes = {


### PR DESCRIPTION
Sets explicitly an optional `project.name` setting.
This doesn't change much, but makes the `buildCtlRuntime` definition compatible with newer versions of `nixpkgs.arion` (see their [CHANGELOG](https://github.com/hercules-ci/arion/blob/main/CHANGELOG.md#breaking)).

### Pre-commit checklist

 - [x] Code is formatted with `make format`
 - [x] `nix run .#ctl-runtime` still succeeds, and succeeds after nixpkgs bump