### PR TITLE
Update plutip test limitations doc

### DIFF
--- a/doc/plutip-testing.md
+++ b/doc/plutip-testing.md
@@ -192,7 +192,8 @@ You can run Plutip tests via CTL's `purescriptProject` as well. After creating y
 
 ### Limitations
 
-Non-default values of `slotLength` and `epochSize` break staking rewards - see [this issue](https://github.com/mlabs-haskell/plutip/issues/149) for more info.
+Non-default value of `epochSize` (current default is 80) break staking rewards - see [this issue](https://github.com/mlabs-haskell/plutip/issues/149) for more info.
+`slotLength` can be changed without any problems.
 
 ## Using addresses with staking key components
 


### PR DESCRIPTION
I've checked various `slotLength` values and it doesn't seem to break staking tests (had to un`skip` the `skip`ped ones), while non-default `epochSize` does.

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
