### PR TITLE
Better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `CannotConvertPaymentPubKeyHash`, `CannotHashMintingPolicy`, `CannotHashValidator` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
   used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `InvalidInContext` (not needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `CannotGetBigIntFromNumber'` and `CannotGetBigNumFromBigInt'` variants of
+  `PosixTimeToSlotError` (no longer needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
 - `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `CannotConvertPaymentPubKeyHash` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
+- `CannotConvertPaymentPubKeyHash`, `CannotHashMintingPolicy`, `CannotHashValidator` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
   used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `E2E_SKIP_JQUERY_DOWNLOAD` configuration variable for [E2E test suite](./doc/e2e-testing.md). It is not needed, because it's expected value can be determined from the environment, and thus it can be an implementation detail ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
+- `ImpossibleError` (as it is no longer used)
 
 ## [v5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- `mkUnbalancedTxE`, as a non-'throwing' version of `mkUnbalancedTx`. This
-  version returns in `Either`, like `mkUnbalancedTx` used to
-  ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `balanceTxE` and `balanceTxWithConstraintsE`, as non-'throwing' versions of
-  `balanceTx` and `balanceTxWithConstraints`. These return in `Either`, like
-  `balanceTx` and `balanceTxWithConstraints` used to do ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `mkUnbalancedTxE`, `balanceTxE` and `balanceTxWithConstraintsE` as
+  non-throwing versions of `mkUnbalancedTx`, `balanceTx` and
+  `balanceTxWithConstraints` ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `explainMkUnbalancedTxError` and `explainBalanceTxError`, which prettyprint
   `MkUnbalancedTxError` and `BalanceTxError` for a more human-readable output. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `Contract.Time.getCurrentEra` and `Contract.Time.normalizeTimeInterval`,
@@ -88,7 +85,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
-- Expose `ValidatorHashNotFound` constructor of `MkUnbalancedTxError`. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `scriptCurrencySymbol` no longer returns `Maybe`
   ([#1538](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1538)
 - **[IMPORTANT]** It is no more recommended to use `utxosAt` to get UTxOs at light wallet addresses. It may be a source of application bugs in some cases due to how wallets operate. Please see *Synchronization and wallet UTxO locking* section [here](./doc/query-layers.md) ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))
@@ -110,6 +106,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Removed re-exports of wallet-related functions from `Contract.Utxos` and `Contract.Address` (use `Contract.Wallet`) ([#1477](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1477))
 - `ownPaymentPubKeysHashes` renamed to `ownPaymentPubKeyHashes`, `ownStakePubKeysHashes` renamed to `ownStakePubKeyHashes` and both moved to `Contract.Wallet` ([#1477](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1477))
 - UTxO lists and combined input/output/mint/fee values are now being pretty-printed instead of logged using `Show` instance (in the balancer) ([#1531](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1531))
+- `mkUnbalancedTx`, `balanceTx` and `balanceTxWithConstraints` now throw instead
+  of returning in `Either` ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
 - `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `CannotConvertPaymentPubKeyHash` variant of `MkUnbalancedTxError` (no longer
+  used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+- `mkUnbalancedTxE`, as a 'throwing' version of `mkUnbalancedTx`. This version
+  throws an exception on failure, instead of returning in `Either`
+  ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `balanceTxE` and `balanceTxWithConstraintsE`, as 'throwing' versions of
+  `balanceTx` and `balanceTxWithConstraints`. These throw exceptions on failure,
+  instead of returning in `Either`. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `explainMkUnbalancedTxError` and `explainBalanceTxError`, which prettyprint
+  `MkUnbalancedTxError` and `BalanceTxError` for a more human-readable output. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - Added `extraSources` and `data` features to CTL's Nix build function ([#1516](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1516))
 - Added several `Ring`-like numeric instances for `Coin` ([#1485](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1485))
 - Added `ToData` and `FromData` instances for `PoolPubKeyHash` ([#1483](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1483))
@@ -76,7 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
-- Expose `ValidatorHashNotFound` constructor of `MkUnbalancedTxError`.
+- Expose `ValidatorHashNotFound` constructor of `MkUnbalancedTxError`. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `scriptCurrencySymbol` no longer returns `Maybe`
   ([#1538](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1538)
 - **[IMPORTANT]** It is no more recommended to use `utxosAt` to get UTxOs at light wallet addresses. It may be a source of application bugs in some cases due to how wallets operate. Please see *Synchronization and wallet UTxO locking* section [here](./doc/query-layers.md) ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Changed
 
+- Expose `ValidatorHashNotFound` constructor of `MkUnbalancedTxError`.
 - `scriptCurrencySymbol` no longer returns `Maybe`
   ([#1538](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1538)
 - **[IMPORTANT]** It is no more recommended to use `utxosAt` to get UTxOs at light wallet addresses. It may be a source of application bugs in some cases due to how wallets operate. Please see *Synchronization and wallet UTxO locking* section [here](./doc/query-layers.md) ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,12 +142,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `E2E_SKIP_JQUERY_DOWNLOAD` configuration variable for [E2E test suite](./doc/e2e-testing.md). It is not needed, because it's expected value can be determined from the environment, and thus it can be an implementation detail ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
-- `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `CannotConvertPaymentPubKeyHash`, `CannotHashMintingPolicy`, `CannotHashValidator` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
-  used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `InvalidInContext` (not needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `CannotGetBigIntFromNumber'` and `CannotGetBigNumFromBigInt'` variants of
-  `PosixTimeToSlotError` (no longer needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- Removed error variants (no more needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)):
+  - `ImpossibleError`
+  - `CannotConvertPaymentPubKeyHash`, `CannotHashMintingPolicy`, `CannotHashValidator` and `CannotHashDatum` variants of `MkUnbalancedTxError`
+  - `InvalidInContext`
+  - `CannotGetBigIntFromNumber'` and `CannotGetBigNumFromBigInt'` variants of `PosixTimeToSlotError`
 
 ## [v5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
 - `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `CannotConvertPaymentPubKeyHash` variant of `MkUnbalancedTxError` (no longer
+- `CannotConvertPaymentPubKeyHash` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
   used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `CannotConvertPaymentPubKeyHash`, `CannotHashMintingPolicy`, `CannotHashValidator` and `CannotHashDatum` variants of `MkUnbalancedTxError` (no longer
   used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `InvalidInContext` (not needed) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - UTxO lists and combined input/output/mint/fee values are now being pretty-printed instead of logged using `Show` instance (in the balancer) ([#1531](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1531))
 - `mkUnbalancedTx`, `balanceTx` and `balanceTxWithConstraints` now throw instead
   of returning in `Either` ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `mkUnbalancedTx` isn't exported from `Contract.ScriptLookups` anymore; get it
+  from `Contract.UnbalancedTx` instead.
+  ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- `mkUnbalancedTxE`, as a 'throwing' version of `mkUnbalancedTx`. This version
-  throws an exception on failure, instead of returning in `Either`
+- `mkUnbalancedTxE`, as a non-'throwing' version of `mkUnbalancedTx`. This
+  version returns in `Either`, like `mkUnbalancedTx` used to
   ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
-- `balanceTxE` and `balanceTxWithConstraintsE`, as 'throwing' versions of
-  `balanceTx` and `balanceTxWithConstraints`. These throw exceptions on failure,
-  instead of returning in `Either`. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
+- `balanceTxE` and `balanceTxWithConstraintsE`, as non-'throwing' versions of
+  `balanceTx` and `balanceTxWithConstraints`. These return in `Either`, like
+  `balanceTx` and `balanceTxWithConstraints` used to do ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - `explainMkUnbalancedTxError` and `explainBalanceTxError`, which prettyprint
   `MkUnbalancedTxError` and `BalanceTxError` for a more human-readable output. ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 - Added `extraSources` and `data` features to CTL's Nix build function ([#1516](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1516))
@@ -134,7 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - `E2E_SKIP_JQUERY_DOWNLOAD` configuration variable for [E2E test suite](./doc/e2e-testing.md). It is not needed, because it's expected value can be determined from the environment, and thus it can be an implementation detail ([#1440](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1440))
 - `reindexSpentScriptRedeemers` function from the public API - if there is a need to modify the `Transaction` in a way that breaks redeemer indices, it should be done before balancing ([#1462](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1462))
 - Typed scripts and constraints interface. In practice, it means that the following types now have no type-level arguments: `TxConstraints`, `ScriptLookups`.
-- `ImpossibleError` (as it is no longer used)
+- `ImpossibleError` (as it is no longer used) ([#1545](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1545)
 
 ## [v5.0.0]
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ CTL is being developed by MLabs. The following companies/funds have contributed 
 - [Catalyst Fund8](https://cardano.ideascale.com/c/idea/396607)
 - [Catalyst Fund9](https://cardano.ideascale.com/c/idea/420791)
 - [Catalyst Fund10](https://cardano.ideascale.com/c/idea/101478)
-- [MLabs](https://mlabs.city/)
+- [MLabs](https://www.mlabs.city/)
 - [Indigo Protocol](https://indigoprotocol.io/)
 - [Equine](https://www.equine.gg/)
 - [Liqwid Labs](https://liqwid.finance/)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ CTL is being developed by MLabs. The following companies/funds have contributed 
 - [Catalyst Fund8](https://cardano.ideascale.com/c/idea/396607)
 - [Catalyst Fund9](https://cardano.ideascale.com/c/idea/420791)
 - [Catalyst Fund10](https://cardano.ideascale.com/c/idea/101478)
-- [MLabs](https://www.mlabs.city/)
+- [MLabs](https://mlabs.city/)
 - [Indigo Protocol](https://indigoprotocol.io/)
 - [Equine](https://www.equine.gg/)
 - [Liqwid Labs](https://liqwid.finance/)

--- a/examples/AdditionalUtxos.purs
+++ b/examples/AdditionalUtxos.purs
@@ -124,8 +124,7 @@ spendFromValidator validator additionalUtxos datum = do
       BalancerConstraints.mustUseAdditionalUtxos additionalUtxos
 
   unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
-  balancedTx <- liftedE $ balanceTxWithConstraints unbalancedTx
-    balancerConstraints
+  balancedTx <- balanceTxWithConstraints unbalancedTx balancerConstraints
   balancedSignedTx <- signTransaction balancedTx
   txHash <- submit balancedSignedTx
 

--- a/examples/AdditionalUtxos.purs
+++ b/examples/AdditionalUtxos.purs
@@ -10,9 +10,9 @@ import Contract.BalanceTxConstraints (BalanceTxConstraintsBuilder)
 import Contract.BalanceTxConstraints (mustUseAdditionalUtxos) as BalancerConstraints
 import Contract.Config (ContractParams, testnetNamiConfig)
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, launchAff_, liftedE, runContract)
+import Contract.Monad (Contract, launchAff_, runContract)
 import Contract.PlutusData (Datum, PlutusData(Integer), unitRedeemer)
-import Contract.ScriptLookups (ScriptLookups, UnbalancedTx, mkUnbalancedTx)
+import Contract.ScriptLookups (ScriptLookups, UnbalancedTx)
 import Contract.ScriptLookups (datum, unspentOutputs, validator) as Lookups
 import Contract.Scripts (Validator, ValidatorHash, validatorHash)
 import Contract.Sync (withoutSync)
@@ -36,6 +36,7 @@ import Contract.TxConstraints
   , mustSpendPubKeyOutput
   , mustSpendScriptOutput
   ) as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Utxos (UtxoMap)
 import Contract.Value (Value)
 import Contract.Value (lovelaceValueOf) as Value
@@ -89,7 +90,7 @@ payToValidator vhash = do
     lookups :: ScriptLookups
     lookups = Lookups.datum datum
 
-  unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
+  unbalancedTx <- mkUnbalancedTx lookups constraints
   pure { unbalancedTx, datum }
 
 spendFromValidator :: Validator -> UtxoMap -> Datum -> Contract Unit
@@ -123,7 +124,7 @@ spendFromValidator validator additionalUtxos datum = do
     balancerConstraints =
       BalancerConstraints.mustUseAdditionalUtxos additionalUtxos
 
-  unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
+  unbalancedTx <- mkUnbalancedTx lookups constraints
   balancedTx <- balanceTxWithConstraints unbalancedTx balancerConstraints
   balancedSignedTx <- signTransaction balancedTx
   txHash <- submit balancedSignedTx

--- a/examples/BalanceTxConstraints.purs
+++ b/examples/BalanceTxConstraints.purs
@@ -158,8 +158,7 @@ contract (ContractParams p) = do
     unbalancedTx <-
       liftedE $ Lookups.mkUnbalancedTx lookups constraints
 
-    balancedTx <-
-      liftedE $ balanceTxWithConstraints unbalancedTx balanceTxConstraints
+    balancedTx <- balanceTxWithConstraints unbalancedTx balanceTxConstraints
 
     balancedSignedTx <-
       (withKeyWallet p.bobKeyWallet <<< signTransaction)

--- a/examples/BalanceTxConstraints.purs
+++ b/examples/BalanceTxConstraints.purs
@@ -16,7 +16,7 @@ import Contract.BalanceTxConstraints
   , mustUseUtxosAtAddress
   ) as BalanceTxConstraints
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, liftedE, liftedM)
+import Contract.Monad (Contract, liftedM)
 import Contract.ScriptLookups as Lookups
 import Contract.Test.Assert
   ( ContractAssertionFailure(CustomFailure)
@@ -36,6 +36,7 @@ import Contract.Transaction
   , submit
   )
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Utxos (utxosAt)
 import Contract.Value (CurrencySymbol, TokenName, Value)
 import Contract.Value (singleton, valueOf) as Value
@@ -155,8 +156,7 @@ contract (ContractParams p) = do
         <> BalanceTxConstraints.mustNotSpendUtxoWithOutRef nonSpendableOref
 
   void $ runChecks checks $ lift do
-    unbalancedTx <-
-      liftedE $ Lookups.mkUnbalancedTx lookups constraints
+    unbalancedTx <- mkUnbalancedTx lookups constraints
 
     balancedTx <- balanceTxWithConstraints unbalancedTx balanceTxConstraints
 

--- a/examples/ChangeGeneration.purs
+++ b/examples/ChangeGeneration.purs
@@ -3,7 +3,7 @@ module Ctl.Examples.ChangeGeneration (checkChangeOutputsDistribution) where
 import Prelude
 
 import Contract.BalanceTxConstraints (mustSendChangeWithDatum)
-import Contract.Monad (Contract, liftedE)
+import Contract.Monad (Contract)
 import Contract.PlutusData
   ( Datum(Datum)
   , OutputDatum(OutputDatum)
@@ -64,8 +64,8 @@ checkChangeOutputsDistribution outputsToScript outputsToSelf expectedOutputs =
 
       lookups :: Lookups.ScriptLookups
       lookups = mempty
-    unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
-    balancedTx <- liftedE $ balanceTxWithConstraints unbalancedTx
+    unbalancedTx <- mkUnbalancedTx lookups constraints
+    balancedTx <- balanceTxWithConstraints unbalancedTx
       -- just to check that attaching datums works
       ( mustSendChangeWithDatum $ OutputDatum $ Datum $ Integer $ BigInt.fromInt
           1000

--- a/examples/ContractTestUtils.purs
+++ b/examples/ContractTestUtils.purs
@@ -23,7 +23,7 @@ import Contract.AuxiliaryData (setTxMetadata)
 import Contract.Hashing (datumHash)
 import Contract.Log (logInfo')
 import Contract.Metadata (Cip25Metadata)
-import Contract.Monad (Contract, liftContractM, liftedE, liftedM)
+import Contract.Monad (Contract, liftContractM, liftedM)
 import Contract.PlutusData (Datum, OutputDatum(OutputDatumHash))
 import Contract.ScriptLookups as Lookups
 import Contract.Scripts (MintingPolicy)
@@ -54,6 +54,7 @@ import Contract.Transaction
   )
 import Contract.TxConstraints (DatumPresence(DatumWitness))
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Utxos (utxosAt)
 import Contract.Value (CurrencySymbol, TokenName, Value)
 import Contract.Value (lovelaceValueOf, singleton) as Value
@@ -159,7 +160,7 @@ mkContract p = do
     lookups :: Lookups.ScriptLookups
     lookups = Lookups.mintingPolicy p.mintingPolicy
 
-  unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+  unbalancedTx <- mkUnbalancedTx lookups constraints
   unbalancedTxWithMetadata <- setTxMetadata unbalancedTx p.txMetadata
   balancedTx <- balanceTx unbalancedTxWithMetadata
   balancedSignedTx <- signTransaction balancedTx

--- a/examples/ContractTestUtils.purs
+++ b/examples/ContractTestUtils.purs
@@ -161,7 +161,7 @@ mkContract p = do
 
   unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
   unbalancedTxWithMetadata <- setTxMetadata unbalancedTx p.txMetadata
-  balancedTx <- liftedE $ balanceTx unbalancedTxWithMetadata
+  balancedTx <- balanceTx unbalancedTxWithMetadata
   balancedSignedTx <- signTransaction balancedTx
 
   txId <- submit balancedSignedTx

--- a/examples/KeyWallet/SignMultiple.purs
+++ b/examples/KeyWallet/SignMultiple.purs
@@ -3,7 +3,7 @@ module Ctl.Examples.KeyWallet.SignMultiple where
 import Contract.Prelude
 
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, liftedE, throwContractError)
+import Contract.Monad (Contract, throwContractError)
 import Contract.ScriptLookups as Lookups
 import Contract.Transaction
   ( BalancedSignedTransaction
@@ -14,6 +14,7 @@ import Contract.Transaction
   , withBalancedTxs
   )
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Value (lovelaceValueOf) as Value
 import Control.Monad.Reader (asks)
 import Ctl.Examples.KeyWallet.Internal.Pkh2PkhContract (runKeyWalletContract_)
@@ -41,8 +42,8 @@ main = runKeyWalletContract_ \pkh lovelace unlock -> do
     lookups :: Lookups.ScriptLookups
     lookups = mempty
 
-  unbalancedTx0 <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-  unbalancedTx1 <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+  unbalancedTx0 <- mkUnbalancedTx lookups constraints
+  unbalancedTx1 <- mkUnbalancedTx lookups constraints
 
   txIds <- withBalancedTxs [ unbalancedTx0, unbalancedTx1 ] $ \balancedTxs -> do
     locked <- getLockedInputs

--- a/examples/PlutusV2/ReferenceInputs.purs
+++ b/examples/PlutusV2/ReferenceInputs.purs
@@ -77,7 +77,7 @@ contract = do
 
   void $ runChecks checks $ lift do
     unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-    balancedSignedTx <- signTransaction =<< liftedE (balanceTx unbalancedTx)
+    balancedSignedTx <- signTransaction =<< balanceTx unbalancedTx
     txHash <- submit balancedSignedTx
     logInfo' $ "Tx ID: " <> show txHash
     awaitTxConfirmed txHash

--- a/examples/PlutusV2/ReferenceInputs.purs
+++ b/examples/PlutusV2/ReferenceInputs.purs
@@ -8,7 +8,6 @@ import Contract.Monad
   ( Contract
   , launchAff_
   , liftContractM
-  , liftedE
   , liftedM
   , runContract
   )
@@ -31,6 +30,7 @@ import Contract.Transaction
   , submit
   )
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Value (lovelaceValueOf) as Value
 import Contract.Wallet
   ( getWalletUtxos
@@ -76,7 +76,7 @@ contract = do
     lookups = mempty
 
   void $ runChecks checks $ lift do
-    unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+    unbalancedTx <- mkUnbalancedTx lookups constraints
     balancedSignedTx <- signTransaction =<< balanceTx unbalancedTx
     txHash <- submit balancedSignedTx
     logInfo' $ "Tx ID: " <> show txHash

--- a/examples/SatisfiesAnyOf.purs
+++ b/examples/SatisfiesAnyOf.purs
@@ -13,7 +13,7 @@ import Contract.Prelude
 import Contract.Config (ContractParams, testnetNamiConfig)
 import Contract.Hashing (datumHash) as Hashing
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, launchAff_, liftedE, runContract)
+import Contract.Monad (Contract, launchAff_, runContract)
 import Contract.PlutusData
   ( Datum(Datum)
   , PlutusData(Integer)
@@ -22,6 +22,7 @@ import Contract.PlutusData
 import Contract.ScriptLookups as Lookups
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Data.BigInt as BigInt
 
 main :: Effect Unit
@@ -51,4 +52,4 @@ testMustSatisfyAnyOf = do
     lookups :: Lookups.ScriptLookups
     lookups = mempty
 
-  void $ liftedE $ Lookups.mkUnbalancedTx lookups constraints
+  void $ mkUnbalancedTx lookups constraints

--- a/examples/SignMultiple.purs
+++ b/examples/SignMultiple.purs
@@ -10,7 +10,6 @@ import Contract.Log (logInfo', logWarn')
 import Contract.Monad
   ( Contract
   , launchAff_
-  , liftedE
   , liftedM
   , runContract
   , throwContractError
@@ -27,6 +26,7 @@ import Contract.Transaction
   , withBalancedTxs
   )
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Value (leq)
 import Contract.Value as Value
 import Contract.Wallet
@@ -72,8 +72,8 @@ contract = do
     lookups :: Lookups.ScriptLookups
     lookups = mempty
 
-  unbalancedTx0 <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-  unbalancedTx1 <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+  unbalancedTx0 <- mkUnbalancedTx lookups constraints
+  unbalancedTx1 <- mkUnbalancedTx lookups constraints
 
   txIds <- withBalancedTxs [ unbalancedTx0, unbalancedTx1 ] $ \balancedTxs -> do
     locked <- getLockedInputs

--- a/examples/TxChaining.purs
+++ b/examples/TxChaining.purs
@@ -69,8 +69,7 @@ contract = do
         BalanceTxConstraints.mustUseAdditionalUtxos additionalUtxos
 
     unbalancedTx1 <- liftedE $ Lookups.mkUnbalancedTx lookups1 constraints
-    balancedTx1 <-
-      liftedE $ balanceTxWithConstraints unbalancedTx1 balanceTxConstraints
+    balancedTx1 <- balanceTxWithConstraints unbalancedTx1 balanceTxConstraints
     balancedSignedTx1 <- signTransaction balancedTx1
 
     txId0 <- submit balancedSignedTx0

--- a/examples/TxChaining.purs
+++ b/examples/TxChaining.purs
@@ -16,7 +16,7 @@ import Contract.BalanceTxConstraints
   ) as BalanceTxConstraints
 import Contract.Config (ContractParams, testnetNamiConfig)
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, launchAff_, liftedE, liftedM, runContract)
+import Contract.Monad (Contract, launchAff_, liftedM, runContract)
 import Contract.ScriptLookups as Lookups
 import Contract.Transaction
   ( awaitTxConfirmed
@@ -28,6 +28,7 @@ import Contract.Transaction
   )
 import Contract.TxConstraints (TxConstraints)
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Value as Value
 import Contract.Wallet (ownPaymentPubKeyHashes)
 import Data.Array (head)
@@ -52,7 +53,7 @@ contract = do
     lookups0 :: Lookups.ScriptLookups
     lookups0 = mempty
 
-  unbalancedTx0 <- liftedE $ Lookups.mkUnbalancedTx lookups0 constraints
+  unbalancedTx0 <- mkUnbalancedTx lookups0 constraints
 
   withBalancedTx unbalancedTx0 \balancedTx0 -> do
     balancedSignedTx0 <- signTransaction balancedTx0
@@ -68,7 +69,7 @@ contract = do
       balanceTxConstraints =
         BalanceTxConstraints.mustUseAdditionalUtxos additionalUtxos
 
-    unbalancedTx1 <- liftedE $ Lookups.mkUnbalancedTx lookups1 constraints
+    unbalancedTx1 <- mkUnbalancedTx lookups1 constraints
     balancedTx1 <- balanceTxWithConstraints unbalancedTx1 balanceTxConstraints
     balancedSignedTx1 <- signTransaction balancedTx1
 

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -1,15 +1,7 @@
 -- | A module for creating off-chain script lookups, and an unbalanced
 -- | transaction.
-module Contract.ScriptLookups
-  ( mkUnbalancedTx
-  , module X
-  ) where
+module Contract.ScriptLookups (module X) where
 
-import Contract.Monad (Contract)
-import Ctl.Internal.ProcessConstraints (mkUnbalancedTxImpl) as PC
-import Ctl.Internal.ProcessConstraints.Error
-  ( MkUnbalancedTxError
-  )
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
       ( CannotFindDatum
@@ -37,11 +29,7 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotMintZero
       )
   ) as X
-import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx)
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx(UnbalancedTx)) as X
-import Ctl.Internal.Types.ScriptLookups
-  ( ScriptLookups
-  )
 import Ctl.Internal.Types.ScriptLookups
   ( ScriptLookups(ScriptLookups)
   , datum
@@ -56,16 +44,3 @@ import Ctl.Internal.Types.ScriptLookups
   , validator
   , validatorM
   ) as X
-import Ctl.Internal.Types.TxConstraints (TxConstraints)
-import Data.Either (Either)
-
--- | Create an `UnbalancedTx` given `ScriptLookups` and
--- | `TxConstraints`. You will probably want to use this version as it returns
--- | datums and redeemers that require attaching (and maybe reindexing) in
--- | a separate call. In particular, this should be called in conjuction with
--- | `balanceTx` and  `signTransaction`.
-mkUnbalancedTx
-  :: ScriptLookups
-  -> TxConstraints
-  -> Contract (Either MkUnbalancedTxError UnbalancedTx)
-mkUnbalancedTx = PC.mkUnbalancedTxImpl

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -2,33 +2,6 @@
 -- | transaction.
 module Contract.ScriptLookups (module X) where
 
-import Ctl.Internal.ProcessConstraints.Error
-  ( MkUnbalancedTxError
-      ( CannotFindDatum
-      , CannotQueryDatum
-      , CannotConvertPOSIXTimeRange
-      , CannotSolveTimeConstraints
-      , CannotGetMintingPolicyScriptIndex
-      , CannotGetValidatorHashFromAddress
-      , CannotMakeValue
-      , CannotWithdrawRewardsPubKey
-      , CannotWithdrawRewardsPlutusScript
-      , CannotWithdrawRewardsNativeScript
-      , DatumNotFound
-      , DatumWrongHash
-      , MintingPolicyHashNotCurrencySymbol
-      , MintingPolicyNotFound
-      , ModifyTx
-      , OwnPubKeyAndStakeKeyMissing
-      , TxOutRefNotFound
-      , TxOutRefWrongType
-      , ValidatorHashNotFound
-      , WrongRefScriptHash
-      , CannotSatisfyAny
-      , ExpectedPlutusScriptGotNativeScript
-      , CannotMintZero
-      )
-  ) as X
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx(UnbalancedTx)) as X
 import Ctl.Internal.Types.ScriptLookups
   ( ScriptLookups(ScriptLookups)

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -12,8 +12,7 @@ import Ctl.Internal.ProcessConstraints.Error
   )
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
-      ( CannotConvertPaymentPubKeyHash
-      , CannotFindDatum
+      ( CannotFindDatum
       , CannotQueryDatum
       , CannotConvertPOSIXTimeRange
       , CannotSolveTimeConstraints

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -18,8 +18,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashMintingPolicy
-      , CannotHashValidator
       , CannotMakeValue
       , CannotWithdrawRewardsPubKey
       , CannotWithdrawRewardsPlutusScript

--- a/src/Contract/ScriptLookups.purs
+++ b/src/Contract/ScriptLookups.purs
@@ -18,7 +18,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashDatum
       , CannotHashMintingPolicy
       , CannotHashValidator
       , CannotMakeValue
@@ -54,10 +53,8 @@ import Ctl.Internal.Types.ScriptLookups
   , ownPaymentPubKeyHashM
   , ownStakePubKeyHash
   , ownStakePubKeyHashM
-  -- , paymentPubKeyM
   , unspentOutputs
   , unspentOutputsM
-  -- , unsafePaymentPubKey
   , validator
   , validatorM
   ) as X

--- a/src/Contract/Time.purs
+++ b/src/Contract/Time.purs
@@ -63,7 +63,6 @@ import Ctl.Internal.Types.Interval
       , PosixTimeBeforeSystemStart
       , StartTimeGreaterThanTime
       , EndSlotLessThanSlotOrModNonZero
-      , CannotGetBigIntFromNumber'
       )
   , RelTime(RelTime)
   , SlotRange

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -71,7 +71,6 @@ import Ctl.Internal.BalanceTx.Error
       , UtxoMinAdaValueCalculationFailed
       )
   , Expected(Expected)
-  , InvalidInContext(InvalidInContext)
   , explainBalanceTxError
   ) as BalanceTxError
 import Ctl.Internal.BalanceTx.UnattachedTx (UnindexedTx)

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -407,8 +407,7 @@ unUnbalancedTx
 -- | Attempts to balance an `UnbalancedTx` using the specified
 -- | balancer constraints.
 -- |
--- | This is a 'non-throwing' variant of this functionality. If you want a
--- | 'throwing' variant, use `balanceTxWithConstraints` instead.
+-- | `balanceTxWithConstraints` is a throwing variant.
 balanceTxWithConstraintsE
   :: UnbalancedTx
   -> BalanceTxConstraintsBuilder
@@ -419,10 +418,10 @@ balanceTxWithConstraintsE tx =
   in
     BalanceTx.balanceTxWithConstraints tx' ix
 
--- | 'Throwing' variant of `balanceTxWithConstraintsE`.
+-- | Attempts to balance an `UnbalancedTx` using the specified
+-- | balancer constraints.
 -- |
--- | If you want a non-'throwing' variant, use `balanceWithConstraintsE`
--- | instead.
+-- | 'Throwing' variant of `balanceTxWithConstraintsE`.
 balanceTxWithConstraints
   :: UnbalancedTx
   -> BalanceTxConstraintsBuilder
@@ -433,17 +432,17 @@ balanceTxWithConstraints tx bcb = do
     Left err -> throwError $ error $ BalanceTxError.explainBalanceTxError err
     Right ftx -> pure ftx
 
--- | Same as `balanceTxWithConstraintsE`, but uses the default balancer
--- | constraints.
+-- | Balance a transaction without providing balancer constraints.
 -- |
--- | This is a 'non-throwing' variant of this functionality.
+-- | `balanceTx` is a throwing variant.
 balanceTxE
   :: UnbalancedTx
   -> Contract (Either BalanceTxError.BalanceTxError FinalizedTransaction)
 balanceTxE = flip balanceTxWithConstraintsE mempty
 
--- | 'Throwing' variant of `balanceTxE`. If you want
--- | a non-'throwing' variant, use `balanceTxE` instead.
+-- | Balance a transaction without providing balancer constraints.
+-- |
+-- | `balanceTxE` is a non-throwing version of this function.
 balanceTx :: UnbalancedTx -> Contract FinalizedTransaction
 balanceTx utx = do
   result <- balanceTxE utx

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -41,12 +41,11 @@ import Contract.Metadata (GeneralTransactionMetadata)
 import Contract.Monad
   ( Contract
   , liftContractM
-  , liftedE
   , liftedM
   , runContractInEnv
   )
-import Contract.ScriptLookups (mkUnbalancedTx)
 import Contract.TxConstraints (TxConstraints)
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Control.Monad.Error.Class (catchError, liftEither, throwError)
 import Control.Monad.Reader (ReaderT, asks, runReaderT)
 import Control.Monad.Reader.Class (ask)
@@ -549,7 +548,7 @@ submitTxFromConstraintsReturningFee
   -> TxConstraints
   -> Contract { txHash :: TransactionHash, txFinalFee :: BigInt }
 submitTxFromConstraintsReturningFee lookups constraints = do
-  unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
+  unbalancedTx <- mkUnbalancedTx lookups constraints
   balancedTx <- balanceTx unbalancedTx
   balancedSignedTx <- signTransaction balancedTx
   txHash <- submit balancedSignedTx

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -407,8 +407,7 @@ unUnbalancedTx
 -- | Attempts to balance an `UnbalancedTx` using the specified
 -- | balancer constraints.
 -- |
--- | This is a 'non-throwing' variant of this functionality. Use this when
--- | errors are expected, and graceful recovery is possible. If you want a
+-- | This is a 'non-throwing' variant of this functionality. If you want a
 -- | 'throwing' variant, use `balanceTxWithConstraints` instead.
 balanceTxWithConstraintsE
   :: UnbalancedTx
@@ -420,10 +419,9 @@ balanceTxWithConstraintsE tx =
   in
     BalanceTx.balanceTxWithConstraints tx' ix
 
--- | 'Throwing' variant of `balanceTxWithConstraintsE`. Instead of returning in
--- | `Either`, it throws an exception on failure. Use this when errors are not
--- | expected, and graceful recovery is either impossible or wouldn't make
--- | sense. If you want a non-'throwing' variant, use `balanceWithConstraintsE`
+-- | 'Throwing' variant of `balanceTxWithConstraintsE`.
+-- |
+-- | If you want a non-'throwing' variant, use `balanceWithConstraintsE`
 -- | instead.
 balanceTxWithConstraints
   :: UnbalancedTx
@@ -438,17 +436,13 @@ balanceTxWithConstraints tx bcb = do
 -- | Same as `balanceTxWithConstraintsE`, but uses the default balancer
 -- | constraints.
 -- |
--- | This is a 'non-throwing' variant of this functionality. Use this when
--- | errors are expected, and graceful recovery is possible. If you want a
--- | 'throwing' variant, use `balanceTx` instead.
+-- | This is a 'non-throwing' variant of this functionality.
 balanceTxE
   :: UnbalancedTx
   -> Contract (Either BalanceTxError.BalanceTxError FinalizedTransaction)
 balanceTxE = flip balanceTxWithConstraintsE mempty
 
--- | 'Throwing' variant of `balanceTxE`. Instead of returning in `Either`, it
--- | throws an exception on failure. Use this when errors are not expected, and
--- | graceful recovery is either impossible or wouldn't make sense. If you want
+-- | 'Throwing' variant of `balanceTxE`. If you want
 -- | a non-'throwing' variant, use `balanceTxE` instead.
 balanceTx :: UnbalancedTx -> Contract FinalizedTransaction
 balanceTx utx = do

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -71,7 +71,6 @@ import Ctl.Internal.BalanceTx.Error
       , UtxoMinAdaValueCalculationFailed
       )
   , Expected(Expected)
-  , ImpossibleError(Impossible)
   , InvalidInContext(InvalidInContext)
   , explainBalanceTxError
   ) as BalanceTxError

--- a/src/Contract/Transaction.purs
+++ b/src/Contract/Transaction.purs
@@ -483,8 +483,7 @@ balanceAndLockWithConstraints
   :: UnbalancedTx /\ BalanceTxConstraintsBuilder
   -> Contract FinalizedTransaction
 balanceAndLockWithConstraints (unbalancedTx /\ constraints) = do
-  balancedTx <-
-    liftedE $ balanceTxWithConstraintsE unbalancedTx constraints
+  balancedTx <- balanceTxWithConstraints unbalancedTx constraints
   void $ withUsedTxOuts $
     lockTransactionInputs (unwrap balancedTx)
   pure balancedTx
@@ -551,7 +550,7 @@ submitTxFromConstraintsReturningFee
   -> Contract { txHash :: TransactionHash, txFinalFee :: BigInt }
 submitTxFromConstraintsReturningFee lookups constraints = do
   unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
-  balancedTx <- liftedE $ balanceTxE unbalancedTx
+  balancedTx <- balanceTx unbalancedTx
   balancedSignedTx <- signTransaction balancedTx
   txHash <- submit balancedSignedTx
   pure { txHash, txFinalFee: getTxFinalFee balancedSignedTx }

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -17,8 +17,7 @@ import Ctl.Internal.ProcessConstraints.Error
   )
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
-      ( CannotConvertPaymentPubKeyHash
-      , CannotFindDatum
+      ( CannotFindDatum
       , CannotQueryDatum
       , CannotConvertPOSIXTimeRange
       , CannotSolveTimeConstraints
@@ -48,8 +47,7 @@ import Ctl.Internal.ProcessConstraints.Error
   )
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
-      ( CannotConvertPaymentPubKeyHash
-      , CannotFindDatum
+      ( CannotFindDatum
       , CannotQueryDatum
       , CannotConvertPOSIXTimeRange
       , CannotSolveTimeConstraints
@@ -113,8 +111,6 @@ mkUnbalancedTx lookups constraints =
 -- | Helper to pretty-print `MkUnbalancedTxError`s.
 explainMkUnbalancedTxError :: MkUnbalancedTxError -> String
 explainMkUnbalancedTxError = case _ of
-  CannotConvertPaymentPubKeyHash ppkh ->
-    "Cannot convert payment pubkey hash: " <> show ppkh
   CannotFindDatum -> "Cannot find datum"
   CannotQueryDatum dh ->
     "Querying for datum by datum hash ("

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -23,8 +23,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashMintingPolicy
-      , CannotHashValidator
       , CannotMakeValue
       , CannotWithdrawRewardsPubKey
       , CannotWithdrawRewardsPlutusScript
@@ -52,8 +50,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashMintingPolicy
-      , CannotHashValidator
       , CannotMakeValue
       , CannotWithdrawRewardsPubKey
       , CannotWithdrawRewardsPlutusScript
@@ -130,10 +126,6 @@ explainMkUnbalancedTxError = case _ of
       <> bugTrackerLink
   CannotGetValidatorHashFromAddress addr ->
     "Cannot get a validator hash from address " <> show addr
-  CannotHashMintingPolicy mp ->
-    "Cannot hash minting policy: " <> show mp
-  CannotHashValidator validator ->
-    "Cannot hash validator: " <> show validator
   CannotMakeValue _ tn _ ->
     "Attempted to make an amount with the ADA currency symbol, and non-empty token name "
       <> show tn

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -95,8 +95,7 @@ import Effect.Exception (error)
 -- | `TxConstraints`. This should be called in conjuction with
 -- | `balanceTx` and  `signTransaction`.
 -- |
--- | This is a 'non-throwing' variant; use this when failure is expected, and
--- | can be handled gracefully. If you need the 'throwing' variant, use
+-- | This is a 'non-throwing' variant; if you need the 'throwing' variant, use
 -- | `mkUnbalancedTx` instead.
 mkUnbalancedTxE
   :: ScriptLookups
@@ -104,9 +103,7 @@ mkUnbalancedTxE
   -> Contract (Either MkUnbalancedTxError UnbalancedTx)
 mkUnbalancedTxE = PC.mkUnbalancedTxImpl
 
--- | As `mkUnbalancedTxE`, but 'throwing'; use this when failure is _not_
--- | expected, and graceful handling is either impossible, or wouldn't make
--- | sense.
+-- | As `mkUnbalancedTxE`, but 'throwing'.
 mkUnbalancedTx :: ScriptLookups -> TxConstraints -> Contract UnbalancedTx
 mkUnbalancedTx lookups constraints =
   mkUnbalancedTxE lookups constraints >>= case _ of

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -3,7 +3,6 @@
 module Contract.UnbalancedTx
   ( mkUnbalancedTx
   , mkUnbalancedTxE
-  , explainMkUnbalancedTxError
   , module X
   ) where
 
@@ -11,51 +10,10 @@ import Prelude
 
 import Contract.Monad (Contract)
 import Control.Monad.Error.Class (throwError)
-import Ctl.Internal.Cardano.Types.NativeScript
-  ( NativeScript
-      ( ScriptPubkey
-      , ScriptAll
-      , ScriptAny
-      , ScriptNOfK
-      , TimelockStart
-      , TimelockExpiry
-      )
-  )
-import Ctl.Internal.Cardano.Types.Value
-  ( getCurrencySymbol
-  , pprintValue
-  )
-import Ctl.Internal.Plutus.Conversion.Value (fromPlutusValue)
-import Ctl.Internal.Plutus.Types.Transaction
-  ( TransactionOutput(TransactionOutput)
-  )
 import Ctl.Internal.ProcessConstraints (mkUnbalancedTxImpl) as PC
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
-      ( CannotFindDatum
-      , CannotQueryDatum
-      , CannotConvertPOSIXTimeRange
-      , CannotSolveTimeConstraints
-      , CannotGetMintingPolicyScriptIndex
-      , CannotGetValidatorHashFromAddress
-      , CannotMakeValue
-      , CannotWithdrawRewardsPubKey
-      , CannotWithdrawRewardsPlutusScript
-      , CannotWithdrawRewardsNativeScript
-      , DatumNotFound
-      , DatumWrongHash
-      , MintingPolicyHashNotCurrencySymbol
-      , MintingPolicyNotFound
-      , ModifyTx
-      , OwnPubKeyAndStakeKeyMissing
-      , TxOutRefNotFound
-      , TxOutRefWrongType
-      , WrongRefScriptHash
-      , ValidatorHashNotFound
-      , CannotSatisfyAny
-      , ExpectedPlutusScriptGotNativeScript
-      , CannotMintZero
-      )
+  , explainMkUnbalancedTxError
   )
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
@@ -83,39 +41,13 @@ import Ctl.Internal.ProcessConstraints.Error
       , ExpectedPlutusScriptGotNativeScript
       , CannotMintZero
       )
+  , explainMkUnbalancedTxError
   ) as X
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx)
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx(UnbalancedTx)) as X
-import Ctl.Internal.Serialization.Address (addressBech32)
-import Ctl.Internal.Serialization.Hash
-  ( ed25519KeyHashToBytes
-  , scriptHashToBytes
-  )
-import Ctl.Internal.Transaction (explainModifyTxError)
-import Ctl.Internal.Types.ByteArray (byteArrayToHex)
-import Ctl.Internal.Types.Interval (explainPosixTimeToSlotError)
-import Ctl.Internal.Types.OutputDatum
-  ( OutputDatum(NoOutputDatum, OutputDatumHash, OutputDatum)
-  )
-import Ctl.Internal.Types.PlutusData (pprintPlutusData)
-import Ctl.Internal.Types.RawBytes (rawBytesToHex)
-import Ctl.Internal.Types.ScriptLookups
-  ( ScriptLookups
-  )
-import Ctl.Internal.Types.Scripts (PlutusScript(PlutusScript))
-import Ctl.Internal.Types.TokenName (TokenName, fromTokenName)
-import Ctl.Internal.Types.Transaction
-  ( DataHash(DataHash)
-  , TransactionInput(TransactionInput)
-  )
+import Ctl.Internal.Types.ScriptLookups (ScriptLookups)
 import Ctl.Internal.Types.TxConstraints (TxConstraints)
 import Data.Either (Either(Left, Right))
-import Data.FoldableWithIndex (foldMapWithIndex)
-import Data.Log.Tag as TagSet
-import Data.Maybe (Maybe(Nothing, Just))
-import Data.Newtype (unwrap)
-import Data.String as String
-import Data.Tuple.Nested ((/\))
 import Effect.Exception (error)
 
 -- | Create an `UnbalancedTx` given `ScriptLookups` and
@@ -136,179 +68,3 @@ mkUnbalancedTx lookups constraints =
   mkUnbalancedTxE lookups constraints >>= case _ of
     Left err -> throwError $ error $ explainMkUnbalancedTxError err
     Right res -> pure res
-
--- | Helper to pretty-print `MkUnbalancedTxError`s.
-explainMkUnbalancedTxError :: MkUnbalancedTxError -> String
-explainMkUnbalancedTxError = case _ of
-  CannotFindDatum -> "Cannot find datum"
-  CannotQueryDatum (DataHash dh) ->
-    "Querying for datum by datum hash ("
-      <> byteArrayToHex dh
-      <>
-        ") failed: no datum found"
-  CannotConvertPOSIXTimeRange tr ttsErr ->
-    "Cannot convert POSIX time range to slot time range.\nRange: "
-      <> show tr
-      <> "\nReason: "
-      <>
-        explainPosixTimeToSlotError ttsErr
-  CannotSolveTimeConstraints tr tr' ->
-    "Unsolvable time constraints: " <> show tr <> " and " <> show tr' <>
-      " do not overlap."
-  CannotGetMintingPolicyScriptIndex ->
-    "Cannot get minting policy script index. This should be impossible.\n"
-      <> "Please report this as a bug here: "
-      <> bugTrackerLink
-  CannotGetValidatorHashFromAddress addr ->
-    "Cannot get a payment validator hash from address " <>
-      addressBech32 addr
-  CannotMakeValue _ tn _ ->
-    "Attempted to make an amount with the ADA currency symbol, and non-empty token name "
-      <> prettyTokenName tn
-      <>
-        ". This is not allowed, as the ADA currency symbol can only be combined with the empty token name."
-  CannotWithdrawRewardsPubKey spkh ->
-    "Cannot withdraw rewards, as pubkey "
-      <> rawBytesToHex (ed25519KeyHashToBytes $ unwrap $ unwrap spkh)
-      <>
-        " is not registered"
-  CannotWithdrawRewardsPlutusScript pssv ->
-    "Cannot withdraw rewards from Plutus staking script " <>
-      prettyPlutusScript (unwrap pssv)
-  CannotWithdrawRewardsNativeScript nssv ->
-    "Cannot withdraw rewards from native staking script " <>
-      prettyNativeScript 0 (unwrap nssv)
-  DatumNotFound (DataHash hash) -> "Datum with hash " <> byteArrayToHex hash <>
-    " not found."
-  DatumWrongHash (DataHash dh) datum -> "Datum "
-    <> show datum
-    <> " does not have the hash "
-    <> byteArrayToHex dh
-  MintingPolicyHashNotCurrencySymbol mph ->
-    "Minting policy hash "
-      <> rawBytesToHex (scriptHashToBytes $ unwrap mph)
-      <>
-        " is not a CurrencySymbol. Please check the validity of the byte representation."
-  MintingPolicyNotFound mp -> "Minting policy with hash "
-    <> rawBytesToHex (scriptHashToBytes $ unwrap mp)
-    <> " not found in a set of minting policies"
-  ModifyTx modifyTxErr -> explainModifyTxError modifyTxErr
-  OwnPubKeyAndStakeKeyMissing ->
-    "Could not build own address: both payment pubkey and stake pubkey are missing"
-  TxOutRefNotFound ti ->
-    "Could not find a reference input:\n"
-      <> prettyTxIn ti
-      <> "\nIt maybe have been consumed, or was never created."
-  TxOutRefWrongType ti ->
-    "Transaction output is missing an expected datum:\n"
-      <> prettyTxIn ti
-      <> "\nContext: we were trying to spend a script output."
-  ValidatorHashNotFound vh -> "Cannot find validator hash: " <>
-    rawBytesToHex (scriptHashToBytes $ unwrap vh)
-  WrongRefScriptHash msh tout -> case msh of
-    Nothing -> "Output is missing a reference script hash.\nOutput:\n" <>
-      prettyOutput tout
-    Just missingHash -> "Output is missing reference script hash "
-      <> rawBytesToHex (scriptHashToBytes missingHash)
-      <> ".\nOutput:\n"
-      <>
-        prettyOutput tout
-  CannotSatisfyAny -> "One of the following happened:\n"
-    <> "1. List of constraints is empty.\n"
-    <>
-      "2. All alternatives of a 'mustSatisfyAnyOf' have failed."
-  ExpectedPlutusScriptGotNativeScript mph ->
-    "Expected a Plutus script, but "
-      <> rawBytesToHex (scriptHashToBytes $ unwrap mph)
-      <>
-        " is a native script."
-  CannotMintZero cs tn ->
-    "Cannot mint zero of token "
-      <> prettyTokenName tn
-      <> " of currency "
-      <>
-        byteArrayToHex (getCurrencySymbol cs)
-  where
-  prettyOutput :: TransactionOutput -> String
-  prettyOutput (TransactionOutput { address, amount, datum, referenceScript }) =
-    let
-      datumTagSets = map TagSet.fromArray $ case datum of
-        NoOutputDatum -> []
-        OutputDatumHash datumHash ->
-          [ [ "datumHash" `TagSet.tag` byteArrayToHex
-                (unwrap datumHash)
-            ]
-          ]
-        OutputDatum plutusData ->
-          [ [ "datum" `TagSet.tagSetTag`
-                pprintPlutusData (unwrap plutusData)
-            ]
-          ]
-      scriptRefTagSets = case referenceScript of
-        Nothing -> []
-        Just ref -> [ "Script Reference" `TagSet.tag` show ref ]
-      outputTagSet =
-        [ "amount" `TagSet.tagSetTag` pprintValue (fromPlutusValue amount)
-        , "address" `TagSet.tag` (show address)
-        ] <> datumTagSets <> scriptRefTagSets
-    in
-      foldMapWithIndex prettyEntry $ TagSet.fromArray outputTagSet
-
-  prettyEntry :: String -> TagSet.Tag -> String
-  prettyEntry k v = (k <> ": ")
-    <>
-      ( case v of
-          TagSet.StringTag s -> s
-          TagSet.NumberTag n -> show n
-          TagSet.IntTag i -> show i
-          TagSet.BooleanTag b -> show b
-          TagSet.JSDateTag date -> show date
-          TagSet.TagSetTag ts -> foldMapWithIndex prettyEntry ts
-      )
-    <> "\n"
-
-  prettyTokenName :: TokenName -> String
-  prettyTokenName = fromTokenName byteArrayToHex identity
-
-  prettyPlutusScript :: PlutusScript -> String
-  prettyPlutusScript (PlutusScript (code /\ lang)) =
-    show lang <> ": " <> byteArrayToHex code
-
-  prettyTxIn :: TransactionInput -> String
-  prettyTxIn (TransactionInput ti) =
-    "Id: "
-      <> byteArrayToHex (unwrap ti.transactionId)
-      <> "\nIndex: "
-      <>
-        show ti.index
-
-  prettyNativeScript :: Int -> NativeScript -> String
-  prettyNativeScript indent script =
-    let
-      newIndent = indent + 1
-    in
-      case script of
-        ScriptPubkey kh -> rawBytesToHex $ ed25519KeyHashToBytes kh
-        ScriptAll scripts -> "All of:\n" <>
-          joinWithIndentNewline newIndent scripts
-        ScriptAny scripts -> "At least one of:\n" <>
-          joinWithIndentNewline newIndent scripts
-        ScriptNOfK n scripts -> "At least " <> show n <> " of:\n" <>
-          joinWithIndentNewline newIndent scripts
-        TimelockStart slot -> "Timelock start for slot " <> show (unwrap slot)
-        TimelockExpiry slot -> "Timelock expiry for slot " <> show (unwrap slot)
-
-  joinWithIndentNewline :: Int -> Array NativeScript -> String
-  joinWithIndentNewline indent = map (prettyNativeScript indent) >>>
-    String.joinWith ("\n" <> spaces (2 * indent))
-
-  spaces :: Int -> String
-  spaces n
-    | n <= 0 = ""
-    | otherwise = " " <> spaces (n - 1)
-
--- Helpers
-
-bugTrackerLink :: String
-bugTrackerLink =
-  "https://github.com/Plutonomicon/cardano-transaction-lib/issues"

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -3,12 +3,15 @@
 module Contract.UnbalancedTx
   ( mkUnbalancedTx
   , mkUnbalancedTxM
+  , mkUnbalancedTxE
+  , explainMkUnbalancedTxError
   , module X
   ) where
 
 import Prelude
 
 import Contract.Monad (Contract)
+import Control.Monad.Error.Class (throwError)
 import Ctl.Internal.ProcessConstraints (mkUnbalancedTxImpl) as PC
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
@@ -38,6 +41,7 @@ import Ctl.Internal.ProcessConstraints.Error
       , TxOutRefNotFound
       , TxOutRefWrongType
       , WrongRefScriptHash
+      , ValidatorHashNotFound
       , CannotSatisfyAny
       , ExpectedPlutusScriptGotNativeScript
       , CannotMintZero
@@ -45,21 +49,91 @@ import Ctl.Internal.ProcessConstraints.Error
   ) as X
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx)
 import Ctl.Internal.ProcessConstraints.UnbalancedTx (UnbalancedTx(UnbalancedTx)) as X
+import Ctl.Internal.Transaction (explainModifyTxError)
+import Ctl.Internal.Types.Interval (explainPosixTimeToSlotError)
 import Ctl.Internal.Types.ScriptLookups
   ( ScriptLookups
   )
 import Ctl.Internal.Types.TxConstraints (TxConstraints)
-import Data.Either (Either, hush)
+import Data.Either (Either(Left, Right), hush)
 import Data.Maybe (Maybe)
+import Effect.Exception (error)
 
 -- | Create an `UnbalancedTx` given `ScriptLookups` and
 -- | `TxConstraints`. This should be called in conjuction with
 -- | `balanceTx` and  `signTransaction`.
+-- |
+-- | This is a 'non-throwing' variant; use this when failure is expected, and
+-- | can be handled gracefully.
 mkUnbalancedTx
   :: ScriptLookups
   -> TxConstraints
   -> Contract (Either MkUnbalancedTxError UnbalancedTx)
 mkUnbalancedTx = PC.mkUnbalancedTxImpl
+
+-- | As `mkUnbalancedTx`, but 'throwing'; use this when failure is _not_
+-- | expected, and graceful handling is either impossible, or wouldn't make
+-- | sense.
+mkUnbalancedTxE :: ScriptLookups -> TxConstraints -> Contract UnbalancedTx
+mkUnbalancedTxE lookups constraints =
+  mkUnbalancedTx lookups constraints >>= case _ of
+    Left err -> throwError $ error $ explainMkUnbalancedTxError err
+    Right res -> pure res
+
+-- | Helper to pretty-print `MkUnbalancedTxError`s.
+explainMkUnbalancedTxError :: MkUnbalancedTxError -> String
+explainMkUnbalancedTxError = case _ of
+  X.CannotConvertPaymentPubKeyHash ppkh ->
+    "Cannot convert payment pubkey hash: " <> show ppkh
+  X.CannotFindDatum -> "Cannot find datum."
+  X.CannotQueryDatum dh -> "Cannot query datum: " <> show dh
+  X.CannotConvertPOSIXTimeRange tr ttsErr ->
+    "Cannot convert POSIX time range: " <> show tr <> "\nReason: " <>
+      explainPosixTimeToSlotError ttsErr
+  X.CannotSolveTimeConstraints tr tr' ->
+    "Unsolvable time constraints: " <> show tr <> " and " <> show tr' <>
+      " do not overlap."
+  X.CannotGetMintingPolicyScriptIndex ->
+    "Cannot get minting policy script index. This should be impossible."
+  X.CannotGetValidatorHashFromAddress addr ->
+    "Cannot get a validator hash from address " <> show addr
+  X.CannotHashDatum datum ->
+    "Cannot hash datum: " <> show datum
+  X.CannotHashMintingPolicy mp ->
+    "Cannot hash minting policy: " <> show mp
+  X.CannotHashValidator validator ->
+    "Cannot hash validator: " <> show validator
+  X.CannotMakeValue cs tn amount ->
+    "Cannot make " <> show amount <> " of token " <> show tn <> " of currency "
+      <> show cs
+  X.CannotWithdrawRewardsPubKey spkh ->
+    "Cannot withdraw rewards from staking pubkey " <> show spkh
+  X.CannotWithdrawRewardsPlutusScript pssv ->
+    "Cannot withdraw rewards from Plutus staking script " <> show pssv
+  X.CannotWithdrawRewardsNativeScript nssv ->
+    "Cannot withdraw rewards from native staking script " <> show nssv
+  X.DatumNotFound hash -> "Datum with hash " <> show hash <> " not found."
+  X.DatumWrongHash hash datum -> "Datum " <> show datum
+    <> " does not have the hash "
+    <> show hash
+  X.MintingPolicyHashNotCurrencySymbol mph ->
+    "Minting policy hash " <> show mph <>
+      " is not the hash of a CurrencySymbol."
+  X.MintingPolicyNotFound mp -> "Minting policy not found: " <> show mp
+  X.ModifyTx modifyTxErr -> explainModifyTxError modifyTxErr
+  X.OwnPubKeyAndStakeKeyMissing -> "Own pubkey and staking key is missing."
+  X.TxOutRefNotFound ti -> "Cannot find transaction input: " <> show ti
+  X.TxOutRefWrongType ti ->
+    "Transaction input is missing an expected datum: " <> show ti
+  X.ValidatorHashNotFound vh -> "Cannot find validator hash: " <> show vh
+  X.WrongRefScriptHash msh ->
+    "Output is missing a reference script hash: " <> show msh
+  X.CannotSatisfyAny -> "List of constraints is empty."
+  X.ExpectedPlutusScriptGotNativeScript mph ->
+    "Expected a Plutus script, but " <> show mph <> "is a native script."
+  X.CannotMintZero cs tn -> "Cannot mint zero of token " <> show tn
+    <> " of currency "
+    <> show cs
 
 -- | Same as `mkUnbalancedTx` but hushes the error.
 -- TODO: remove, reason: it's trivial

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -155,7 +155,10 @@ explainMkUnbalancedTxError = case _ of
   MintingPolicyHashNotCurrencySymbol mph ->
     "Minting policy hash " <> show mph <>
       " is not a CurrencySymbol. Please check the validity of the byte representation."
-  MintingPolicyNotFound mp -> "Minting policy not found: " <> show mp
+  MintingPolicyNotFound mp -> "Minting policy "
+    <> show mp
+    <>
+      " not found in a set of minting policies"
   ModifyTx modifyTxErr -> explainModifyTxError modifyTxErr
   OwnPubKeyAndStakeKeyMissing ->
     "Could not build own address: both payment pubkey and stake pubkey are missing"

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -23,7 +23,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashDatum
       , CannotHashMintingPolicy
       , CannotHashValidator
       , CannotMakeValue
@@ -53,7 +52,6 @@ import Ctl.Internal.ProcessConstraints.Error
       , CannotSolveTimeConstraints
       , CannotGetMintingPolicyScriptIndex
       , CannotGetValidatorHashFromAddress
-      , CannotHashDatum
       , CannotHashMintingPolicy
       , CannotHashValidator
       , CannotMakeValue
@@ -132,8 +130,6 @@ explainMkUnbalancedTxError = case _ of
       <> bugTrackerLink
   CannotGetValidatorHashFromAddress addr ->
     "Cannot get a validator hash from address " <> show addr
-  CannotHashDatum datum ->
-    "Cannot hash datum: " <> show datum
   CannotHashMintingPolicy mp ->
     "Cannot hash minting policy: " <> show mp
   CannotHashValidator validator ->

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -93,19 +93,20 @@ import Effect.Exception (error)
 -- | `balanceTx` and  `signTransaction`.
 -- |
 -- | This is a 'non-throwing' variant; use this when failure is expected, and
--- | can be handled gracefully.
-mkUnbalancedTx
+-- | can be handled gracefully. If you need the 'throwing' variant, use
+-- | `mkUnbalancedTx` instead.
+mkUnbalancedTxE
   :: ScriptLookups
   -> TxConstraints
   -> Contract (Either MkUnbalancedTxError UnbalancedTx)
-mkUnbalancedTx = PC.mkUnbalancedTxImpl
+mkUnbalancedTxE = PC.mkUnbalancedTxImpl
 
--- | As `mkUnbalancedTx`, but 'throwing'; use this when failure is _not_
+-- | As `mkUnbalancedTxE`, but 'throwing'; use this when failure is _not_
 -- | expected, and graceful handling is either impossible, or wouldn't make
 -- | sense.
-mkUnbalancedTxE :: ScriptLookups -> TxConstraints -> Contract UnbalancedTx
-mkUnbalancedTxE lookups constraints =
-  mkUnbalancedTx lookups constraints >>= case _ of
+mkUnbalancedTx :: ScriptLookups -> TxConstraints -> Contract UnbalancedTx
+mkUnbalancedTx lookups constraints =
+  mkUnbalancedTxE lookups constraints >>= case _ of
     Left err -> throwError $ error $ explainMkUnbalancedTxError err
     Right res -> pure res
 

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -14,9 +14,6 @@ import Control.Monad.Error.Class (throwError)
 import Ctl.Internal.ProcessConstraints (mkUnbalancedTxImpl) as PC
 import Ctl.Internal.ProcessConstraints.Error
   ( MkUnbalancedTxError
-  )
-import Ctl.Internal.ProcessConstraints.Error
-  ( MkUnbalancedTxError
       ( CannotFindDatum
       , CannotQueryDatum
       , CannotConvertPOSIXTimeRange

--- a/src/Contract/UnbalancedTx.purs
+++ b/src/Contract/UnbalancedTx.purs
@@ -125,7 +125,7 @@ explainMkUnbalancedTxError = case _ of
       <> "Please report this as a bug here: "
       <> bugTrackerLink
   CannotGetValidatorHashFromAddress addr ->
-    "Cannot get a validator hash from address " <> show addr
+    "Cannot get a payment validator hash from address " <> show addr
   CannotMakeValue _ tn _ ->
     "Attempted to make an amount with the ADA currency symbol, and non-empty token name "
       <> show tn
@@ -143,7 +143,7 @@ explainMkUnbalancedTxError = case _ of
     <> show hash
   MintingPolicyHashNotCurrencySymbol mph ->
     "Minting policy hash " <> show mph <>
-      " is not the hash of a CurrencySymbol."
+      " is not a CurrencySymbol. Please check the validity of the byte representation."
   MintingPolicyNotFound mp -> "Minting policy not found: " <> show mp
   ModifyTx modifyTxErr -> explainModifyTxError modifyTxErr
   OwnPubKeyAndStakeKeyMissing ->

--- a/src/Internal/BalanceTx/CoinSelection.purs
+++ b/src/Internal/BalanceTx/CoinSelection.purs
@@ -29,7 +29,6 @@ import Ctl.Internal.BalanceTx.Error
       , InsufficientUtxoBalanceToCoverAsset
       )
   , Expected(Expected)
-  , ImpossibleError(Impossible)
   , InvalidInContext(InvalidInContext)
   )
 import Ctl.Internal.Cardano.Types.Transaction (UtxoMap)
@@ -356,7 +355,7 @@ runSelectionStep lens state
       let
         balanceInsufficientError :: BalanceTxError
         balanceInsufficientError =
-          InsufficientUtxoBalanceToCoverAsset Impossible lens.assetDisplayString
+          InsufficientUtxoBalanceToCoverAsset lens.assetDisplayString
       in
         lens.selectQuantityCover state
           >>= maybe (throwError balanceInsufficientError) (pure <<< Just)

--- a/src/Internal/BalanceTx/CoinSelection.purs
+++ b/src/Internal/BalanceTx/CoinSelection.purs
@@ -29,7 +29,6 @@ import Ctl.Internal.BalanceTx.Error
       , InsufficientUtxoBalanceToCoverAsset
       )
   , Expected(Expected)
-  , InvalidInContext(InvalidInContext)
   )
 import Ctl.Internal.Cardano.Types.Transaction (UtxoMap)
 import Ctl.Internal.Cardano.Types.Value (AssetClass(AssetClass), Coin, Value)
@@ -141,7 +140,6 @@ performMultiAssetSelection strategy utxoIndex requiredValue =
     BalanceInsufficientError
       (Expected $ toPlutusValue requiredValue)
       (Actual $ toPlutusValue availableValue)
-      (InvalidInContext $ toPlutusValue mempty)
 
   availableValue :: Value
   availableValue = balance (utxoIndexUniverse utxoIndex)

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -33,6 +33,7 @@ import Ctl.Internal.Cardano.Types.Transaction
   , _witnessSet
   )
 import Ctl.Internal.Cardano.Types.Value (pprintValue)
+import Ctl.Internal.Helpers (bugTrackerLink)
 import Ctl.Internal.Plutus.Conversion.Value (fromPlutusValue)
 import Ctl.Internal.Plutus.Types.Value (Value)
 import Ctl.Internal.QueryM.Ogmios
@@ -98,8 +99,6 @@ data BalanceTxError
 derive instance Generic BalanceTxError _
 
 instance Show BalanceTxError where
-  show (ExUnitsEvaluationFailed tx failure) =
-    "ExUnitsEvaluationFailed: " <> printTxEvaluationFailure tx failure
   show e = genericShow e
 
 explainBalanceTxError :: BalanceTxError -> String
@@ -312,7 +311,3 @@ printTxEvaluationFailure transaction e =
     :: Ogmios.RedeemerPointer -> Array Ogmios.ScriptFailure -> PrettyString
   printScriptFailures ptr sfs = printRedeemer ptr <> bullet
     (foldMap printScriptFailure sfs)
-
-bugTrackerLink :: String
-bugTrackerLink =
-  "https://github.com/Plutonomicon/cardano-transaction-lib/issues"

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -32,6 +32,8 @@ import Ctl.Internal.Cardano.Types.Transaction
   , _redeemers
   , _witnessSet
   )
+import Ctl.Internal.Cardano.Types.Value (pprintValue)
+import Ctl.Internal.Plutus.Conversion.Value (fromPlutusValue)
 import Ctl.Internal.Plutus.Types.Value (Value)
 import Ctl.Internal.QueryM.Ogmios
   ( RedeemerPointer
@@ -60,8 +62,18 @@ import Data.Function (applyN)
 import Data.Generic.Rep (class Generic)
 import Data.Int (ceil, decimal, toNumber, toStringAs)
 import Data.Lens (non, (^.))
+import Data.Log.Tag
+  ( Tag
+      ( StringTag
+      , IntTag
+      , NumberTag
+      , BooleanTag
+      , JSDateTag
+      , TagSetTag
+      )
+  )
 import Data.Maybe (Maybe(Just, Nothing))
-import Data.Newtype (class Newtype)
+import Data.Newtype (class Newtype, unwrap)
 import Data.Show.Generic (genericShow)
 import Data.String (Pattern(Pattern))
 import Data.String.CodePoints (length) as String
@@ -93,9 +105,9 @@ instance Show BalanceTxError where
 explainBalanceTxError :: BalanceTxError -> String
 explainBalanceTxError = case _ of
   BalanceInsufficientError expected actual ->
-    "Insufficient balance. Expected: " <> show expected
+    "Insufficient balance. Expected: " <> prettyValue expected
       <> ", actual: "
-      <> show actual
+      <> prettyValue actual
   CouldNotConvertScriptOutputToTxInput ->
     "Could not convert script output to transaction input"
   CouldNotGetChangeAddress ->
@@ -138,6 +150,27 @@ explainBalanceTxError = case _ of
         bugTrackerLink
   UtxoMinAdaValueCalculationFailed ->
     "Could not calculate min ADA for UTxO"
+  where
+  prettyValue
+    :: forall (a :: Type)
+     . Newtype a Value
+    => a
+    -> String
+  prettyValue = unwrap >>> fromPlutusValue >>> pprintValue >>>
+    foldMapWithIndex prettyEntry
+
+  prettyEntry :: String -> Tag -> String
+  prettyEntry k v = (k <> ": ")
+    <>
+      ( case v of
+          StringTag s -> s
+          NumberTag n -> show n
+          IntTag i -> show i
+          BooleanTag b -> show b
+          JSDateTag date -> show date
+          TagSetTag ts -> foldMapWithIndex prettyEntry ts
+      )
+    <> "\n"
 
 newtype Actual = Actual Value
 

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -3,7 +3,6 @@
 -- | that may be returned from Ogmios when calculating ex units.
 module Ctl.Internal.BalanceTx.Error
   ( Actual(Actual)
-  , InvalidInContext(InvalidInContext)
   , BalanceTxError
       ( BalanceInsufficientError
       , CouldNotConvertScriptOutputToTxInput
@@ -71,7 +70,7 @@ import Data.String.Utils (padEnd)
 
 -- | Errors conditions that may possibly arise during transaction balancing
 data BalanceTxError
-  = BalanceInsufficientError Expected Actual InvalidInContext
+  = BalanceInsufficientError Expected Actual
   | CouldNotConvertScriptOutputToTxInput
   | CouldNotGetChangeAddress
   | CouldNotGetCollateral
@@ -93,12 +92,10 @@ instance Show BalanceTxError where
 
 explainBalanceTxError :: BalanceTxError -> String
 explainBalanceTxError = case _ of
-  BalanceInsufficientError expected actual ctx ->
+  BalanceInsufficientError expected actual ->
     "Insufficient balance. Expected: " <> show expected
       <> ", actual: "
       <> show actual
-      <> ". All available: "
-      <> show ctx
   CouldNotConvertScriptOutputToTxInput ->
     "Could not convert script output to transaction input"
   CouldNotGetChangeAddress ->
@@ -148,14 +145,6 @@ derive instance Generic Actual _
 derive instance Newtype Actual _
 
 instance Show Actual where
-  show = genericShow
-
-newtype InvalidInContext = InvalidInContext Value
-
-derive instance Generic InvalidInContext _
-derive instance Newtype InvalidInContext _
-
-instance Show InvalidInContext where
   show = genericShow
 
 newtype Expected = Expected Value

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -21,6 +21,7 @@ module Ctl.Internal.BalanceTx.Error
   , Expected(Expected)
   , ImpossibleError(Impossible)
   , printTxEvaluationFailure
+  , explainBalanceTxError
   ) where
 
 import Prelude
@@ -88,6 +89,37 @@ instance Show BalanceTxError where
   show (ExUnitsEvaluationFailed tx failure) =
     "ExUnitsEvaluationFailed: " <> printTxEvaluationFailure tx failure
   show e = genericShow e
+
+explainBalanceTxError :: BalanceTxError -> String
+explainBalanceTxError = case _ of
+  BalanceInsufficientError expected actual ctx ->
+    "Insufficient balance. Expected: " <> show expected
+      <> ", actual: "
+      <> show actual
+      <> ". Context: "
+      <> show ctx
+  CouldNotConvertScriptOutputToTxInput ->
+    "Could not convert script output to transaction input."
+  CouldNotGetChangeAddress ->
+    "Could not get change address."
+  CouldNotGetCollateral -> "Could not get collateral."
+  CouldNotGetUtxos -> "Could not get UTxOs."
+  CollateralReturnError err ->
+    "Collateral return error: " <> show err
+  CollateralReturnMinAdaValueCalcError ->
+    "Could not calculate minimum Ada for collateral return."
+  ExUnitsEvaluationFailed tx txEvalErr ->
+    "Script evaluation failure. Transaction: " <> show tx
+      <> "Error: "
+      <> show txEvalErr
+  InsufficientUtxoBalanceToCoverAsset _ asset ->
+    "Insufficient UTxO balance to cover asset " <> show asset
+  ReindexRedeemersError uir ->
+    "Could not reindex redeemer " <> show uir
+  UtxoLookupFailedFor ti ->
+    "Could not look up UTxO for " <> show ti
+  UtxoMinAdaValueCalculationFailed ->
+    "Could not calculate min ADA for UTxO."
 
 newtype Actual = Actual Value
 

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -102,9 +102,10 @@ explainBalanceTxError = case _ of
   CouldNotConvertScriptOutputToTxInput ->
     "Could not convert script output to transaction input"
   CouldNotGetChangeAddress ->
-    "Could not get change address"
+    "Could not get change address from the wallet or from the balancer constraints"
   CouldNotGetCollateral -> "Could not get collateral from wallet"
-  CouldNotGetUtxos -> "Could not get UTxOs"
+  CouldNotGetUtxos ->
+    "Could not get UTxOs from the wallet or the specified source addresses"
   CollateralReturnError ->
     "Negative totalCollateral after covering min-utxo-ada requirement."
       <> "This should be impossible: please report this as a bug to "
@@ -132,7 +133,12 @@ explainBalanceTxError = case _ of
       <>
         bugTrackerLink
   UtxoLookupFailedFor ti ->
-    "Could not look up UTxO for " <> show ti
+    "Could not look up UTxO for "
+      <> show ti
+      <> " from a given set of UTxOs.\n"
+      <> "This should be impossible: please report this as a bug to "
+      <>
+        bugTrackerLink
   UtxoMinAdaValueCalculationFailed ->
     "Could not calculate min ADA for UTxO"
 

--- a/src/Internal/BalanceTx/Error.purs
+++ b/src/Internal/BalanceTx/Error.purs
@@ -118,36 +118,31 @@ explainBalanceTxError = case _ of
   CollateralReturnError ->
     "Negative totalCollateral after covering min-utxo-ada requirement."
       <> "This should be impossible: please report this as a bug to "
-      <>
-        bugTrackerLink
+      <> bugTrackerLink
   CollateralReturnMinAdaValueCalcError coinsPerUtxoUnit txOut ->
     "Could not calculate minimum Ada for collateral return.\n"
       <> "Coins per UTxO unit: "
       <> show coinsPerUtxoUnit
       <> "\nTransaction output: "
-      <>
-        show txOut
+      <> show txOut
   ExUnitsEvaluationFailed _ _ ->
     "Script evaluation failure while trying to estimate ExUnits"
   InsufficientUtxoBalanceToCoverAsset asset ->
     "Insufficient UTxO balance to cover asset named "
       <> asset
       <> "\nThis should be impossible: please report this as a bug to "
-      <>
-        bugTrackerLink
+      <> bugTrackerLink
   ReindexRedeemersError uir ->
     "Could not reindex redeemer "
       <> show uir
       <> "\nThis should be impossible: please report this as a bug to "
-      <>
-        bugTrackerLink
+      <> bugTrackerLink
   UtxoLookupFailedFor ti ->
     "Could not look up UTxO for "
       <> show ti
       <> " from a given set of UTxOs.\n"
       <> "This should be impossible: please report this as a bug to "
-      <>
-        bugTrackerLink
+      <> bugTrackerLink
   UtxoMinAdaValueCalculationFailed ->
     "Could not calculate min ADA for UTxO"
   where

--- a/src/Internal/Cardano/Types/NativeScript.purs
+++ b/src/Internal/Cardano/Types/NativeScript.purs
@@ -7,6 +7,7 @@ module Ctl.Internal.Cardano.Types.NativeScript
       , TimelockStart
       , TimelockExpiry
       )
+  , pprintNativeScript
   ) where
 
 import Prelude
@@ -22,14 +23,22 @@ import Aeson
 import Ctl.Internal.Helpers (contentsProp, encodeTagged', tagProp)
 import Ctl.Internal.Metadata.Helpers (errExpectedObject)
 import Ctl.Internal.Serialization.Address (Slot)
-import Ctl.Internal.Serialization.Hash (Ed25519KeyHash, ed25519KeyHashFromBytes)
+import Ctl.Internal.Serialization.Hash
+  ( Ed25519KeyHash
+  , ed25519KeyHashFromBytes
+  , ed25519KeyHashToBytes
+  )
 import Ctl.Internal.Types.BigNum (fromString)
+import Ctl.Internal.Types.BigNum as BigNum
 import Ctl.Internal.Types.ByteArray (hexToByteArrayUnsafe)
+import Ctl.Internal.Types.RawBytes (rawBytesToHex)
 import Data.Array.NonEmpty (fromFoldable)
 import Data.Either (Either(Left))
 import Data.Generic.Rep (class Generic)
+import Data.Log.Tag (TagSet, tag, tagSetTag)
+import Data.Log.Tag as TagSet
 import Data.Maybe (fromJust)
-import Data.Newtype (wrap)
+import Data.Newtype (unwrap, wrap)
 import Data.Show.Generic (genericShow)
 import Partial.Unsafe (unsafePartial)
 import Test.QuickCheck (class Arbitrary)
@@ -99,3 +108,16 @@ instance EncodeAeson NativeScript where
       { n, nativeScripts }
     TimelockStart r -> encodeTagged' "TimelockStart" r
     TimelockExpiry r -> encodeTagged' "TimelockExpiry" r
+
+pprintNativeScript :: NativeScript -> TagSet
+pprintNativeScript = case _ of
+  ScriptPubkey kh -> TagSet.fromArray
+    [ "PubKey" `tag` rawBytesToHex (ed25519KeyHashToBytes kh) ]
+  ScriptAll scripts -> "All of" `tagSetTag` TagSet.fromArray
+    (pprintNativeScript <$> scripts)
+  ScriptAny scripts -> "Any of" `tagSetTag` TagSet.fromArray
+    (pprintNativeScript <$> scripts)
+  ScriptNOfK n scripts -> ("At least " <> show n <> " of ")
+    `tagSetTag` TagSet.fromArray (pprintNativeScript <$> scripts)
+  TimelockStart slot -> "Timelock start" `tag` BigNum.toString (unwrap slot)
+  TimelockExpiry slot -> "Timelock expiry" `tag` BigNum.toString (unwrap slot)

--- a/src/Internal/Cardano/Types/Value.purs
+++ b/src/Internal/Cardano/Types/Value.purs
@@ -500,7 +500,7 @@ instance Equipartition Value where
 
 pprintValue :: Value -> TagSet
 pprintValue value = TagSet.fromArray $
-  [ "ADA" `tag` BigInt.toString (unwrap (valueToCoin value)) ]
+  [ "Lovelace" `tag` BigInt.toString (unwrap (valueToCoin value)) ]
     <>
       if nonAdaAssets /= mempty then
         [ "Assets" `tagSetTag` pprintNonAdaAsset nonAdaAssets ]

--- a/src/Internal/Helpers.purs
+++ b/src/Internal/Helpers.purs
@@ -9,6 +9,7 @@ module Ctl.Internal.Helpers
   , appendMap
   , appendRightMap
   , bigIntToUInt
+  , bugTrackerLink
   , concatPaths
   , contentsProp
   , encodeMap
@@ -31,6 +32,7 @@ module Ctl.Internal.Helpers
   , showWithParens
   , tagProp
   , uIntToBigInt
+  , unsafePprintTagSet
   ) where
 
 import Prelude
@@ -47,8 +49,9 @@ import Data.Function (on)
 import Data.JSDate (now)
 import Data.List.Lazy as LL
 import Data.Log.Formatter.Pretty (prettyFormatter)
-import Data.Log.Level (LogLevel)
+import Data.Log.Level (LogLevel(Info))
 import Data.Log.Message (Message)
+import Data.Log.Tag (TagSet)
 import Data.Map (Map, toUnfoldable)
 import Data.Map as Map
 import Data.Maybe (Maybe(Just, Nothing), fromJust, fromMaybe, maybe)
@@ -65,9 +68,20 @@ import Effect (Effect)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (log)
 import Effect.Exception (throw)
+import Effect.Unsafe (unsafePerformEffect)
 import Foreign.Object as Obj
 import Partial.Unsafe (unsafePartial)
 import Prim.TypeError (class Warn, Text)
+
+bugTrackerLink :: String
+bugTrackerLink =
+  "https://github.com/Plutonomicon/cardano-transaction-lib/issues"
+
+unsafePprintTagSet :: String -> TagSet -> String
+unsafePprintTagSet message tags = unsafePerformEffect do
+  timestamp <- now
+  let msg = { level: Info, message, tags, timestamp }
+  prettyFormatter msg
 
 -- | Throws provided error on `Nothing`
 fromJustEff :: forall (a :: Type). String -> Maybe a -> Effect a

--- a/src/Internal/Plutus/Types/Transaction.purs
+++ b/src/Internal/Plutus/Types/Transaction.purs
@@ -6,30 +6,33 @@ module Ctl.Internal.Plutus.Types.Transaction
   , _datum
   , _output
   , _scriptRef
+  , pprintTransactionOutput
   ) where
 
 import Prelude
 
-import Aeson
-  ( class DecodeAeson
-  , class EncodeAeson
-  )
+import Aeson (class DecodeAeson, class EncodeAeson)
 import Ctl.Internal.Cardano.Types.ScriptRef (ScriptRef)
+import Ctl.Internal.Cardano.Types.Value (pprintValue)
 import Ctl.Internal.FromData (class FromData, fromData)
+import Ctl.Internal.Plutus.Conversion.Value (fromPlutusValue)
 import Ctl.Internal.Plutus.Types.Address (Address)
 import Ctl.Internal.Plutus.Types.Value (Value)
-import Ctl.Internal.Serialization.Hash (ScriptHash)
+import Ctl.Internal.Serialization.Hash (ScriptHash, scriptHashToBytes)
 import Ctl.Internal.ToData (class ToData, toData)
 import Ctl.Internal.Types.BigNum as BigNum
-import Ctl.Internal.Types.OutputDatum (OutputDatum)
+import Ctl.Internal.Types.OutputDatum (OutputDatum, pprintOutputDatum)
 import Ctl.Internal.Types.PlutusData (PlutusData(Constr))
+import Ctl.Internal.Types.RawBytes (rawBytesToHex)
 import Ctl.Internal.Types.Transaction (TransactionInput)
 import Data.Generic.Rep (class Generic)
 import Data.Lens (Lens')
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
+import Data.Log.Tag (TagSet, tag, tagSetTag)
+import Data.Log.Tag as TagSet
 import Data.Map (Map)
-import Data.Maybe (Maybe(Nothing))
+import Data.Maybe (Maybe(Nothing), maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Show.Generic (genericShow)
 import Type.Proxy (Proxy(Proxy))
@@ -74,6 +77,19 @@ instance ToData TransactionOutput where
   toData (TransactionOutput { address, amount, datum, referenceScript }) =
     Constr BigNum.zero
       [ toData address, toData amount, toData datum, toData referenceScript ]
+
+pprintTransactionOutput :: TransactionOutput -> TagSet
+pprintTransactionOutput
+  (TransactionOutput { address, amount, datum, referenceScript }) =
+  TagSet.fromArray $
+    [ "address" `tag` show address
+    , "amount" `tagSetTag` pprintValue (fromPlutusValue amount)
+    , pprintOutputDatum datum
+    ] <> referenceScriptTagSet
+  where
+  referenceScriptTagSet = maybe []
+    (pure <<< tag "referenceScript" <<< rawBytesToHex <<< scriptHashToBytes)
+    referenceScript
 
 newtype TransactionOutputWithRefScript = TransactionOutputWithRefScript
   { output :: TransactionOutput

--- a/src/Internal/ProcessConstraints.purs
+++ b/src/Internal/ProcessConstraints.purs
@@ -477,6 +477,7 @@ processScriptRefUnspentOut scriptHash inputWithRefScript = do
 
       err :: ConstraintsM (Either MkUnbalancedTxError Unit)
       err = pure $ throwError $ WrongRefScriptHash refScriptHash
+        (unwrap output).output
     in
       if Just (unwrap scriptHash) /= refScriptHash then err
       else pure (Right unit)
@@ -484,8 +485,12 @@ processScriptRefUnspentOut scriptHash inputWithRefScript = do
 checkRefNative
   :: InputWithScriptRef
   -> ConstraintsM (Either MkUnbalancedTxError Boolean)
-checkRefNative scriptRef = pure $ note (WrongRefScriptHash Nothing) $ isNative
-  (unwrap (unwrap uout).output).scriptRef
+checkRefNative scriptRef =
+  let
+    out = (unwrap ((unwrap uout).output)).output
+  in
+    pure $ note (WrongRefScriptHash Nothing out) $ isNative
+      (unwrap (unwrap uout).output).scriptRef
   where
   isNative ref = ref >>=
     ( case _ of

--- a/src/Internal/ProcessConstraints/Error.purs
+++ b/src/Internal/ProcessConstraints/Error.purs
@@ -3,6 +3,7 @@ module Ctl.Internal.ProcessConstraints.Error where
 import Prelude
 
 import Ctl.Internal.Cardano.Types.Value (CurrencySymbol)
+import Ctl.Internal.Plutus.Types.Transaction (TransactionOutput)
 import Ctl.Internal.Serialization.Address (Address)
 import Ctl.Internal.Serialization.Hash (ScriptHash)
 import Ctl.Internal.Transaction (ModifyTxError)
@@ -42,7 +43,7 @@ data MkUnbalancedTxError
   | TxOutRefNotFound TransactionInput
   | TxOutRefWrongType TransactionInput
   | ValidatorHashNotFound ValidatorHash
-  | WrongRefScriptHash (Maybe ScriptHash)
+  | WrongRefScriptHash (Maybe ScriptHash) TransactionOutput
   | CannotSatisfyAny
   | ExpectedPlutusScriptGotNativeScript MintingPolicyHash
   | CannotMintZero CurrencySymbol TokenName

--- a/src/Internal/ProcessConstraints/Error.purs
+++ b/src/Internal/ProcessConstraints/Error.purs
@@ -31,7 +31,6 @@ data MkUnbalancedTxError
   | CannotSolveTimeConstraints POSIXTimeRange POSIXTimeRange
   | CannotGetMintingPolicyScriptIndex -- Should be impossible
   | CannotGetValidatorHashFromAddress Address -- Get `ValidatorHash` from internal `Address`
-  | CannotHashDatum Datum
   | CannotHashMintingPolicy MintingPolicy
   | CannotHashValidator Validator
   | CannotMakeValue CurrencySymbol TokenName BigInt

--- a/src/Internal/ProcessConstraints/Error.purs
+++ b/src/Internal/ProcessConstraints/Error.purs
@@ -8,7 +8,7 @@ import Ctl.Internal.Serialization.Hash (ScriptHash)
 import Ctl.Internal.Transaction (ModifyTxError)
 import Ctl.Internal.Types.Datum (DataHash, Datum)
 import Ctl.Internal.Types.Interval (POSIXTimeRange, PosixTimeToSlotError)
-import Ctl.Internal.Types.PubKeyHash (PaymentPubKeyHash, StakePubKeyHash)
+import Ctl.Internal.Types.PubKeyHash (StakePubKeyHash)
 import Ctl.Internal.Types.Scripts
   ( MintingPolicy
   , MintingPolicyHash
@@ -25,8 +25,7 @@ import Data.Maybe (Maybe)
 import Data.Show.Generic (genericShow)
 
 data MkUnbalancedTxError
-  = CannotConvertPaymentPubKeyHash PaymentPubKeyHash
-  | CannotFindDatum
+  = CannotFindDatum
   | CannotQueryDatum DataHash
   | CannotConvertPOSIXTimeRange POSIXTimeRange PosixTimeToSlotError
   | CannotSolveTimeConstraints POSIXTimeRange POSIXTimeRange

--- a/src/Internal/ProcessConstraints/Error.purs
+++ b/src/Internal/ProcessConstraints/Error.purs
@@ -2,26 +2,46 @@ module Ctl.Internal.ProcessConstraints.Error where
 
 import Prelude
 
-import Ctl.Internal.Cardano.Types.Value (CurrencySymbol)
-import Ctl.Internal.Plutus.Types.Transaction (TransactionOutput)
-import Ctl.Internal.Serialization.Address (Address)
-import Ctl.Internal.Serialization.Hash (ScriptHash)
-import Ctl.Internal.Transaction (ModifyTxError)
-import Ctl.Internal.Types.Datum (DataHash, Datum)
-import Ctl.Internal.Types.Interval (POSIXTimeRange, PosixTimeToSlotError)
+import Ctl.Internal.Cardano.Types.NativeScript (pprintNativeScript)
+import Ctl.Internal.Cardano.Types.Value (CurrencySymbol, getCurrencySymbol)
+import Ctl.Internal.Helpers (bugTrackerLink, unsafePprintTagSet)
+import Ctl.Internal.Plutus.Types.Transaction
+  ( TransactionOutput
+  , pprintTransactionOutput
+  )
+import Ctl.Internal.Serialization.Address (Address, addressBech32)
+import Ctl.Internal.Serialization.Hash
+  ( ScriptHash
+  , ed25519KeyHashToBytes
+  , scriptHashToBytes
+  )
+import Ctl.Internal.Transaction (ModifyTxError, explainModifyTxError)
+import Ctl.Internal.Types.ByteArray (byteArrayToHex)
+import Ctl.Internal.Types.Datum (DataHash(DataHash), Datum)
+import Ctl.Internal.Types.Interval
+  ( POSIXTimeRange
+  , PosixTimeToSlotError
+  , explainPosixTimeToSlotError
+  )
 import Ctl.Internal.Types.PubKeyHash (StakePubKeyHash)
+import Ctl.Internal.Types.RawBytes (rawBytesToHex)
 import Ctl.Internal.Types.Scripts
   ( MintingPolicyHash
   , NativeScriptStakeValidator
+  , PlutusScript(PlutusScript)
   , PlutusScriptStakeValidator
   , ValidatorHash
   )
-import Ctl.Internal.Types.TokenName (TokenName)
-import Ctl.Internal.Types.Transaction (TransactionInput)
+import Ctl.Internal.Types.TokenName (TokenName, fromTokenName)
+import Ctl.Internal.Types.Transaction (TransactionInput(TransactionInput))
 import Data.BigInt (BigInt)
 import Data.Generic.Rep (class Generic)
-import Data.Maybe (Maybe)
+import Data.Log.Tag (tagSetTag)
+import Data.Maybe (Maybe(Just, Nothing))
+import Data.Newtype (unwrap)
 import Data.Show.Generic (genericShow)
+import Data.Tuple.Nested ((/\))
+import Data.UInt as UInt
 
 data MkUnbalancedTxError
   = CannotFindDatum
@@ -53,3 +73,105 @@ derive instance Eq MkUnbalancedTxError
 
 instance Show MkUnbalancedTxError where
   show = genericShow
+
+-- | Helper to pretty-print `MkUnbalancedTxError`s.
+explainMkUnbalancedTxError :: MkUnbalancedTxError -> String
+explainMkUnbalancedTxError = case _ of
+  CannotFindDatum -> "Cannot find datum"
+  CannotQueryDatum (DataHash dh) ->
+    "Querying for datum by datum hash ("
+      <> byteArrayToHex dh
+      <> ") failed: no datum found"
+  CannotConvertPOSIXTimeRange tr ttsErr ->
+    "Cannot convert POSIX time range to slot time range.\nRange: "
+      <> show tr
+      <> "\nReason: "
+      <> explainPosixTimeToSlotError ttsErr
+  CannotSolveTimeConstraints tr tr' ->
+    "Unsolvable time constraints: " <> show tr <> " and " <> show tr' <>
+      " do not overlap."
+  CannotGetMintingPolicyScriptIndex ->
+    "Cannot get minting policy script index. This should be impossible.\n"
+      <> "Please report this as a bug here: "
+      <> bugTrackerLink
+  CannotGetValidatorHashFromAddress addr ->
+    "Cannot get a payment validator hash from address " <>
+      addressBech32 addr
+  CannotMakeValue _ tn _ ->
+    "Attempted to make an amount with the ADA currency symbol, and "
+      <> "non-empty token name "
+      <> prettyTokenName tn
+      <> ". This is not allowed, as the ADA currency symbol can only be "
+      <> "combined with the empty token name."
+  CannotWithdrawRewardsPubKey spkh ->
+    "Cannot withdraw rewards, as pubkey "
+      <> rawBytesToHex (ed25519KeyHashToBytes $ unwrap $ unwrap spkh)
+      <> " is not registered"
+  CannotWithdrawRewardsPlutusScript pssv ->
+    "Cannot withdraw rewards from Plutus staking script " <>
+      prettyPlutusScript (unwrap pssv)
+  CannotWithdrawRewardsNativeScript nssv ->
+    unsafePprintTagSet "Cannot withdraw rewards from native staking script "
+      ("NativeScript" `tagSetTag` pprintNativeScript (unwrap nssv))
+  DatumNotFound (DataHash hash) -> "Datum with hash " <> byteArrayToHex hash <>
+    " not found."
+  DatumWrongHash (DataHash dh) datum -> "Datum "
+    <> show datum
+    <> " does not have the hash "
+    <> byteArrayToHex dh
+  MintingPolicyHashNotCurrencySymbol mph ->
+    "Minting policy hash "
+      <> rawBytesToHex (scriptHashToBytes $ unwrap mph)
+      <>
+        " is not a CurrencySymbol. Please check the validity of the byte representation."
+  MintingPolicyNotFound mp -> "Minting policy with hash "
+    <> rawBytesToHex (scriptHashToBytes $ unwrap mp)
+    <> " not found in a set of minting policies"
+  ModifyTx modifyTxErr -> explainModifyTxError modifyTxErr
+  OwnPubKeyAndStakeKeyMissing ->
+    "Could not build own address: both payment pubkey and stake pubkey are missing"
+  TxOutRefNotFound ti ->
+    "Could not find a reference input:\n"
+      <> prettyTxIn ti
+      <> "\nIt maybe have been consumed, or was never created."
+  TxOutRefWrongType ti ->
+    "Transaction output is missing an expected datum:\n"
+      <> prettyTxIn ti
+      <> "\nContext: we were trying to spend a script output."
+  ValidatorHashNotFound vh -> "Cannot find validator hash: " <>
+    rawBytesToHex (scriptHashToBytes $ unwrap vh)
+  WrongRefScriptHash msh tout -> case msh of
+    Nothing -> unsafePprintTagSet "Output is missing a reference script hash"
+      ("TransactionOutput" `tagSetTag` pprintTransactionOutput tout)
+    Just missingHash ->
+      unsafePprintTagSet
+        ( "TransactionOutput is missing reference script hash "
+            <> rawBytesToHex (scriptHashToBytes missingHash)
+        )
+        ("TransactionOutput" `tagSetTag` pprintTransactionOutput tout)
+  CannotSatisfyAny -> "One of the following happened:\n"
+    <> "1. List of constraints is empty.\n"
+    <> "2. All alternatives of a 'mustSatisfyAnyOf' have failed."
+  ExpectedPlutusScriptGotNativeScript mph ->
+    "Expected a Plutus script, but "
+      <> rawBytesToHex (scriptHashToBytes $ unwrap mph)
+      <> " is a hash of a native script."
+  CannotMintZero cs tn ->
+    "Cannot mint zero of token "
+      <> prettyTokenName tn
+      <> " of currency "
+      <> byteArrayToHex (getCurrencySymbol cs)
+  where
+
+  prettyTokenName :: TokenName -> String
+  prettyTokenName = fromTokenName byteArrayToHex show
+
+  prettyPlutusScript :: PlutusScript -> String
+  prettyPlutusScript (PlutusScript (code /\ lang)) =
+    show lang <> ": " <> byteArrayToHex code
+
+  prettyTxIn :: TransactionInput -> String
+  prettyTxIn (TransactionInput ti) =
+    byteArrayToHex (unwrap ti.transactionId)
+      <> "#"
+      <> UInt.toString ti.index

--- a/src/Internal/ProcessConstraints/Error.purs
+++ b/src/Internal/ProcessConstraints/Error.purs
@@ -10,11 +10,9 @@ import Ctl.Internal.Types.Datum (DataHash, Datum)
 import Ctl.Internal.Types.Interval (POSIXTimeRange, PosixTimeToSlotError)
 import Ctl.Internal.Types.PubKeyHash (StakePubKeyHash)
 import Ctl.Internal.Types.Scripts
-  ( MintingPolicy
-  , MintingPolicyHash
+  ( MintingPolicyHash
   , NativeScriptStakeValidator
   , PlutusScriptStakeValidator
-  , Validator
   , ValidatorHash
   )
 import Ctl.Internal.Types.TokenName (TokenName)
@@ -31,8 +29,6 @@ data MkUnbalancedTxError
   | CannotSolveTimeConstraints POSIXTimeRange POSIXTimeRange
   | CannotGetMintingPolicyScriptIndex -- Should be impossible
   | CannotGetValidatorHashFromAddress Address -- Get `ValidatorHash` from internal `Address`
-  | CannotHashMintingPolicy MintingPolicy
-  | CannotHashValidator Validator
   | CannotMakeValue CurrencySymbol TokenName BigInt
   | CannotWithdrawRewardsPubKey StakePubKeyHash
   | CannotWithdrawRewardsPlutusScript PlutusScriptStakeValidator

--- a/src/Internal/Test/KeyDir.purs
+++ b/src/Internal/Test/KeyDir.purs
@@ -21,7 +21,6 @@ import Contract.Monad
 import Contract.TextEnvelope (decodeTextEnvelope)
 import Contract.Transaction
   ( awaitTxConfirmed
-  , balanceTx
   , balanceTxE
   , signTransaction
   , submit

--- a/src/Internal/Test/KeyDir.purs
+++ b/src/Internal/Test/KeyDir.purs
@@ -22,6 +22,7 @@ import Contract.TextEnvelope (decodeTextEnvelope)
 import Contract.Transaction
   ( awaitTxConfirmed
   , balanceTx
+  , balanceTxE
   , signTransaction
   , submit
   , submitTxFromConstraints
@@ -387,7 +388,7 @@ returnFunds backup env allWalletsArray mbFundTotal hasRun =
           lookups = unspentOutputs utxos
 
         unbalancedTx <- liftedE $ mkUnbalancedTxImpl lookups constraints
-        balancedTx <- liftedE $ balanceTx unbalancedTx
+        balancedTx <- liftedE $ balanceTxE unbalancedTx
         balancedSignedTx <- Array.foldM
           (\tx wallet -> withKeyWallet wallet $ signTransaction tx)
           (wrap $ unwrap balancedTx)

--- a/src/Internal/Test/KeyDir.purs
+++ b/src/Internal/Test/KeyDir.purs
@@ -21,7 +21,7 @@ import Contract.Monad
 import Contract.TextEnvelope (decodeTextEnvelope)
 import Contract.Transaction
   ( awaitTxConfirmed
-  , balanceTxE
+  , balanceTx
   , signTransaction
   , submit
   , submitTxFromConstraints
@@ -387,7 +387,7 @@ returnFunds backup env allWalletsArray mbFundTotal hasRun =
           lookups = unspentOutputs utxos
 
         unbalancedTx <- liftedE $ mkUnbalancedTxImpl lookups constraints
-        balancedTx <- liftedE $ balanceTxE unbalancedTx
+        balancedTx <- balanceTx unbalancedTx
         balancedSignedTx <- Array.foldM
           (\tx wallet -> withKeyWallet wallet $ signTransaction tx)
           (wrap $ unwrap balancedTx)

--- a/src/Internal/Test/UtxoDistribution.purs
+++ b/src/Internal/Test/UtxoDistribution.purs
@@ -20,7 +20,7 @@ import Contract.Address
   , getNetworkId
   , payPubKeyHashEnterpriseAddress
   )
-import Contract.Monad (Contract, liftContractM, liftedE, liftedM)
+import Contract.Monad (Contract, liftContractM, liftedM)
 import Contract.Prelude (foldM, foldMap, null)
 import Contract.ScriptLookups as Lookups
 import Contract.Transaction
@@ -31,6 +31,7 @@ import Contract.Transaction
   , submit
   )
 import Contract.TxConstraints as Constraints
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Utxos (utxosAt)
 import Contract.Wallet
   ( getWalletAddresses
@@ -212,7 +213,7 @@ transferFundsFromEnterpriseToBase ourKey wallets = do
       constraints :: Constraints.TxConstraints
       constraints = Constraints.mustBeSignedBy ourPkh
         <> foldMap constraintsForWallet walletsInfo
-    unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+    unbalancedTx <- mkUnbalancedTx lookups constraints
     signedTx <-
       withKeyWallet ourWallet $
         signTransaction =<< balanceTx unbalancedTx

--- a/src/Internal/Test/UtxoDistribution.purs
+++ b/src/Internal/Test/UtxoDistribution.purs
@@ -26,7 +26,7 @@ import Contract.ScriptLookups as Lookups
 import Contract.Transaction
   ( TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   , awaitTxConfirmed
-  , balanceTxE
+  , balanceTx
   , signTransaction
   , submit
   )
@@ -215,7 +215,7 @@ transferFundsFromEnterpriseToBase ourKey wallets = do
     unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
     signedTx <-
       withKeyWallet ourWallet $
-        signTransaction =<< liftedE (balanceTxE unbalancedTx)
+        signTransaction =<< balanceTx unbalancedTx
     signedTx' <- foldM
       (\tx { wallet } -> withKeyWallet wallet $ signTransaction tx)
       signedTx

--- a/src/Internal/Test/UtxoDistribution.purs
+++ b/src/Internal/Test/UtxoDistribution.purs
@@ -26,7 +26,6 @@ import Contract.ScriptLookups as Lookups
 import Contract.Transaction
   ( TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   , awaitTxConfirmed
-  , balanceTx
   , balanceTxE
   , signTransaction
   , submit

--- a/src/Internal/Test/UtxoDistribution.purs
+++ b/src/Internal/Test/UtxoDistribution.purs
@@ -27,6 +27,7 @@ import Contract.Transaction
   ( TransactionOutputWithRefScript(TransactionOutputWithRefScript)
   , awaitTxConfirmed
   , balanceTx
+  , balanceTxE
   , signTransaction
   , submit
   )
@@ -215,7 +216,7 @@ transferFundsFromEnterpriseToBase ourKey wallets = do
     unbalancedTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
     signedTx <-
       withKeyWallet ourWallet $
-        signTransaction =<< liftedE (balanceTx unbalancedTx)
+        signTransaction =<< liftedE (balanceTxE unbalancedTx)
     signedTx' <- foldM
       (\tx { wallet } -> withKeyWallet wallet $ signTransaction tx)
       signedTx

--- a/src/Internal/Transaction.purs
+++ b/src/Internal/Transaction.purs
@@ -5,6 +5,7 @@ module Ctl.Internal.Transaction
   , attachPlutusScript
   , attachNativeScript
   , setScriptDataHash
+  , explainModifyTxError
   ) where
 
 import Prelude
@@ -48,6 +49,12 @@ derive instance Eq ModifyTxError
 
 instance Show ModifyTxError where
   show = genericShow
+
+-- | Helper for showing `ModifyTxError` in a human-readable way.
+explainModifyTxError :: ModifyTxError -> String
+explainModifyTxError = case _ of
+  ConvertWitnessesError -> "Could not convert witnesses."
+  ConvertDatumError -> "Could not convert datum."
 
 -- | Set the `Transaction` body's script data hash. NOTE: Must include *all* of
 -- | the datums and redeemers for the given transaction

--- a/src/Internal/Types/Interval.purs
+++ b/src/Internal/Types/Interval.purs
@@ -50,6 +50,7 @@ module Ctl.Internal.Types.Interval
   , posixTimeRangeToSlotRange
   , posixTimeRangeToTransactionValidity
   , posixTimeToSlot
+  , explainPosixTimeToSlotError
   , singleton
   , slotRangeToPosixTimeRange
   , slotToPosixTime
@@ -860,6 +861,25 @@ derive instance Eq PosixTimeToSlotError
 
 instance Show PosixTimeToSlotError where
   show = genericShow
+
+explainPosixTimeToSlotError :: PosixTimeToSlotError -> String
+explainPosixTimeToSlotError = case _ of
+  CannotFindTimeInEraSummaries atime ->
+    "Time " <> show atime <> " is not in era summaries."
+  PosixTimeBeforeSystemStart t ->
+    "Time " <> show t <> " is before the system start."
+  StartTimeGreaterThanTime atime ->
+    "Time " <> show atime <> " is before the era start time."
+  EndSlotLessThanSlotOrModNonZero slot mtime ->
+    "Time is after the era end time. Calculated slot: " <> show slot
+      <> ", calculated residual time after end: "
+      <> show mtime
+  CannotGetBigIntFromNumber' ->
+    "Internal error: cannot convert a time to a usable value. " <>
+      "This should be impossible."
+  CannotGetBigNumFromBigInt' ->
+    "Internal error: cannot convert a slot number to a usable value. " <>
+      "This should be impossible."
 
 posixTimeToSlotErrorStr :: String
 posixTimeToSlotErrorStr = "posixTimeToSlotError"

--- a/test/BalanceTx/Time.purs
+++ b/test/BalanceTx/Time.purs
@@ -7,7 +7,6 @@ import Contract.Monad (Contract, runContract)
 import Contract.ScriptLookups
   ( ScriptLookups
   , UnbalancedTx
-  , mkUnbalancedTx
   )
 import Contract.Time
   ( POSIXTime
@@ -24,6 +23,7 @@ import Contract.Time
   , to
   )
 import Contract.TxConstraints (mustValidateIn)
+import Contract.UnbalancedTx (mkUnbalancedTxE)
 import Control.Monad.Except (throwError)
 import Ctl.Internal.Test.TestPlanM (TestPlanM)
 import Ctl.Internal.Types.BigNum (BigNum)
@@ -82,7 +82,7 @@ mkTestFromSingleInterval :: Interval POSIXTime -> Contract Unit
 mkTestFromSingleInterval interval = do
   let
     constraint = mustValidateIn interval
-  mutx <- mkUnbalancedTx emptyLookup constraint
+  mutx <- mkUnbalancedTxE emptyLookup constraint
   case mutx of
     Left e -> fail $ show e
     Right utx ->
@@ -94,7 +94,7 @@ testEmptyInterval :: Contract Unit
 testEmptyInterval = do
   let
     constraint = mustValidateIn never
-  mutx <- mkUnbalancedTx emptyLookup constraint
+  mutx <- mkUnbalancedTxE emptyLookup constraint
   case mutx of
     Left _ -> pure unit
     Right utx -> fail $ "Empty interval must fail : " <> show utx
@@ -107,7 +107,7 @@ testEmptyMultipleIntervals = do
       , mkFiniteInterval (now + mkPosixTime "3000") (now + mkPosixTime "4000")
       ]
     constraint = foldMap mustValidateIn intervals
-  mutx <- mkUnbalancedTx emptyLookup constraint
+  mutx <- mkUnbalancedTxE emptyLookup constraint
   case mutx of
     Left _ -> pure unit
     Right utx -> fail $ "Empty interval must fail : " <> show utx
@@ -117,7 +117,7 @@ mkTestMultipleInterval
 mkTestMultipleInterval intervals expected = do
   let
     constraint = foldMap mustValidateIn intervals
-  mutx <- mkUnbalancedTx emptyLookup constraint
+  mutx <- mkUnbalancedTxE emptyLookup constraint
   case mutx of
     Left e -> fail $ show e
     Right utx ->

--- a/test/Plutip/Contract.purs
+++ b/test/Plutip/Contract.purs
@@ -63,7 +63,6 @@ import Contract.Time (Slot(Slot), getEraSummaries)
 import Contract.Transaction
   ( BalanceTxError(BalanceInsufficientError)
   , DataHash
-  , InvalidInContext(InvalidInContext)
   , NativeScript(ScriptPubkey, ScriptNOfK, ScriptAll)
   , OutputDatum(OutputDatumHash, NoOutputDatum, OutputDatum)
   , ScriptRef(PlutusScriptRef, NativeScriptRef)
@@ -1188,9 +1187,7 @@ suite = do
           hasInsufficientBalance
             :: forall (a :: Type). Either BalanceTxError a -> Boolean
           hasInsufficientBalance = case _ of
-            Left (BalanceInsufficientError _ _ (InvalidInContext amount))
-              | amount == Value.lovelaceValueOf (BigInt.fromInt 50_000_000) ->
-                  true
+            Left (BalanceInsufficientError _ _) -> true
             _ -> false
 
         balanceWithDatum NoOutputDatum >>= flip shouldSatisfy isRight

--- a/test/Plutip/Staking.purs
+++ b/test/Plutip/Staking.purs
@@ -13,7 +13,7 @@ import Contract.Backend.Ogmios (getPoolParameters)
 import Contract.Credential (Credential(ScriptCredential))
 import Contract.Hashing (plutusScriptStakeValidatorHash, publicKeyHash)
 import Contract.Log (logInfo')
-import Contract.Monad (Contract, liftedE, liftedM)
+import Contract.Monad (Contract, liftedM)
 import Contract.Numeric.BigNum as BigNum
 import Contract.PlutusData (unitDatum, unitRedeemer)
 import Contract.Prelude (liftM)
@@ -63,6 +63,7 @@ import Contract.TxConstraints
   , mustWithdrawStakePlutusScript
   , mustWithdrawStakePubKey
   )
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Value (lovelaceValueOf)
 import Contract.Wallet
   ( ownPaymentPubKeyHashes
@@ -157,7 +158,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
@@ -170,7 +171,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
       test "PlutusScript" do
@@ -205,7 +206,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
@@ -222,7 +223,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
       test "NativeScript" do
@@ -255,7 +256,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
@@ -268,7 +269,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
     test "Pool registration & retirement" do
@@ -293,7 +294,7 @@ suite = do
               Lookups.ownPaymentPubKeyHash alicePkh <>
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
-          ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+          ubTx <- mkUnbalancedTx lookups constraints
           balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         privateStakeKey <- liftM (error "Failed to get private stake key") $
@@ -342,7 +343,7 @@ suite = do
               Lookups.ownPaymentPubKeyHash alicePkh <>
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
-          ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+          ubTx <- mkUnbalancedTx lookups constraints
           balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         -- List pools: the pool must appear in the list
@@ -369,7 +370,7 @@ suite = do
               Lookups.ownPaymentPubKeyHash alicePkh <>
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
-          ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+          ubTx <- mkUnbalancedTx lookups constraints
           balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         let
@@ -422,7 +423,7 @@ suite = do
                 lookups :: Lookups.ScriptLookups
                 lookups = mempty
 
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Register stake script
@@ -434,7 +435,7 @@ suite = do
                 lookups :: Lookups.ScriptLookups
                 lookups = mempty
 
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Select a pool
@@ -450,7 +451,7 @@ suite = do
                 lookups =
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
@@ -480,7 +481,7 @@ suite = do
                 lookups =
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
@@ -537,7 +538,7 @@ suite = do
                 lookups :: Lookups.ScriptLookups
                 lookups = mempty
 
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Alice registers stake script (again, no need to validate it)
@@ -549,7 +550,7 @@ suite = do
                 lookups :: Lookups.ScriptLookups
                 lookups = mempty
 
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Bob performs operations with the stake script that require his
@@ -569,7 +570,7 @@ suite = do
                 lookups =
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
@@ -599,7 +600,7 @@ suite = do
                 lookups =
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
-              ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+              ubTx <- mkUnbalancedTx lookups constraints
               balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
@@ -635,7 +636,7 @@ suite = do
               lookups =
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Select a pool ID
@@ -651,7 +652,7 @@ suite = do
               lookups =
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Wait until rewards
@@ -684,7 +685,7 @@ suite = do
               lookups =
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
-            ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
+            ubTx <- mkUnbalancedTx lookups constraints
             balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Check rewards.

--- a/test/Plutip/Staking.purs
+++ b/test/Plutip/Staking.purs
@@ -40,7 +40,7 @@ import Contract.Time (getCurrentEpoch)
 import Contract.Transaction
   ( Epoch(Epoch)
   , PoolPubKeyHash(PoolPubKeyHash)
-  , balanceTx
+  , balanceTxE
   , mkPoolPubKeyHash
   , signTransaction
   , vrfKeyHashFromBytes
@@ -158,7 +158,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -171,7 +171,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
       test "PlutusScript" do
         let
@@ -206,7 +206,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -223,7 +223,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
       test "NativeScript" do
         let
@@ -256,7 +256,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -269,7 +269,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
     test "Pool registration & retirement" do
       let
@@ -294,7 +294,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
         privateStakeKey <- liftM (error "Failed to get private stake key") $
           keyWalletPrivateStakeKey alice
@@ -343,7 +343,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
         -- List pools: the pool must appear in the list
         do
@@ -370,7 +370,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
         let
           waitEpoch :: Epoch -> Contract Epoch
@@ -423,7 +423,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Register stake script
             do
@@ -435,7 +435,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Select a pool
             poolId <- selectPoolId
@@ -451,7 +451,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
             let
@@ -481,7 +481,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
             -- Not going to deregister here, because the rewards are added too
@@ -538,7 +538,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Alice registers stake script (again, no need to validate it)
             do
@@ -550,7 +550,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Bob performs operations with the stake script that require his
           -- (and only his) signature.
@@ -570,7 +570,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
             let
@@ -600,7 +600,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
             -- Not going to deregister here, because the rewards are added too
@@ -636,7 +636,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Select a pool ID
           poolId <- selectPoolId
@@ -652,7 +652,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Wait until rewards
           let
@@ -685,7 +685,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTx ubTx) >>= signTransaction >>= submitAndLog
+            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
 
           -- Check rewards.
           -- Not going to deregister here, because the rewards are added too

--- a/test/Plutip/Staking.purs
+++ b/test/Plutip/Staking.purs
@@ -40,7 +40,7 @@ import Contract.Time (getCurrentEpoch)
 import Contract.Transaction
   ( Epoch(Epoch)
   , PoolPubKeyHash(PoolPubKeyHash)
-  , balanceTxE
+  , balanceTx
   , mkPoolPubKeyHash
   , signTransaction
   , vrfKeyHashFromBytes
@@ -158,7 +158,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -171,7 +171,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
       test "PlutusScript" do
         let
@@ -206,7 +206,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -223,7 +223,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
       test "NativeScript" do
         let
@@ -256,7 +256,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Deregister stake key
           do
@@ -269,7 +269,7 @@ suite = do
                   Lookups.ownStakePubKeyHash aliceStakePkh
 
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
     test "Pool registration & retirement" do
       let
@@ -294,7 +294,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+          balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         privateStakeKey <- liftM (error "Failed to get private stake key") $
           keyWalletPrivateStakeKey alice
@@ -343,7 +343,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+          balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         -- List pools: the pool must appear in the list
         do
@@ -370,7 +370,7 @@ suite = do
                 Lookups.ownStakePubKeyHash aliceStakePkh
 
           ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-          liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+          balanceTx ubTx >>= signTransaction >>= submitAndLog
 
         let
           waitEpoch :: Epoch -> Contract Epoch
@@ -423,7 +423,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Register stake script
             do
@@ -435,7 +435,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Select a pool
             poolId <- selectPoolId
@@ -451,7 +451,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
             let
@@ -481,7 +481,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash alicePkh <>
                     Lookups.ownStakePubKeyHash aliceStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
             -- Not going to deregister here, because the rewards are added too
@@ -538,7 +538,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Alice registers stake script (again, no need to validate it)
             do
@@ -550,7 +550,7 @@ suite = do
                 lookups = mempty
 
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Bob performs operations with the stake script that require his
           -- (and only his) signature.
@@ -570,7 +570,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Wait until rewards
             let
@@ -600,7 +600,7 @@ suite = do
                   Lookups.ownPaymentPubKeyHash bobPkh <>
                     Lookups.ownStakePubKeyHash bobStakePkh
               ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-              liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+              balanceTx ubTx >>= signTransaction >>= submitAndLog
 
             -- Check rewards.
             -- Not going to deregister here, because the rewards are added too
@@ -636,7 +636,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Select a pool ID
           poolId <- selectPoolId
@@ -652,7 +652,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Wait until rewards
           let
@@ -685,7 +685,7 @@ suite = do
                 Lookups.ownPaymentPubKeyHash alicePkh <>
                   Lookups.ownStakePubKeyHash aliceStakePkh
             ubTx <- liftedE $ Lookups.mkUnbalancedTx lookups constraints
-            liftedE (balanceTxE ubTx) >>= signTransaction >>= submitAndLog
+            balanceTx ubTx >>= signTransaction >>= submitAndLog
 
           -- Check rewards.
           -- Not going to deregister here, because the rewards are added too

--- a/test/Plutus/Time.purs
+++ b/test/Plutus/Time.purs
@@ -28,7 +28,6 @@ import Ctl.Internal.Types.Interval
   , POSIXTime(POSIXTime)
   , PosixTimeToSlotError
       ( CannotFindTimeInEraSummaries
-      , CannotGetBigIntFromNumber'
       , EndSlotLessThanSlotOrModNonZero
       , PosixTimeBeforeSystemStart
       , StartTimeGreaterThanTime
@@ -251,7 +250,6 @@ suite = do
         absTimeFixture
       toFromAesonTest "EndSlotLessThanSlotOrModNonZero" $
         EndSlotLessThanSlotOrModNonZero slotFixture modTimeFixture
-      toFromAesonTest "CannotGetBigIntFromNumber'" $ CannotGetBigIntFromNumber'
     group "ToOnChainPosixTimeRangeError" do
       toFromAesonTest "PosixTimeToSlotError'" $ PosixTimeToSlotError'
         posixTimeToSlotErrFixture

--- a/test/Utils/DrainWallets.purs
+++ b/test/Utils/DrainWallets.purs
@@ -13,7 +13,7 @@ import Contract.Monad (liftedE, runContract)
 import Contract.ScriptLookups (mkUnbalancedTx, unspentOutputs)
 import Contract.Transaction
   ( awaitTxConfirmed
-  , balanceTx
+  , balanceTxE
   , signTransaction
   , submit
   )
@@ -121,7 +121,7 @@ run privateKey walletsDir = runContract config do
 
   unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
 
-  balancedTx <- liftedE $ balanceTx unbalancedTx
+  balancedTx <- liftedE $ balanceTxE unbalancedTx
   balancedSignedTx <- Array.foldM
     (\tx wallet -> withKeyWallet wallet $ signTransaction tx)
     (wrap $ unwrap balancedTx)

--- a/test/Utils/DrainWallets.purs
+++ b/test/Utils/DrainWallets.purs
@@ -9,8 +9,8 @@ import Contract.Config
   , mkCtlBackendParams
   , testnetConfig
   )
-import Contract.Monad (liftedE, runContract)
-import Contract.ScriptLookups (mkUnbalancedTx, unspentOutputs)
+import Contract.Monad (runContract)
+import Contract.ScriptLookups (unspentOutputs)
 import Contract.Transaction
   ( awaitTxConfirmed
   , balanceTx
@@ -18,6 +18,7 @@ import Contract.Transaction
   , submit
   )
 import Contract.TxConstraints (mustBeSignedBy, mustSpendPubKeyOutput)
+import Contract.UnbalancedTx (mkUnbalancedTx)
 import Contract.Utxos (utxosAt)
 import Contract.Wallet
   ( getWalletAddresses
@@ -119,7 +120,7 @@ run privateKey walletsDir = runContract config do
       <> foldMap (_.pkh >>> mustBeSignedBy) usedWallets
     lookups = unspentOutputs utxos
 
-  unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
+  unbalancedTx <- mkUnbalancedTx lookups constraints
 
   balancedTx <- balanceTx unbalancedTx
   balancedSignedTx <- Array.foldM

--- a/test/Utils/DrainWallets.purs
+++ b/test/Utils/DrainWallets.purs
@@ -13,7 +13,7 @@ import Contract.Monad (liftedE, runContract)
 import Contract.ScriptLookups (mkUnbalancedTx, unspentOutputs)
 import Contract.Transaction
   ( awaitTxConfirmed
-  , balanceTxE
+  , balanceTx
   , signTransaction
   , submit
   )
@@ -121,7 +121,7 @@ run privateKey walletsDir = runContract config do
 
   unbalancedTx <- liftedE $ mkUnbalancedTx lookups constraints
 
-  balancedTx <- liftedE $ balanceTxE unbalancedTx
+  balancedTx <- balanceTx unbalancedTx
   balancedSignedTx <- Array.foldM
     (\tx wallet -> withKeyWallet wallet $ signTransaction tx)
     (wrap $ unwrap balancedTx)


### PR DESCRIPTION
Closes #1464.
Closes #107 - we added non-throwing variants for functions with structured errors.

### Pre-review checklist

- [X] All code has been formatted using our config (`make format`)
- [X] Any new API features or modification of existing behavior is covered as defined in our [test plan](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/test-plan.md)
- [X] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
