### PR TITLE
Aggregate ctl-npm-meta package for NPM deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,11 +91,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 - `cardano-serialization-lib` has been updated to `v13.2.0` ([#1656](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1656))
+- Switched to the aggregate `@mlabs-haskell/ctl-npm-meta` package for NPM dependencies (see the [section on updating JS dependencies in the docs](./doc/ctl-as-dependency.md)) ([#1666](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1666))
 
 ### Fixed
 
 - Fixed transaction witness set 'attach' functions. Previously, the updated witness set was incorrectly appended to the existing set, causing performance degradation when processing constraints for complex transactions. ([#1653](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1653))
 - Updating to CSL `v13.2.0` should resolve the issue of occasional transaction script integrity hash mismatches on tx submission ([#1656](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1656))
+- Fixed a critical bug where Blockfrost `getUtxo` would also return **spent** outputs ([#1664](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1664))
 
 ## [v9.3.1]
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ CTL is being developed by MLabs. The following companies/funds have contributed 
 - [Indigo Protocol](https://indigoprotocol.io/)
 - [Equine](https://www.equine.gg/)
 - [Liqwid Labs](https://liqwid.finance/)
-- [PlayerMint](https://www.playermint.com/)
+- PlayerMint
 - [Fourier Labs](https://fourierlabs.io/)
 - Ardana
 
@@ -97,5 +97,5 @@ CTL is being developed by MLabs. The following companies/funds have contributed 
 - [Indigo Protocol](https://indigoprotocol.io/)
 - [Liqwid](https://liqwid.finance/)
 - [Clarity](https://clarity.community/)
-- [PlayerMint](https://www.playermint.com/)
+- PlayerMint
 - [SingularityNet](https://singularitynet.io/)

--- a/doc/ctl-as-dependency.md
+++ b/doc/ctl-as-dependency.md
@@ -67,7 +67,7 @@ Make sure to perform **all** of the following steps, otherwise you **will** enco
 
 3. **Update your JS dependencies**
 
-- The NPM dependencies your project has must have the exact same versions CTL's own `package.json` specifies.
+- CTL currently has a single aggregate or meta NPM dependency that encompasses all other dependencies: `@mlabs-haskell/ctl-npm-meta`. Your project must use **the exact same version** of this dependency as specified in CTL's `package.json`.
 - You have to update `package-lock.json` by running `npm install`. If you are in a nix shell and use our setup that symlinks `./node_modules`, npm will complain about inability to write to the filesystem, use `npm i --package-lock-only` to skip writing to `node_modules`. If your `node_modules` are managed by Nix, you will have to re-enter the shell for the changes to apply.
 
 4. **Update your webpack/esbuild config**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,23 +8,7 @@
       "name": "cardano-transaction-lib",
       "license": "MIT",
       "dependencies": {
-        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
-        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
-        "@mlabs-haskell/json-bigint": "2.0.0",
-        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
-        "@noble/secp256k1": "^1.7.0",
-        "base64-js": "^1.5.1",
-        "bignumber.js": "^9.1.1",
-        "bip39": "^3.1.0",
-        "bufferutil": "4.0.5",
-        "isomorphic-ws": "^5.0.0",
-        "puppeteer-core": "^15.3.2",
-        "reconnecting-websocket": "4.4.0",
-        "uniqid": "5.4.0",
-        "utf-8-validate": "^5.0.10",
-        "web-encoding": "^1.1.5",
-        "ws": "^8.16.0",
-        "xhr2": "0.2.1"
+        "@mlabs-haskell/ctl-npm-meta": "1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.7.0",
@@ -525,6 +509,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mlabs-haskell/csl-gc-wrapper/-/csl-gc-wrapper-1.0.2.tgz",
       "integrity": "sha512-jyASltvC/ZVzpMUgbIkIaCLc56uGqymCPnieLkgIMWPhzcRoAxEfshjYONyxPY5XIl0NdIQXjbppXFoPQMk0VQ=="
+    },
+    "node_modules/@mlabs-haskell/ctl-npm-meta": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mlabs-haskell/ctl-npm-meta/-/ctl-npm-meta-1.0.0.tgz",
+      "integrity": "sha512-YN1ATEyuL9mpd9C9DHbNuaY3P0WmPNXk0SvTac2xWnLSbaAOs5eebB2EsWKAx2DTgviuYSroh/SF/AWGsqYksA==",
+      "dependencies": {
+        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
+        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
+        "@mlabs-haskell/json-bigint": "2.0.0",
+        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
+        "@noble/secp256k1": "^1.7.0",
+        "base64-js": "^1.5.1",
+        "bignumber.js": "^9.1.1",
+        "bip39": "^3.1.0",
+        "bufferutil": "4.0.5",
+        "isomorphic-ws": "^5.0.0",
+        "puppeteer-core": "^15.3.2",
+        "reconnecting-websocket": "4.4.0",
+        "uniqid": "5.4.0",
+        "utf-8-validate": "^5.0.10",
+        "web-encoding": "^1.1.5",
+        "ws": "^8.16.0",
+        "xhr2": "0.2.1"
+      }
     },
     "node_modules/@mlabs-haskell/json-bigint": {
       "version": "2.0.0",
@@ -6667,6 +6675,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mlabs-haskell/csl-gc-wrapper/-/csl-gc-wrapper-1.0.2.tgz",
       "integrity": "sha512-jyASltvC/ZVzpMUgbIkIaCLc56uGqymCPnieLkgIMWPhzcRoAxEfshjYONyxPY5XIl0NdIQXjbppXFoPQMk0VQ=="
+    },
+    "@mlabs-haskell/ctl-npm-meta": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mlabs-haskell/ctl-npm-meta/-/ctl-npm-meta-1.0.0.tgz",
+      "integrity": "sha512-YN1ATEyuL9mpd9C9DHbNuaY3P0WmPNXk0SvTac2xWnLSbaAOs5eebB2EsWKAx2DTgviuYSroh/SF/AWGsqYksA==",
+      "requires": {
+        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
+        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
+        "@mlabs-haskell/json-bigint": "2.0.0",
+        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
+        "@noble/secp256k1": "^1.7.0",
+        "base64-js": "^1.5.1",
+        "bignumber.js": "^9.1.1",
+        "bip39": "^3.1.0",
+        "bufferutil": "4.0.5",
+        "isomorphic-ws": "^5.0.0",
+        "puppeteer-core": "^15.3.2",
+        "reconnecting-websocket": "4.4.0",
+        "uniqid": "5.4.0",
+        "utf-8-validate": "^5.0.10",
+        "web-encoding": "^1.1.5",
+        "ws": "^8.16.0",
+        "xhr2": "0.2.1"
+      }
     },
     "@mlabs-haskell/json-bigint": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,23 +31,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mlabs-haskell/cardano-message-signing": "^1.0.1",
-    "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
-    "@mlabs-haskell/json-bigint": "2.0.0",
-    "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
-    "@noble/secp256k1": "^1.7.0",
-    "base64-js": "^1.5.1",
-    "bignumber.js": "^9.1.1",
-    "bip39": "^3.1.0",
-    "bufferutil": "4.0.5",
-    "isomorphic-ws": "^5.0.0",
-    "puppeteer-core": "^15.3.2",
-    "reconnecting-websocket": "4.4.0",
-    "uniqid": "5.4.0",
-    "utf-8-validate": "^5.0.10",
-    "web-encoding": "^1.1.5",
-    "ws": "^8.16.0",
-    "xhr2": "0.2.1"
+    "@mlabs-haskell/ctl-npm-meta": "1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.7.0",

--- a/templates/ctl-scaffold/package-lock.json
+++ b/templates/ctl-scaffold/package-lock.json
@@ -9,23 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
-        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
-        "@mlabs-haskell/json-bigint": "2.0.0",
-        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
-        "@noble/secp256k1": "^1.7.0",
-        "base64-js": "^1.5.1",
-        "bignumber.js": "^9.1.1",
-        "bip39": "^3.1.0",
-        "bufferutil": "4.0.5",
-        "isomorphic-ws": "^5.0.0",
-        "puppeteer-core": "^15.3.2",
-        "reconnecting-websocket": "4.4.0",
-        "uniqid": "5.4.0",
-        "utf-8-validate": "^5.0.10",
-        "web-encoding": "^1.1.5",
-        "ws": "^8.16.0",
-        "xhr2": "0.2.1"
+        "@mlabs-haskell/ctl-npm-meta": "1.0.0"
       },
       "devDependencies": {
         "buffer": "6.0.3",
@@ -512,6 +496,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mlabs-haskell/csl-gc-wrapper/-/csl-gc-wrapper-1.0.2.tgz",
       "integrity": "sha512-jyASltvC/ZVzpMUgbIkIaCLc56uGqymCPnieLkgIMWPhzcRoAxEfshjYONyxPY5XIl0NdIQXjbppXFoPQMk0VQ=="
+    },
+    "node_modules/@mlabs-haskell/ctl-npm-meta": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mlabs-haskell/ctl-npm-meta/-/ctl-npm-meta-1.0.0.tgz",
+      "integrity": "sha512-YN1ATEyuL9mpd9C9DHbNuaY3P0WmPNXk0SvTac2xWnLSbaAOs5eebB2EsWKAx2DTgviuYSroh/SF/AWGsqYksA==",
+      "dependencies": {
+        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
+        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
+        "@mlabs-haskell/json-bigint": "2.0.0",
+        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
+        "@noble/secp256k1": "^1.7.0",
+        "base64-js": "^1.5.1",
+        "bignumber.js": "^9.1.1",
+        "bip39": "^3.1.0",
+        "bufferutil": "4.0.5",
+        "isomorphic-ws": "^5.0.0",
+        "puppeteer-core": "^15.3.2",
+        "reconnecting-websocket": "4.4.0",
+        "uniqid": "5.4.0",
+        "utf-8-validate": "^5.0.10",
+        "web-encoding": "^1.1.5",
+        "ws": "^8.16.0",
+        "xhr2": "0.2.1"
+      }
     },
     "node_modules/@mlabs-haskell/json-bigint": {
       "version": "2.0.0",
@@ -5765,6 +5773,30 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mlabs-haskell/csl-gc-wrapper/-/csl-gc-wrapper-1.0.2.tgz",
       "integrity": "sha512-jyASltvC/ZVzpMUgbIkIaCLc56uGqymCPnieLkgIMWPhzcRoAxEfshjYONyxPY5XIl0NdIQXjbppXFoPQMk0VQ=="
+    },
+    "@mlabs-haskell/ctl-npm-meta": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mlabs-haskell/ctl-npm-meta/-/ctl-npm-meta-1.0.0.tgz",
+      "integrity": "sha512-YN1ATEyuL9mpd9C9DHbNuaY3P0WmPNXk0SvTac2xWnLSbaAOs5eebB2EsWKAx2DTgviuYSroh/SF/AWGsqYksA==",
+      "requires": {
+        "@mlabs-haskell/cardano-message-signing": "^1.0.1",
+        "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
+        "@mlabs-haskell/json-bigint": "2.0.0",
+        "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
+        "@noble/secp256k1": "^1.7.0",
+        "base64-js": "^1.5.1",
+        "bignumber.js": "^9.1.1",
+        "bip39": "^3.1.0",
+        "bufferutil": "4.0.5",
+        "isomorphic-ws": "^5.0.0",
+        "puppeteer-core": "^15.3.2",
+        "reconnecting-websocket": "4.4.0",
+        "uniqid": "5.4.0",
+        "utf-8-validate": "^5.0.10",
+        "web-encoding": "^1.1.5",
+        "ws": "^8.16.0",
+        "xhr2": "0.2.1"
+      }
     },
     "@mlabs-haskell/json-bigint": {
       "version": "2.0.0",

--- a/templates/ctl-scaffold/package.json
+++ b/templates/ctl-scaffold/package.json
@@ -25,23 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@mlabs-haskell/cardano-message-signing": "^1.0.1",
-    "@mlabs-haskell/cardano-serialization-lib-gc": "13.2.0",
-    "@mlabs-haskell/json-bigint": "2.0.0",
-    "@mlabs-haskell/uplc-apply-args": "1.0.29-alpha",
-    "@noble/secp256k1": "^1.7.0",
-    "base64-js": "^1.5.1",
-    "bignumber.js": "^9.1.1",
-    "bip39": "^3.1.0",
-    "bufferutil": "4.0.5",
-    "isomorphic-ws": "^5.0.0",
-    "puppeteer-core": "^15.3.2",
-    "reconnecting-websocket": "4.4.0",
-    "uniqid": "5.4.0",
-    "utf-8-validate": "^5.0.10",
-    "web-encoding": "^1.1.5",
-    "ws": "^8.16.0",
-    "xhr2": "0.2.1"
+    "@mlabs-haskell/ctl-npm-meta": "1.0.0"
   },
   "devDependencies": {
     "buffer": "6.0.3",


### PR DESCRIPTION
Closes [Create an aggregate NPM package for CTL dependencies #1659](https://github.com/Plutonomicon/cardano-transaction-lib/issues/1659)

New repository: https://github.com/mlabs-haskell/ctl-npm-meta
New npm package: https://www.npmjs.com/package/@mlabs-haskell/ctl-npm-meta

### TODO

- [x] Update documentation
- [x] Retroactively add CHANGELOG entry for [Fix Blockfrost getUtxo to exclude spent outputs #1664](https://github.com/Plutonomicon/cardano-transaction-lib/pull/1664)

### Pre-review checklist

- [x] All code has been formatted using our config (`make format`)
- [x] Any new API features or modification of existing behavior are covered with tests
- [x] The template (`templates/ctl-scaffold`) has been [updated](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/development.md#maintaining-the-template)
- [x] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Changed`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included
