### PR TITLE
Fix `redeemerHash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - A problem with collateral selection not respecting `mustNotSpendUtxosWithOutRefs` ([#1509](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1509))
 - A problem with too many change UTxOs being generated ([#1530](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1530))
 - A problem where tx evaluation with additional utxos failed with an Ogmios `AdditionalUtxoOverlap` exception if some additional utxos got confirmed in the meantime ([#1537](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1537))
+- `Contract.PlutusData.redeemerHash` definition ([#1565](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1565))
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-whitespace:
 check-format: check-explicit-exports check-examples-imports check-whitespace
 	@purs-tidy check ${ps-sources}
 	@nixpkgs-fmt --check ${nix-sources}
-	@prettier --loglevel warn -c ${js-sources}
+	@prettier --log-level warn -c ${js-sources}
 	@eslint --quiet ${js-sources}
 
 format:

--- a/src/Internal/Hashing.purs
+++ b/src/Internal/Hashing.purs
@@ -4,14 +4,15 @@ module Ctl.Internal.Hashing
   , blake2b256Hash
   , blake2b256HashHex
   , datumHash
+  , hashPlutusData
   , md5HashHex
   , plutusScriptHash
+  , scriptRefHash
   , sha256Hash
   , sha256HashHex
   , sha3_256Hash
   , sha3_256HashHex
   , transactionHash
-  , scriptRefHash
   ) where
 
 import Prelude

--- a/src/Internal/Types/Redeemer.purs
+++ b/src/Internal/Types/Redeemer.purs
@@ -8,6 +8,7 @@ module Ctl.Internal.Types.Redeemer
 import Prelude
 
 import Ctl.Internal.FromData (class FromData)
+import Ctl.Internal.Hashing (hashPlutusData)
 import Ctl.Internal.Serialization (toBytes)
 import Ctl.Internal.Serialization.PlutusData (convertPlutusData)
 import Ctl.Internal.ToData (class ToData, toData)
@@ -49,4 +50,5 @@ instance Show RedeemerHash where
 -- | This is a duplicate of `datumHash`.
 redeemerHash :: Redeemer -> RedeemerHash
 redeemerHash =
-  wrap <<< unwrap <<< toBytes <<< convertPlutusData <<< unwrap
+  wrap <<< unwrap <<< toBytes <<< hashPlutusData <<< convertPlutusData <<<
+    unwrap


### PR DESCRIPTION
Looks like a typo was made in the definition long time ago. Seems to not be used, hence not catched