### PR TITLE
Add `RefInputUnchecked` that allows referencing only with `TransactionInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - [HD wallet support](./doc/key-management.md) with mnemonic seed phrases ([#1498](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1498))
 - Ogmios-specific functions for Local TX Monitor Ouroboros Mini-Protocol in `Contract.Backend.Ogmios` ([#1508](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1508/))
 - New `mustSendChangeWithDatum` balancer constraint that adds datum to all change outputs ([#1510](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1510/))
+- New `RefInputUnchecked` that allows referencing utxo only with `TransactionInput` ([#1519](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1519))
 
 ### Changed
 

--- a/examples/PlutusV2/ReferenceInputsAndScripts.purs
+++ b/examples/PlutusV2/ReferenceInputsAndScripts.purs
@@ -43,7 +43,7 @@ import Contract.Transaction
   )
 import Contract.TxConstraints
   ( DatumPresence(DatumWitness)
-  , InputWithScriptRef(RefInput)
+  , InputWithScriptRef(RefInput, RefInputUnchecked)
   , TxConstraints
   )
 import Contract.TxConstraints as Constraints
@@ -155,7 +155,7 @@ spendFromAlwaysSucceeds vhash txId validator mp tokenName = do
           (RefInput $ mkTxUnspentOut refValidatorInput refValidatorOutput)
 
       , Constraints.mustMintCurrencyUsingScriptRef mph tokenName one
-          (RefInput $ mkTxUnspentOut refMpInput refMpOutput)
+          (RefInputUnchecked refMpInput)
       ]
 
     lookups :: Lookups.ScriptLookups PlutusData

--- a/src/Contract/TxConstraints.purs
+++ b/src/Contract/TxConstraints.purs
@@ -5,7 +5,7 @@ module Contract.TxConstraints (module TxConstraints) where
 import Ctl.Internal.Types.TxConstraints
   ( DatumPresence(DatumInline, DatumWitness)
   , InputConstraint(InputConstraint)
-  , InputWithScriptRef(RefInput, SpendInput)
+  , InputWithScriptRef(RefInput, RefInputUnchecked, SpendInput)
   , OutputConstraint(OutputConstraint)
   , TxConstraints(TxConstraints)
   , addTxIn


### PR DESCRIPTION


Closes #1518 

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
