### PR TITLE
Add `plutarch-ctl-bridge` docs

### DIFF
--- a/doc/importing-scripts.md
+++ b/doc/importing-scripts.md
@@ -8,6 +8,7 @@
 - [Serializing Plutus scripts](#serializing-plutus-scripts)
   - [PlutusTx](#plutustx)
   - [Plutarch](#plutarch)
+  - [plutarch-ctl-bridge](#plutarch-ctl-bridge)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Importing serialized scripts
@@ -138,3 +139,7 @@ Note that we specified plutus version.
 ### Plutarch
 
 You can use [`ply`](https://github.com/mlabs-haskell/ply) and [`ply-ctl`](https://github.com/mlabs-haskell/ply-ctl).
+
+### plutarch-ctl-bridge
+
+You can use [`plutarch-ctl-bridge`](https://github.com/mlabs-haskell/plutarch-ctl-bridge) to generate Purescript types from your Haskell type definitions and typed script wrappers from parametrized Plutarch scripts. See [example module](https://github.com/mlabs-haskell/plutarch-ctl-bridge/blob/main/example/Main.hs).


### PR DESCRIPTION
Add https://github.com/mlabs-haskell/plutarch-ctl-bridge links to script section in the documentation.

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
